### PR TITLE
Exclude our own packages from pnpm minimumReleaseAge delay

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,6 +70,14 @@ peerDependencyRules:
 
 linkWorkspacePackages: true
 
+# Exempt our own packages from the minimumReleaseAge delay so freshly published
+# Azure SDK packages (and the TypeSpec runtime we own) install immediately
+# instead of waiting out the default maturation window.
+minimumReleaseAgeExclude:
+  - '@azure/*'
+  - '@azure-rest/*'
+  - '@typespec/ts-http-runtime'
+
 # Ensure lockfile includes optional dependencies for all CI and development platforms
 # This prevents lockfile churn when running pnpm install on different OSes
 # Lists all OS/CPU combinations used in CI (Ubuntu, Windows, macOS) and dev machines


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng):

## Why

pnpm 11 defaults `minimumReleaseAge` to 1440 minutes (1 day), delaying installation of any newly published package version to reduce the risk of pulling in a compromised release before it is caught and removed from the registry. That protection is valuable for third-party dependencies, but it also delays our own freshly published packages, which we trust and often need to consume immediately (e.g. right after a release).

## What

Adds a `minimumReleaseAgeExclude` list to `pnpm-workspace.yaml` so our own packages bypass the maturation window and install as soon as they are published:

- `@azure/*`
- `@azure-rest/*`
- `@typespec/ts-http-runtime`

The exclusion matches by package name (glob patterns supported since pnpm 10.17.0) and applies to all versions. Third-party dependencies keep the default delay.

## Notes

Verified pnpm parses the setting via `pnpm config get minimumReleaseAgeExclude`, which returned the three entries.