### PR TITLE
[Service Bus] Fix createSubscription failing with "availabilityStatus expected to be a string" on GeoDR-enabled namespaces

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `createSubscription` failing with `"availabilityStatus" received from service expected to be a string value and not undefined` on Geo-Replication (GeoDR)-enabled namespaces. The optional `availabilityStatus` field is now parsed with `getStringOrUndefined`, tolerating its omission by the service, consistent with the .NET, Java, and Python SDKs.
+
 - Read `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB.
 - Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping remaining-time computations to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
 - Fixed CBS token renewal stopping permanently after a single failed renewal. A transient credential error (for example a failed AAD `getToken` during a workload-identity rotation) no longer leaves the link's token un-renewed; renewal now retries with a capped exponential backoff until it succeeds or the link closes. [#38467](https://github.com/Azure/azure-sdk-for-js/issues/38467)

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -103,10 +103,9 @@ export function buildSubscription(rawSubscription: Record<string, any>): Subscri
 
     status: getString(rawSubscription[Constants.STATUS], "status") as EntityStatus,
 
-    availabilityStatus: getString(
+    availabilityStatus: getStringOrUndefined(
       rawSubscription[Constants.ENTITY_AVAILABILITY_STATUS],
-      "availabilityStatus",
-    ) as EntityAvailabilityStatus,
+    ) as EntityAvailabilityStatus | undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes `ServiceBusAdministrationClient.createSubscription()` throwing `"availabilityStatus" received from service expected to be a string value and not undefined` on namespaces with Data Geo-Replication (GeoDR) enabled. Affects all auth methods (SAS and AAD); only `createSubscription` is impacted.

## Root cause
GeoDR namespaces use the ManagementAsync path, whose ATOM response omits the optional `EntityAvailabilityStatus` element. In `subscriptionResourceSerializer.ts`, `buildSubscription()` parsed it with `getString()`, which throws on `undefined`. .NET/Java/Python tolerate the missing field; only JS crashed.

## Fix
Parse the optional field with `getStringOrUndefined()` (already used for other optional fields like `forwardTo`), returning `undefined` instead of throwing. The `availabilityStatus` property is already optional, so no interface change is needed. Behavior is unchanged when the service returns the field.

## Testing
Verified the error originates from this exact `getString()` call. A unit test (asserting `buildSubscription` returns `undefined` when the field is omitted) will follow.
