### PR TITLE
[monitor-opentelemetry] Release 1.19.0 distro and 1.0.0-beta.44 exporter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,8 +825,8 @@ importers:
         specifier: ^1.11.1
         version: link:../../monitor/monitor-opentelemetry
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.43
-        version: 1.0.0-beta.43
+        specifier: 1.0.0-beta.44
+        version: link:../../monitor/monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0
@@ -931,8 +931,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.43
-        version: 1.0.0-beta.43
+        specifier: 1.0.0-beta.44
+        version: link:../../monitor/monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1055,7 +1055,7 @@ importers:
         specifier: workspace:^
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/monitor-opentelemetry':
-        specifier: ^1.17.0
+        specifier: ^1.19.0
         version: link:../../monitor/monitor-opentelemetry
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
@@ -22497,7 +22497,7 @@ importers:
         specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/monitor-opentelemetry':
-        specifier: ^1.17.0
+        specifier: ^1.19.0
         version: link:../monitor-opentelemetry
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -22592,8 +22592,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.43
-        version: 1.0.0-beta.43
+        specifier: 1.0.0-beta.44
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -22683,8 +22683,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.43
-        version: 1.0.0-beta.43
+        specifier: 1.0.0-beta.44
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -35695,10 +35695,6 @@ packages:
     resolution: {integrity: sha1-Cey+hAiSgQAjgn7y2DjyGaUcHDU=}
     engines: {node: '>=14.0.0'}
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.43':
-    resolution: {integrity: sha1-W2siG+6x+yYn03KXHloGei9otlI=}
-    engines: {node: '>=22.0.0'}
-
   '@azure/msal-browser@4.30.0':
     resolution: {integrity: sha1-MPuveuJtmrdnGqvKPUH5xS0qOTc=}
     engines: {node: '>=0.8.0'}
@@ -36845,10 +36841,6 @@ packages:
     resolution: {integrity: sha1-MtntmJOZVqhNTi/14BWYy50o10Q=}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/api-logs@0.219.0':
-    resolution: {integrity: sha1-MwPxD0Pm/xdB+PYBnkOpJyN4FjA=}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha1-su0jXeS188F2mt+l87wkfYLN+8k=}
     engines: {node: '>=8.0.0'}
@@ -36891,12 +36883,6 @@ packages:
 
   '@opentelemetry/core@2.10.0':
     resolution: {integrity: sha1-qnf3E450ulOZ1fO7DereDBaPALI=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.8.0':
-    resolution: {integrity: sha1-9uht42iL21Smyo9JNTY6W1iK6Rw=}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -37103,12 +37089,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.8.0':
-    resolution: {integrity: sha1-m8tlirYlTzMJn0qVVEtA1vU8yUY=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.9.0':
     resolution: {integrity: sha1-geHOlG7sZhhXqdbE+lB7N1CuUA8=}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -37117,12 +37097,6 @@ packages:
 
   '@opentelemetry/sdk-logs@0.200.0':
     resolution: {integrity: sha1-iT2GzvpvLAKnzQPVy0qVnu02U9E=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.219.0':
-    resolution: {integrity: sha1-ACQzI3kI0k+p5/F+tJY/JfA9ZVw=}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
@@ -42353,25 +42327,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.43':
-    dependencies:
-      '@azure-rest/core-client': 2.8.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
-      '@azure/core-util': 1.14.0
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/msal-browser@4.30.0':
     dependencies:
       '@azure/msal-common': 15.17.0
@@ -43626,10 +43581,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api-logs@0.219.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -43664,11 +43615,6 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
@@ -43960,12 +43906,6 @@ snapshots:
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
   '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -43978,14 +43918,6 @@ snapshots:
       '@opentelemetry/api-logs': 0.200.0
       '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.219.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/sdk/ai/ai-agents/package.json
+++ b/sdk/ai/ai-agents/package.json
@@ -66,7 +66,7 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
     "@azure/monitor-opentelemetry": "^1.11.1",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "0.57.0",

--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -90,7 +90,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "^0.200.0",

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -65,7 +65,7 @@
     "@azure/arm-cognitiveservices": "catalog:arm",
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
-    "@azure/monitor-opentelemetry": "^1.17.0",
+    "@azure/monitor-opentelemetry": "^1.19.0",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@opentelemetry/api": "^1.9.0",

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.44 (Unreleased)
+## 1.0.0-beta.44 (2026-07-29)
 
 ### Bugs Fixed
 
@@ -72,7 +72,7 @@
 
 ## 1.0.0-beta.39 (2026-02-20)
 
-### Features Added 
+### Features Added
 
 - Add ownership checks for storage directories.
 - Added a 64KB size limit on custom dimensions. Individual custom dimension values greater than 64KB are truncated to the upper limit of 64KB. Set the `AZURE_MONITOR_DISABLE_CUSTOM_DIMENSIONS_LIMIT` environment variable to `"true"` to disable this limit for scenarios requiring larger payloads.
@@ -81,14 +81,14 @@
 
 - Fixed an issue where telemetry rejected by ingestion-side sampling was incorrectly persisted for retry, causing offline storage to fill up unnecessarily.
 
-### 1.0.0-beta.38 (2026-01-16)
+## 1.0.0-beta.38 (2026-01-16)
 
 ### Features Added
 
 - Remove limit on custom properties field on both logs and spans.
 - Updated customer SDK Stats metric names from preview format to stable format.
 
-### 1.0.0-beta.37 (2026-01-15)
+## 1.0.0-beta.37 (2026-01-15)
 
 ### Features Added
 

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
@@ -48,7 +48,7 @@
   "private": true,
   "dependencies": {
     "@azure-tools/test-perf": "workspace:^",
-    "@azure/monitor-opentelemetry": "^1.17.0",
+    "@azure/monitor-opentelemetry": "^1.19.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.200.0",
     "@opentelemetry/sdk-logs": "^0.200.0",

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.19.0 (Unreleased)
+## 1.19.0 (2026-07-29)
 
 ### Features Added
 
@@ -15,6 +15,7 @@
 
 - Fixed Statsbeat instrumentation encoding so adding an instrumentation no longer shifts the reported bits of others, and flags above `2 ** 32` (such as `pino`, `restify`, `router`, and `amqplib`) are no longer dropped. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`, `@opentelemetry/sdk-logs`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-trace-otlp-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). Updated the bundled contrib instrumentations and resource detector to their latest versions. [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
+- Updated to using exporter version 1.0.0-beta.44.
 
 ## 1.18.2 (2026-07-01)
 
@@ -200,6 +201,7 @@
 ## 1.8.0 (2024-10-23)
 
 ### Features Added
+
 - Changed live metrics CPU/Memory perf counter metrics to emit normalized process CPU and process physical memory bytes.
 - Support for Live Metrics Filtering.
 - Support parsing AAD Audience from the connection string for live metrics.
@@ -211,6 +213,7 @@
 ## 1.7.1 (2024-09-13)
 
 ### Bugs Fixed
+
 - Live Metrics: Do not send documents from past time intervals.
 
 ### Other Changes

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -77,7 +77,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -66,7 +66,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry` — released as **1.19.0**
- `@azure/monitor-opentelemetry-exporter` — released as **1.0.0-beta.44**

### Describe the problem that is addressed by this PR

Prepares the next co-release of both Azure Monitor OpenTelemetry packages. This is a **release-prep only** change cut cleanly from `main`: it stamps release dates (2026-07-29) on the existing `Unreleased` CHANGELOG sections, bumps the exporter dep pin to `1.0.0-beta.44` across all consuming packages, refreshes the distro caret pins, and regenerates the workspace lockfile.

### Notable changes

- `@azure/monitor-opentelemetry` **1.19.0** — CHANGELOG date stamped (2026-07-29), added `Updated to using exporter version 1.0.0-beta.44` bullet. Runtime version constant `AZURE_MONITOR_OPENTELEMETRY_VERSION` already at `1.19.0`.
- `@azure/monitor-opentelemetry-exporter` **1.0.0-beta.44** — CHANGELOG date stamped (2026-07-29); `packageVersion` constant already at `1.0.0-beta.44`.
- Bumped the exporter dep pin to `1.0.0-beta.44` in every consuming package: `monitor-query-logs`, `monitor-query-metrics`, `ai-agents`, `ai-inference-rest`. (`monitor-opentelemetry` was already pinned to `1.0.0-beta.44`.)
- Refreshed the distro caret pin to `^1.19.0` in `ai-projects` and `monitor-opentelemetry-perf-tests`, restoring the convention used through the 1.17.0 release.
- Fixed two malformed `###` CHANGELOG headings (`1.0.0-beta.38`, `1.0.0-beta.37`) that should be `##`, plus minor pre-existing prettier drift in older entries, so the format check stays green now that these files are in scope.
- `pnpm-lock.yaml` refreshed.

### Are there test cases added in this PR?

No new tests; this is a release-prep change. Existing tests still apply.

### Verification

- `pnpm turbo build` for both Monitor packages: succeeds (19/19 tasks), no API report drift.
- `pnpm check-format`: passes for all 8 impacted packages.
- `Confirm-ChangeLogEntry -ForRelease $true`: valid for both packages.
- `pnpm install`: lockfile up to date.

### Checklists

- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
