### PR TITLE
Creating release communication-common version 2.5.0

### DIFF
--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.5.0 (Unreleased)
+## 2.5.0 (2026-07-30)
 
 ### Features Added
 
@@ -9,14 +9,10 @@
   - A token that cannot be decoded is now accepted as-is and assigned a fallback expiry, instead of throwing at construction as it did previously; only an empty token is rejected.
   - Added `undecodableTokenExpiryIntervalInSeconds` to `CommunicationTokenRefreshOptions` to configure the lifetime assumed for an undecodable token without an explicit expiry (default 600 seconds).
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed `dispose()` not always cancelling the scheduled proactive token refresh, which could trigger a token refresh after the credential was disposed.
 - A token that decodes successfully but has no `exp` claim no longer yields a `NaN` expiry; it now uses the fallback expiry.
-
-### Other Changes
 
 ## 2.4.2 (2026-06-02)
 

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.5.0 (2026-07-30)
+## 2.5.0 (2026-07-31)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/communication-common

### Issues associated with this PR
- ADO User Story 4604730 — Update JS SDK to support encrypted access token

### Describe the problem that is addressed by this PR
Preparing `@azure/communication-common` version 2.5.0 for release on July 31, 2026.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This applies the standard JavaScript SDK release preparation: date the existing 2.5.0 changelog entry and remove empty sections.

### Are there test cases added in this PR? _(If not, why?)_
No new tests are required because this PR changes release metadata only. The `js - communication-common - tests` pipeline and the full JavaScript PR pipeline passed. The packed 2.5.0 artifact was also validated across ESM, CommonJS, browser, and React Native outputs.

### Provide a list of related PRs _(if any)_
- Implementation: https://github.com/Azure/azure-sdk-for-js/pull/39156

### Command used to generate this PR: **_(Applicable only to SDK release request PRs)_**
`.\eng\common\scripts\Prepare-Release.ps1 -PackageName @azure/communication-common -ServiceDirectory communication -ReleaseDate 07/31/2026`

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(Not applicable; this package is handwritten.)_
- [x] Added a changelog