### PR TITLE
[engSys] Consolidate new-dependency size guidance on minified + gzipped

### DIFF
--- a/.github/agents/dash.agent.md
+++ b/.github/agents/dash.agent.md
@@ -22,8 +22,8 @@ Follow the full guidelines in [performance-review-guidelines.md](../prompts/perf
 6. **Retry & polling** — exponential backoff, no retry on 4xx
    (except 408/429), polling ≥ 1 s, respect Retry-After
 7. **Sync blocking** — no `readFileSync` / `execSync` in production
-8. **Bundle size** — no large new deps (> 50 KB), no Node-only imports
-   in browser paths, no `export *` barrels
+8. **Bundle size** — no large new deps (> 50 KB minified + gzipped), no
+   Node-only imports in browser paths, no `export *` barrels
 9. **Async patterns** — `Promise.all` for independent calls; no
    unbounded concurrency; no unnecessary `async`
 10. **Caching** — hoist RegExp and repeated computation; eviction on

--- a/.github/agents/dexter.agent.md
+++ b/.github/agents/dexter.agent.md
@@ -20,7 +20,7 @@ When reviewing dependency changes, check for:
    `workspace:^` for internal dev tools. No pinning, tilde, star, or
    git URLs.
 4. **New dependency evaluation** — necessity (core-* already provides?),
-   size (>100 KB?), license (MIT-compatible?), maintenance, types
+   size (>50 KB minified + gzipped?), license (MIT-compatible?), maintenance, types
 5. **Dependency removal** — verify no remaining imports, check peer dep
    impact, flag suspicious core-* removal
 6. **Dev vs runtime boundary** — test-only packages in devDependencies,

--- a/.github/instructions/reviewer/sdk-source.instructions.md
+++ b/.github/instructions/reviewer/sdk-source.instructions.md
@@ -59,7 +59,7 @@ Use `@azure/core-*`: `core-rest-pipeline`, `core-client`, `core-lro`, `core-auth
 
 ### Retry & Bundle
 - Exponential backoff via `core-rest-pipeline` | Only retry 408/429/5xx
-- New deps <50KB | No Node imports in browser without platform check
+- New deps <50KB minified + gzipped | No Node imports in browser without platform check
 - String unions over `enum` | No `namespace`
 
 ### Async

--- a/.github/prompts/dependency-review-guidelines.md
+++ b/.github/prompts/dependency-review-guidelines.md
@@ -103,7 +103,8 @@ When a PR adds a new production dependency, check:
    - `@azure/core-auth` provides credential interfaces
    - `@azure/core-lro` provides long-running operation support
 2. **Size** — large transitive dependency trees impact bundle size for
-   browser-compatible packages. Flag dependencies > 100 KB minified.
+   browser-compatible packages. Measure size as **minified + gzipped**.
+   Flag new runtime dependencies larger than 50 KB.
 3. **Maintenance** — is the package actively maintained? Flag packages
    with no commits in 2+ years or deprecated npm status.
 4. **License** — must be compatible with MIT. Acceptable licenses:

--- a/.github/prompts/performance-review-guidelines.md
+++ b/.github/prompts/performance-review-guidelines.md
@@ -124,7 +124,7 @@ Flag synchronous operations that block the event loop:
 For browser-compatible packages:
 
 - **Large new dependency** — flag new dependencies that add > 50 KB
-  minified to the bundle. Check if a lighter alternative exists.
+  minified + gzipped to the bundle. Check if a lighter alternative exists.
 - **Node-only code in browser bundle** — flag imports of `fs`,
   `crypto`, `child_process`, `net`, `http` in code paths that execute
   in browsers without a platform check.


### PR DESCRIPTION
While reviewing a dependency question for the Storage `apache-arrow` work, we noticed our new-dependency size guidance is inconsistent across the reviewer guidance files. They disagree on both the **unit** and the **threshold**:

| File | Wording | Threshold | Unit |
|---|---|---|---|
| `.github/instructions/reviewer/sdk-source.instructions.md` | "New deps <50KB" | 50 KB | none |
| `.github/agents/dash.agent.md` | "no large new deps (> 50 KB)" | 50 KB | none |
| `.github/agents/dexter.agent.md` | "size (>100 KB?)" | 100 KB | none |
| `.github/prompts/dependency-review-guidelines.md` | "> 100 KB minified" | 100 KB | minified |
| `.github/prompts/performance-review-guidelines.md` | "> 50 KB minified" | 50 KB | minified |

Different thresholds (50 KB vs 100 KB) and inconsistent units (none / minified / no gzip). That ambiguity is real in practice: `apache-arrow@21.1.0` is ~48 KB minified+gzipped but ~210 KB raw minified, so the same dependency passes or fails depending purely on how you read the rule.

This PR standardizes all five references on **50 KB minified + gzipped**. I went with min+gzip because that's what customers actually download and roughly what a bundler adds; raw-minified overstates cost for compressible libraries.

### Changes
- `dependency-review-guidelines.md` — "> 100 KB minified" → "minified + gzipped", flag > 50 KB
- `performance-review-guidelines.md` — "> 50 KB minified" → "> 50 KB minified + gzipped"
- `sdk-source.instructions.md` — "New deps <50KB" → "<50KB minified + gzipped"
- `dash.agent.md` — "> 50 KB" → "> 50 KB minified + gzipped"
- `dexter.agent.md` — "size (>100 KB?)" → "size (>50 KB minified + gzipped?)"

Docs-only; no code or behavior changes.

Opening as a draft to gather input on the **unit + threshold** before we lock it in.

_Supersedes #39457, which addressed the same inconsistency (thanks to that PR for catching `dexter.agent.md` and `performance-review-guidelines.md`, now folded in here)._
