### PR TITLE
[keyvault-certificates] Fix updateCertificatePolicy returning policy built from undefined

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugs Fixed
 
+- Fixed `updateCertificatePolicy` returning a policy built from an unassigned
+  variable instead of the updated policy returned by the service.
+  [#39461](https://github.com/Azure/azure-sdk-for-js/pull/39461)
+
 ### Other Changes
 
 ## 4.11.0-beta.1 (2026-06-04)

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -1062,14 +1062,17 @@ export class CertificateClient {
     policy: CertificatePolicy,
     options: UpdateCertificatePolicyOptions = {},
   ): Promise<CertificatePolicy> {
-    let parsedBody: any;
     return tracingClient.withSpan(
       "CertificateClient.updateCertificatePolicy",
       options,
       async (updatedOptions) => {
         const corePolicy = toCorePolicy(undefined, policy);
-        await this.client.updateCertificatePolicy(certificateName, corePolicy, updatedOptions);
-        return toPublicPolicy(parsedBody);
+        const response = await this.client.updateCertificatePolicy(
+          certificateName,
+          corePolicy,
+          updatedOptions,
+        );
+        return toPublicPolicy(response);
       },
     );
   }

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -480,12 +480,16 @@ describe("Certificates client - create, read, update and delete", () => {
     expect(result.policy!.issuerName).toEqual("Self");
     expect(result.policy!.subject).toEqual("cn=MyCert");
 
-    await client.updateCertificatePolicy(certificateName, {
+    const updatedPolicy = await client.updateCertificatePolicy(certificateName, {
       issuerName: "Self",
       subject: "cn=MyOtherCert",
     });
+    expect(updatedPolicy.issuerName).toEqual("Self");
+    expect(updatedPolicy.subject).toEqual("cn=MyOtherCert");
+
     const updated = await client.getCertificate(certificateName);
     expect(updated.policy!.issuerName).toEqual("Self");
+    expect(updated.policy!.subject).toEqual("cn=MyOtherCert");
   });
 
   it("can read, cancel and delete a certificate's operation", async () => {


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Fixes a latent bug in `CertificateClient.updateCertificatePolicy`.

The method declared `let parsedBody: any;`, never assigned it, discarded the result of the `updateCertificatePolicy` service call, and then returned `toPublicPolicy(parsedBody)` — so it always returned a policy built from `undefined` instead of the updated policy returned by the service.

The fix captures the service response and passes it to `toPublicPolicy`, matching the sibling `getCertificatePolicy` implementation. The public API surface is unchanged.

## Context

This bug was surfaced by the ESLint v10 `no-unassigned-vars` recommended rule (the unassigned `parsedBody` local) during the rule-restore cleanup in #39460 (part of #39423). Per reviewer preference it is split out here into a dedicated, clearly-labeled bug-fix PR so the user-facing changelog and bug-fix framing live on their own, separate from the mechanical lint cleanup.

## Changes

- `src/index.ts`: capture the `updateCertificatePolicy` response and return `toPublicPolicy(response)`; remove the unassigned `parsedBody` local.
- `CHANGELOG.md`: bug-fix entry under the existing unreleased `4.11.0-beta.2`.

No version bump required (the package is already at an unpublished `4.11.0-beta.2`).
