### PR TITLE
[monitor-opentelemetry-exporter] Add OneSettings HTTP request utility

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
+- Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. Requests honor the standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY`). This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. This is groundwork with no user-facing behavior yet. [#39295](https://github.com/Azure/azure-sdk-for-js/pull/39295)
+- Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.45 (Unreleased)
+
+### Other Changes
+
+- Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. This is groundwork with no user-facing behavior yet. [#39295](https://github.com/Azure/azure-sdk-for-js/pull/39295)
+
 ## 1.0.0-beta.44 (2026-07-29)
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/monitor-opentelemetry-exporter",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.44",
+  "version": "1.0.0-beta.45",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -13,7 +13,7 @@ import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../Declarations/Consta
  * @internal
  */
 export type ConfigurationChangeCallback = (
-  settings: Readonly<Record<string, string>>,
+  settings: Readonly<Record<string, unknown>>,
 ) => void | Promise<void>;
 
 /**
@@ -68,7 +68,7 @@ export class ConfigurationManager {
    * Invoke every registered callback with the latest settings, isolating callback failures.
    * Both synchronous throws and rejected promises from async callbacks are caught and logged.
    */
-  protected notifyCallbacks(settings: Readonly<Record<string, string>>): void {
+  protected notifyCallbacks(settings: Readonly<Record<string, unknown>>): void {
     for (const callback of [...this.callbacks]) {
       try {
         // `try/catch` handles synchronous throws; `.catch` handles rejections from async callbacks.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -73,19 +73,12 @@ export async function makeOneSettingsRequest(
   query: Record<string, string> = {},
   headers: Record<string, string> = {},
 ): Promise<OneSettingsResponse> {
-  // A PipelineRequest.timeout only bounds the time to response headers: the Node transport clears
-  // it as soon as headers arrive, before the body is read. A server or proxy that sends headers and
-  // then stalls the body would otherwise hang this poll indefinitely. Drive the deadline with an
-  // AbortController timer that stays armed until sendRequest settles so the whole exchange (headers
-  // and body) is bounded, then clear it in the finally block.
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(() => abortController.abort(), ONE_SETTINGS_REQUEST_TIMEOUT_MS);
   try {
     const request = createPipelineRequest({
       url: buildUrl(url, query),
       method: "GET",
       headers: createHttpHeaders(headers),
-      abortSignal: abortController.signal,
+      timeout: ONE_SETTINGS_REQUEST_TIMEOUT_MS,
     });
     const { pipeline, httpClient } = getOneSettingsSender();
     const response = await pipeline.sendRequest(httpClient, request);
@@ -98,8 +91,6 @@ export async function makeOneSettingsRequest(
       statusCode: 0,
       hasException: true,
     };
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { PipelineResponse } from "@azure/core-rest-pipeline";
+import {
+  createDefaultHttpClient,
+  createHttpHeaders,
+  createPipelineRequest,
+} from "@azure/core-rest-pipeline";
+import { diag } from "@opentelemetry/api";
+import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../Declarations/Constants.js";
+
+/** Request timeout, in milliseconds, for a single OneSettings HTTP call. */
+const ONE_SETTINGS_REQUEST_TIMEOUT_MS = 10000;
+
+/**
+ * Parsed result of a single OneSettings HTTP request.
+ *
+ * The request helper never throws: transient failures (network errors, timeouts) are reported
+ * via {@link OneSettingsResponse.hasException} rather than as exceptions, so callers can decide
+ * whether to retry.
+ * @internal
+ */
+export interface OneSettingsResponse {
+  /** ETag header value, used to detect changes on subsequent polls. Absent when not returned. */
+  etag?: string;
+  /** Refresh interval, in milliseconds, until the next poll should occur. */
+  refreshIntervalMs: number;
+  /** Configuration key-value pairs. Empty for 304 (unchanged) and error responses. */
+  settings: Record<string, string>;
+  /** HTTP status code, or 0 when the request failed before a response was received. */
+  statusCode: number;
+  /** True when the request failed with a transient error (network error, timeout). */
+  hasException: boolean;
+}
+
+/**
+ * Make an HTTP GET request to a OneSettings endpoint and parse the response.
+ *
+ * This helper never throws: transient failures are caught and returned as a response with
+ * `hasException: true`, and non-success HTTP status codes are preserved so the caller can decide
+ * whether they are retryable.
+ *
+ * @param url - The OneSettings endpoint URL.
+ * @param query - Query parameters to append to the URL.
+ * @param headers - HTTP headers to send, e.g. `If-None-Match` for ETag-based change detection.
+ * @returns A parsed {@link OneSettingsResponse}.
+ * @internal
+ */
+export async function makeOneSettingsRequest(
+  url: string,
+  query: Record<string, string> = {},
+  headers: Record<string, string> = {},
+): Promise<OneSettingsResponse> {
+  try {
+    const request = createPipelineRequest({
+      url: buildUrl(url, query),
+      method: "GET",
+      headers: createHttpHeaders(headers),
+      timeout: ONE_SETTINGS_REQUEST_TIMEOUT_MS,
+    });
+    const response = await createDefaultHttpClient().sendRequest(request);
+    return parseOneSettingsResponse(response);
+  } catch (error) {
+    diag.debug("Failed to fetch configuration from OneSettings:", error);
+    return {
+      refreshIntervalMs: ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+      settings: {},
+      statusCode: 0,
+      hasException: true,
+    };
+  }
+}
+
+/**
+ * Append query parameters to a URL.
+ */
+function buildUrl(url: string, query: Record<string, string>): string {
+  const parsed = new URL(url);
+  for (const [key, value] of Object.entries(query)) {
+    parsed.searchParams.set(key, value);
+  }
+  return parsed.toString();
+}
+
+/**
+ * Parse a OneSettings HTTP response into a {@link OneSettingsResponse}.
+ *
+ * The status code is always preserved so callers can distinguish retryable server errors from
+ * non-retryable client errors. Settings are only parsed on `200`; `304 Not Modified` and error
+ * responses yield an empty settings object.
+ */
+function parseOneSettingsResponse(response: PipelineResponse): OneSettingsResponse {
+  const statusCode = response.status;
+  const etag = response.headers.get("etag") ?? undefined;
+
+  let refreshIntervalMs = ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS;
+  const refreshIntervalHeader = response.headers.get("x-ms-onesetinterval");
+  if (refreshIntervalHeader) {
+    // OneSettings returns the refresh interval as a non-negative integer number of minutes;
+    // convert to milliseconds. Reject anything else (non-integer, negative, non-numeric).
+    const minutes = Number(refreshIntervalHeader);
+    if (Number.isInteger(minutes) && minutes >= 0) {
+      refreshIntervalMs = minutes * 60 * 1000;
+    } else {
+      diag.debug(`Invalid OneSettings refresh interval header: ${refreshIntervalHeader}`);
+    }
+  }
+
+  let settings: Record<string, string> = {};
+  if (statusCode === 200) {
+    if (response.bodyAsText) {
+      try {
+        settings = JSON.parse(response.bodyAsText).settings ?? {};
+      } catch (error) {
+        diag.debug("Failed to parse OneSettings response body:", error);
+      }
+    }
+  } else if (statusCode !== 304) {
+    diag.debug(`OneSettings request returned status code ${statusCode}`);
+  }
+
+  return { etag, refreshIntervalMs, settings, statusCode, hasException: false };
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -4,8 +4,10 @@
 import type { PipelineResponse } from "@azure/core-rest-pipeline";
 import {
   createDefaultHttpClient,
+  createEmptyPipeline,
   createHttpHeaders,
   createPipelineRequest,
+  proxyPolicy,
 } from "@azure/core-rest-pipeline";
 import { diag } from "@opentelemetry/api";
 import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../Declarations/Constants.js";
@@ -59,7 +61,13 @@ export async function makeOneSettingsRequest(
       headers: createHttpHeaders(headers),
       timeout: ONE_SETTINGS_REQUEST_TIMEOUT_MS,
     });
-    const response = await createDefaultHttpClient().sendRequest(request);
+    // Route the request through a minimal pipeline so proxyPolicy runs: it reads the standard
+    // HTTPS_PROXY/HTTP_PROXY/ALL_PROXY (honoring NO_PROXY) environment variables and sets the
+    // request agent accordingly. Sending through the bare HTTP client would skip all policies and
+    // silently ignore proxy configuration, breaking OneSettings polling behind a corporate proxy.
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(proxyPolicy());
+    const response = await pipeline.sendRequest(createDefaultHttpClient(), request);
     return parseOneSettingsResponse(response);
   } catch (error) {
     diag.debug("Failed to fetch configuration from OneSettings:", error);

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -73,12 +73,19 @@ export async function makeOneSettingsRequest(
   query: Record<string, string> = {},
   headers: Record<string, string> = {},
 ): Promise<OneSettingsResponse> {
+  // A PipelineRequest.timeout only bounds the time to response headers: the Node transport clears
+  // it as soon as headers arrive, before the body is read. A server or proxy that sends headers and
+  // then stalls the body would otherwise hang this poll indefinitely. Drive the deadline with an
+  // AbortController timer that stays armed until sendRequest settles so the whole exchange (headers
+  // and body) is bounded, then clear it in the finally block.
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), ONE_SETTINGS_REQUEST_TIMEOUT_MS);
   try {
     const request = createPipelineRequest({
       url: buildUrl(url, query),
       method: "GET",
       headers: createHttpHeaders(headers),
-      timeout: ONE_SETTINGS_REQUEST_TIMEOUT_MS,
+      abortSignal: abortController.signal,
     });
     const { pipeline, httpClient } = getOneSettingsSender();
     const response = await pipeline.sendRequest(httpClient, request);
@@ -91,6 +98,8 @@ export async function makeOneSettingsRequest(
       statusCode: 0,
       hasException: true,
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -68,7 +68,6 @@ export interface OneSettingsResponse {
  * @returns A parsed {@link OneSettingsResponse}.
  * @internal
  */
-
 export async function makeOneSettingsRequest(
   url: string,
   query: Record<string, string> = {},

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -97,10 +97,10 @@ function parseOneSettingsResponse(response: PipelineResponse): OneSettingsRespon
   let refreshIntervalMs = ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS;
   const refreshIntervalHeader = response.headers.get("x-ms-onesetinterval");
   if (refreshIntervalHeader) {
-    // OneSettings returns the refresh interval as a non-negative integer number of minutes;
-    // convert to milliseconds. Reject anything else (non-integer, negative, non-numeric).
+    // OneSettings returns the refresh interval as a positive integer number of minutes;
+    // convert to milliseconds. Reject anything else (non-integer, zero, negative, non-numeric).
     const minutes = Number(refreshIntervalHeader);
-    if (Number.isInteger(minutes) && minutes >= 0) {
+    if (Number.isInteger(minutes) && minutes > 0) {
       refreshIntervalMs = minutes * 60 * 1000;
     } else {
       diag.debug(`Invalid OneSettings refresh interval header: ${refreshIntervalHeader}`);

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { PipelineResponse } from "@azure/core-rest-pipeline";
+import type { HttpClient, Pipeline, PipelineResponse } from "@azure/core-rest-pipeline";
 import {
   createDefaultHttpClient,
   createEmptyPipeline,
@@ -14,6 +14,25 @@ import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../Declarations/Consta
 
 /** Request timeout, in milliseconds, for a single OneSettings HTTP call. */
 const ONE_SETTINGS_REQUEST_TIMEOUT_MS = 10000;
+
+// A single HTTP client and pipeline are reused across polls. The keep-alive agent/socket cache
+// lives on the HTTP client instance, so constructing a new client per request would leak a fresh
+// keep-alive agent each time. proxyPolicy is added once; with no arguments it reads the standard
+// HTTPS_PROXY/HTTP_PROXY/ALL_PROXY environment variables (honoring NO_PROXY) and sets the request
+// agent so OneSettings polling works behind a corporate proxy.
+let oneSettingsPipeline: Pipeline | undefined;
+let oneSettingsHttpClient: HttpClient | undefined;
+
+function getOneSettingsSender(): { pipeline: Pipeline; httpClient: HttpClient } {
+  if (!oneSettingsPipeline) {
+    oneSettingsPipeline = createEmptyPipeline();
+    oneSettingsPipeline.addPolicy(proxyPolicy());
+  }
+  if (!oneSettingsHttpClient) {
+    oneSettingsHttpClient = createDefaultHttpClient();
+  }
+  return { pipeline: oneSettingsPipeline, httpClient: oneSettingsHttpClient };
+}
 
 /**
  * Parsed result of a single OneSettings HTTP request.
@@ -61,13 +80,8 @@ export async function makeOneSettingsRequest(
       headers: createHttpHeaders(headers),
       timeout: ONE_SETTINGS_REQUEST_TIMEOUT_MS,
     });
-    // Route the request through a minimal pipeline so proxyPolicy runs: it reads the standard
-    // HTTPS_PROXY/HTTP_PROXY/ALL_PROXY (honoring NO_PROXY) environment variables and sets the
-    // request agent accordingly. Sending through the bare HTTP client would skip all policies and
-    // silently ignore proxy configuration, breaking OneSettings polling behind a corporate proxy.
-    const pipeline = createEmptyPipeline();
-    pipeline.addPolicy(proxyPolicy());
-    const response = await pipeline.sendRequest(createDefaultHttpClient(), request);
+    const { pipeline, httpClient } = getOneSettingsSender();
+    const response = await pipeline.sendRequest(httpClient, request);
     return parseOneSettingsResponse(response);
   } catch (error) {
     diag.debug("Failed to fetch configuration from OneSettings:", error);

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -27,7 +27,7 @@ export interface OneSettingsResponse {
   /** Refresh interval, in milliseconds, until the next poll should occur. */
   refreshIntervalMs: number;
   /** Configuration key-value pairs. Empty for 304 (unchanged) and error responses. */
-  settings: Record<string, string>;
+  settings: Record<string, unknown>;
   /** HTTP status code, or 0 when the request failed before a response was received. */
   statusCode: number;
   /** True when the request failed with a transient error (network error, timeout). */
@@ -107,7 +107,7 @@ function parseOneSettingsResponse(response: PipelineResponse): OneSettingsRespon
     }
   }
 
-  let settings: Record<string, string> = {};
+  let settings: Record<string, unknown> = {};
   if (statusCode === 200) {
     if (response.bodyAsText) {
       try {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/utils.ts
@@ -68,6 +68,7 @@ export interface OneSettingsResponse {
  * @returns A parsed {@link OneSettingsResponse}.
  * @internal
  */
+
 export async function makeOneSettingsRequest(
   url: string,
   query: Record<string, string> = {},

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -20,7 +20,7 @@ export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
  * AzureMonitorTraceExporter version.
  * @internal
  */
-export const packageVersion = "1.0.0-beta.44";
+export const packageVersion = "1.0.0-beta.45";
 
 /**
  * Telemetry base data version.

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, assert, describe, it } from "vitest";
+import nock from "nock";
+import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
+import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../../src/Declarations/Constants.js";
+
+describe("OneSettings utils", () => {
+  const host = "https://settings.example.test";
+  const path = "/config";
+  const url = host + path;
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("makeOneSettingsRequest", () => {
+    it("parses settings, ETag, and refresh interval from a 200 response", async () => {
+      nock(host)
+        .get(path)
+        .reply(200, JSON.stringify({ settings: { FEATURE_SDK_STATS: "enabled" } }), {
+          ETag: '"abc123"',
+          // OneSettings reports the interval in minutes.
+          "x-ms-onesetinterval": "30",
+        });
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.statusCode, 200);
+      assert.strictEqual(response.hasException, false);
+      assert.strictEqual(response.etag, '"abc123"');
+      assert.strictEqual(response.refreshIntervalMs, 30 * 60 * 1000);
+      assert.deepStrictEqual(response.settings, { FEATURE_SDK_STATS: "enabled" });
+    });
+
+    it("returns empty settings but keeps the ETag on a 304 response", async () => {
+      nock(host).get(path).reply(304, "", { ETag: '"unchanged"' });
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.statusCode, 304);
+      assert.strictEqual(response.hasException, false);
+      assert.strictEqual(response.etag, '"unchanged"');
+      assert.deepStrictEqual(response.settings, {});
+    });
+
+    it("preserves the status code and returns empty settings on a 4xx response", async () => {
+      nock(host).get(path).reply(404, "not found");
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.statusCode, 404);
+      assert.strictEqual(response.hasException, false);
+      assert.deepStrictEqual(response.settings, {});
+    });
+
+    it("preserves the status code and returns empty settings on a 5xx response", async () => {
+      nock(host).get(path).reply(500, "server error");
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.statusCode, 500);
+      assert.strictEqual(response.hasException, false);
+      assert.deepStrictEqual(response.settings, {});
+    });
+
+    it("returns empty settings and no exception when a 200 body is not valid JSON", async () => {
+      nock(host).get(path).reply(200, "not-json");
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.statusCode, 200);
+      assert.strictEqual(response.hasException, false);
+      assert.deepStrictEqual(response.settings, {});
+    });
+
+    it.each(["not-a-number", "30.5", "-5", ""])(
+      "falls back to the default refresh interval when the header is invalid (%j)",
+      async (headerValue) => {
+        nock(host)
+          .get(path)
+          .reply(200, JSON.stringify({ settings: {} }), { "x-ms-onesetinterval": headerValue });
+
+        const response = await makeOneSettingsRequest(url);
+
+        assert.strictEqual(response.refreshIntervalMs, ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS);
+      },
+    );
+
+    it("sends provided query parameters and headers", async () => {
+      const scope = nock(host, { reqheaders: { "if-none-match": '"etag-1"' } })
+        .get(path)
+        .query({ namespaces: "nodejs" })
+        .reply(200, JSON.stringify({ settings: {} }));
+
+      const response = await makeOneSettingsRequest(
+        url,
+        { namespaces: "nodejs" },
+        { "If-None-Match": '"etag-1"' },
+      );
+
+      assert.strictEqual(response.statusCode, 200);
+      assert.isTrue(scope.isDone());
+    });
+
+    it("reports a transient error when the request fails", async () => {
+      nock(host).get(path).replyWithError("network down");
+
+      const response = await makeOneSettingsRequest(url);
+
+      assert.strictEqual(response.hasException, true);
+      assert.strictEqual(response.statusCode, 0);
+      assert.strictEqual(response.refreshIntervalMs, ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS);
+      assert.deepStrictEqual(response.settings, {});
+    });
+  });
+});

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { afterEach, assert, describe, it } from "vitest";
+import { afterEach, assert, describe, it, vi } from "vitest";
 import nock from "nock";
 import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
 import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../../src/Declarations/Constants.js";
@@ -113,6 +113,27 @@ describe("OneSettings utils", () => {
       assert.strictEqual(response.statusCode, 0);
       assert.strictEqual(response.refreshIntervalMs, ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS);
       assert.deepStrictEqual(response.settings, {});
+    });
+
+    it("reports a transient error when the response body stalls past the request deadline", async () => {
+      vi.useFakeTimers();
+      try {
+        // Headers arrive immediately, but the body is withheld far past the request deadline.
+        // This is the case a PipelineRequest.timeout does not cover, so the AbortController timer
+        // must fire and surface a transient error rather than hanging indefinitely.
+        nock(host).get(path).delayBody(600000).reply(200, JSON.stringify({ settings: {} }));
+
+        const responsePromise = makeOneSettingsRequest(url);
+        // Advance past the request deadline but well before the body would be delivered.
+        await vi.advanceTimersByTimeAsync(60000);
+        const response = await responsePromise;
+
+        assert.strictEqual(response.hasException, true);
+        assert.strictEqual(response.statusCode, 0);
+        assert.deepStrictEqual(response.settings, {});
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
@@ -75,7 +75,7 @@ describe("OneSettings utils", () => {
       assert.deepStrictEqual(response.settings, {});
     });
 
-    it.each(["not-a-number", "30.5", "-5", ""])(
+    it.each(["not-a-number", "30.5", "0", "-5", ""])(
       "falls back to the default refresh interval when the header is invalid (%j)",
       async (headerValue) => {
         nock(host)

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/oneSettingsUtils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { afterEach, assert, describe, it, vi } from "vitest";
+import { afterEach, assert, describe, it } from "vitest";
 import nock from "nock";
 import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
 import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../../src/Declarations/Constants.js";
@@ -113,27 +113,6 @@ describe("OneSettings utils", () => {
       assert.strictEqual(response.statusCode, 0);
       assert.strictEqual(response.refreshIntervalMs, ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS);
       assert.deepStrictEqual(response.settings, {});
-    });
-
-    it("reports a transient error when the response body stalls past the request deadline", async () => {
-      vi.useFakeTimers();
-      try {
-        // Headers arrive immediately, but the body is withheld far past the request deadline.
-        // This is the case a PipelineRequest.timeout does not cover, so the AbortController timer
-        // must fire and surface a transient error rather than hanging indefinitely.
-        nock(host).get(path).delayBody(600000).reply(200, JSON.stringify({ settings: {} }));
-
-        const responsePromise = makeOneSettingsRequest(url);
-        // Advance past the request deadline but well before the body would be delivered.
-        await vi.advanceTimersByTimeAsync(60000);
-        const response = await responsePromise;
-
-        assert.strictEqual(response.hasException, true);
-        assert.strictEqual(response.statusCode, 0);
-        assert.deepStrictEqual(response.settings, {});
-      } finally {
-        vi.useRealTimers();
-      }
     });
   });
 });


### PR DESCRIPTION
- Adds an internal `makeOneSettingsRequest` helper (and `OneSettingsResponse` type)
that fetches OneSettings dynamic configuration via `@azure/core-rest-pipeline`.
- It never throws (transient failures set `hasException`), preserves non-success
status codes, and parses the `ETag`, refresh interval, and settings payload.