### PR TITLE
[discovery] Address APIView feedback and add CODEOWNERS for @azure/ai-discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,6 +187,12 @@
 # PRLabel: %Digital Twins
 /sdk/digitaltwins/    @johngallardo @olivakar @sjiherzig
 
+# PRLabel: %Discovery
+/sdk/discovery/ai-discovery    @ahall-msft @mike-menaker
+
+# ServiceLabel: %Discovery
+# ServiceOwners: @ahall-msft @mike-menaker
+
 # PRLabel: %DocumentTranslator
 /sdk/documenttranslator/    @jeremymeng
 

--- a/sdk/discovery/ai-discovery/review/ai-discovery-bookshelf-node.api.md
+++ b/sdk/discovery/ai-discovery/review/ai-discovery-bookshelf-node.api.md
@@ -64,7 +64,7 @@ export interface KnowledgeBasesListOptionalParams extends OperationOptions {
 export interface KnowledgeBasesOperations {
     cancelIndexing: (knowledgeBaseName: string, options?: KnowledgeBasesCancelIndexingOptionalParams) => PollerLike<OperationState<void>, void>;
     createOrUpdate: (knowledgeBaseName: string, resource: KnowledgeBaseCreateOrUpdateContent, options?: KnowledgeBasesCreateOrUpdateOptionalParams) => PollerLike<OperationState<KnowledgeBase>, KnowledgeBase>;
-    delete: (knowledgeBaseName: string, options?: KnowledgeBasesDeleteOptionalParams) => PollerLike<OperationState<void>, void>;
+    deleteKnowledgeBase: (knowledgeBaseName: string, options?: KnowledgeBasesDeleteOptionalParams) => PollerLike<OperationState<void>, void>;
     get: (knowledgeBaseName: string, options?: KnowledgeBasesGetOptionalParams) => Promise<KnowledgeBase>;
     getOperationStatus: (knowledgeBaseName: string, operationId: string, options?: KnowledgeBasesGetOperationStatusOptionalParams) => Promise<KnowledgeBaseOperationResponseUnion>;
     list: (options?: KnowledgeBasesListOptionalParams) => PagedAsyncIterableIterator<KnowledgeBase>;

--- a/sdk/discovery/ai-discovery/review/ai-discovery-node.api.md
+++ b/sdk/discovery/ai-discovery/review/ai-discovery-node.api.md
@@ -28,7 +28,7 @@ export interface BookshelfClientOptionalParams extends ClientOptions {
 }
 
 // @public
-export function BookshelfClientRestorePoller<TResponse extends PathUncheckedResponse, TResult>(client: BookshelfClient, serializedState: string, sourceOperation: (...args: any[]) => PollerLike<OperationState_2<TResult>, TResult>, options?: BookshelfClientRestorePollerOptions<TResult>): PollerLike<OperationState_2<TResult>, TResult>;
+export function bookshelfClientRestorePoller<TResponse extends PathUncheckedResponse, TResult>(client: BookshelfClient, serializedState: string, sourceOperation: (...args: any[]) => PollerLike<OperationState_2<TResult>, TResult>, options?: BookshelfClientRestorePollerOptions<TResult>): PollerLike<OperationState_2<TResult>, TResult>;
 
 // @public (undocumented)
 export interface BookshelfClientRestorePollerOptions<TResult, TResponse extends PathUncheckedResponse = PathUncheckedResponse> extends OperationOptions {
@@ -106,7 +106,7 @@ export interface ConversationsListOptionalParams extends OperationOptions {
 // @public
 export interface ConversationsOperations {
     create: (projectName: string, options?: ConversationsCreateOptionalParams) => Promise<Conversation>;
-    delete: (conversationName: string, options?: ConversationsDeleteOptionalParams) => Promise<void>;
+    deleteConversation: (conversationName: string, options?: ConversationsDeleteOptionalParams) => Promise<void>;
     get: (conversationName: string, options?: ConversationsGetOptionalParams) => Promise<Conversation>;
     list: (options?: ConversationsListOptionalParams) => PagedAsyncIterableIterator<Conversation>;
     update: (conversationName: string, resource: ConversationCreateOrUpdateContent, options?: ConversationsUpdateOptionalParams) => Promise<Conversation>;
@@ -262,7 +262,7 @@ export interface InvestigationsListOptionalParams extends OperationOptions {
 // @public
 export interface InvestigationsOperations {
     createOrReplace: (projectName: string, investigationName: string, resource: InvestigationCreateOrUpdateContent, options?: InvestigationsCreateOrReplaceOptionalParams) => Promise<Investigation>;
-    delete: (projectName: string, investigationName: string, options?: InvestigationsDeleteOptionalParams) => PollerLike<OperationState_2<void>, void>;
+    deleteInvestigation: (projectName: string, investigationName: string, options?: InvestigationsDeleteOptionalParams) => PollerLike<OperationState_2<void>, void>;
     get: (projectName: string, investigationName: string, options?: InvestigationsGetOptionalParams) => Promise<Investigation>;
     getDiscoveryEngine: (projectName: string, investigationName: string, options?: InvestigationsGetDiscoveryEngineOptionalParams) => Promise<DiscoveryEngine>;
     getOperationStatus: (projectName: string, investigationName: string, operationId: string, options?: InvestigationsGetOperationStatusOptionalParams) => Promise<InvestigationOperationStatus>;
@@ -381,7 +381,7 @@ export interface KnowledgeBasesListOptionalParams extends OperationOptions {
 export interface KnowledgeBasesOperations {
     cancelIndexing: (knowledgeBaseName: string, options?: KnowledgeBasesCancelIndexingOptionalParams) => PollerLike<OperationState_2<void>, void>;
     createOrUpdate: (knowledgeBaseName: string, resource: KnowledgeBaseCreateOrUpdateContent, options?: KnowledgeBasesCreateOrUpdateOptionalParams) => PollerLike<OperationState_2<KnowledgeBase>, KnowledgeBase>;
-    delete: (knowledgeBaseName: string, options?: KnowledgeBasesDeleteOptionalParams) => PollerLike<OperationState_2<void>, void>;
+    deleteKnowledgeBase: (knowledgeBaseName: string, options?: KnowledgeBasesDeleteOptionalParams) => PollerLike<OperationState_2<void>, void>;
     get: (knowledgeBaseName: string, options?: KnowledgeBasesGetOptionalParams) => Promise<KnowledgeBase>;
     getOperationStatus: (knowledgeBaseName: string, operationId: string, options?: KnowledgeBasesGetOperationStatusOptionalParams) => Promise<KnowledgeBaseOperationResponseUnion>;
     list: (options?: KnowledgeBasesListOptionalParams) => PagedAsyncIterableIterator<KnowledgeBase>;
@@ -609,16 +609,6 @@ export type RepeatabilityResult = "accepted" | "rejected";
 export { RestError }
 
 // @public
-export function restorePoller<TResponse extends PathUncheckedResponse, TResult>(client: WorkspaceClient, serializedState: string, sourceOperation: (...args: any[]) => PollerLike<OperationState_2<TResult>, TResult>, options?: RestorePollerOptions<TResult>): PollerLike<OperationState_2<TResult>, TResult>;
-
-// @public (undocumented)
-export interface RestorePollerOptions<TResult, TResponse extends PathUncheckedResponse = PathUncheckedResponse> extends OperationOptions {
-    abortSignal?: AbortSignalLike;
-    processResponseBody?: (result: TResponse) => Promise<TResult>;
-    updateIntervalInMs?: number;
-}
-
-// @public
 export interface RunResult {
     readonly completedAt?: Date;
     readonly createdAt?: Date;
@@ -761,7 +751,7 @@ export interface TasksOperations {
     addComment: (projectName: string, investigationName: string, taskName: string, body: TaskComment, options?: TasksAddCommentOptionalParams) => Promise<Task>;
     addExecutionHistory: (projectName: string, investigationName: string, taskName: string, body: ExecutionHistoryEntry, options?: TasksAddExecutionHistoryOptionalParams) => Promise<Task>;
     create: (projectName: string, investigationName: string, body: TaskCreateOrUpdateContent, options?: TasksCreateOptionalParams) => Promise<Task>;
-    delete: (projectName: string, investigationName: string, taskName: string, options?: TasksDeleteOptionalParams) => Promise<void>;
+    deleteTask: (projectName: string, investigationName: string, taskName: string, options?: TasksDeleteOptionalParams) => Promise<void>;
     get: (projectName: string, investigationName: string, taskName: string, options?: TasksGetOptionalParams) => Promise<Task>;
     list: (projectName: string, investigationName: string, options?: TasksListOptionalParams) => PagedAsyncIterableIterator<Task>;
     start: (projectName: string, investigationName: string, taskName: string, options?: TasksStartOptionalParams) => Promise<Task>;
@@ -846,6 +836,16 @@ export class WorkspaceClient {
 
 // @public
 export interface WorkspaceClientOptionalParams extends ClientOptions {
+}
+
+// @public
+export function workspaceClientRestorePoller<TResponse extends PathUncheckedResponse, TResult>(client: WorkspaceClient, serializedState: string, sourceOperation: (...args: any[]) => PollerLike<OperationState_2<TResult>, TResult>, options?: WorkspaceClientRestorePollerOptions<TResult>): PollerLike<OperationState_2<TResult>, TResult>;
+
+// @public (undocumented)
+export interface WorkspaceClientRestorePollerOptions<TResult, TResponse extends PathUncheckedResponse = PathUncheckedResponse> extends OperationOptions {
+    abortSignal?: AbortSignalLike;
+    processResponseBody?: (result: TResponse) => Promise<TResult>;
+    updateIntervalInMs?: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/discovery/ai-discovery/review/ai-discovery-workspace-node.api.md
+++ b/sdk/discovery/ai-discovery/review/ai-discovery-workspace-node.api.md
@@ -42,7 +42,7 @@ export interface ConversationsListOptionalParams extends OperationOptions {
 // @public
 export interface ConversationsOperations {
     create: (projectName: string, options?: ConversationsCreateOptionalParams) => Promise<Conversation>;
-    delete: (conversationName: string, options?: ConversationsDeleteOptionalParams) => Promise<void>;
+    deleteConversation: (conversationName: string, options?: ConversationsDeleteOptionalParams) => Promise<void>;
     get: (conversationName: string, options?: ConversationsGetOptionalParams) => Promise<Conversation>;
     list: (options?: ConversationsListOptionalParams) => PagedAsyncIterableIterator<Conversation>;
     update: (conversationName: string, resource: ConversationCreateOrUpdateContent, options?: ConversationsUpdateOptionalParams) => Promise<Conversation>;
@@ -91,7 +91,7 @@ export interface InvestigationsListOptionalParams extends OperationOptions {
 // @public
 export interface InvestigationsOperations {
     createOrReplace: (projectName: string, investigationName: string, resource: InvestigationCreateOrUpdateContent, options?: InvestigationsCreateOrReplaceOptionalParams) => Promise<Investigation>;
-    delete: (projectName: string, investigationName: string, options?: InvestigationsDeleteOptionalParams) => PollerLike<OperationState<void>, void>;
+    deleteInvestigation: (projectName: string, investigationName: string, options?: InvestigationsDeleteOptionalParams) => PollerLike<OperationState<void>, void>;
     get: (projectName: string, investigationName: string, options?: InvestigationsGetOptionalParams) => Promise<Investigation>;
     getDiscoveryEngine: (projectName: string, investigationName: string, options?: InvestigationsGetDiscoveryEngineOptionalParams) => Promise<DiscoveryEngine>;
     getOperationStatus: (projectName: string, investigationName: string, operationId: string, options?: InvestigationsGetOperationStatusOptionalParams) => Promise<InvestigationOperationStatus>;
@@ -159,7 +159,7 @@ export interface TasksOperations {
     addComment: (projectName: string, investigationName: string, taskName: string, body: TaskComment, options?: TasksAddCommentOptionalParams) => Promise<Task>;
     addExecutionHistory: (projectName: string, investigationName: string, taskName: string, body: ExecutionHistoryEntry, options?: TasksAddExecutionHistoryOptionalParams) => Promise<Task>;
     create: (projectName: string, investigationName: string, body: TaskCreateOrUpdateContent, options?: TasksCreateOptionalParams) => Promise<Task>;
-    delete: (projectName: string, investigationName: string, taskName: string, options?: TasksDeleteOptionalParams) => Promise<void>;
+    deleteTask: (projectName: string, investigationName: string, taskName: string, options?: TasksDeleteOptionalParams) => Promise<void>;
     get: (projectName: string, investigationName: string, taskName: string, options?: TasksGetOptionalParams) => Promise<Task>;
     list: (projectName: string, investigationName: string, options?: TasksListOptionalParams) => PagedAsyncIterableIterator<Task>;
     start: (projectName: string, investigationName: string, taskName: string, options?: TasksStartOptionalParams) => Promise<Task>;

--- a/sdk/discovery/ai-discovery/src/bookshelf/classic/knowledgeBases/index.ts
+++ b/sdk/discovery/ai-discovery/src/bookshelf/classic/knowledgeBases/index.ts
@@ -35,12 +35,7 @@ import { PollerLike, OperationState } from "@azure/core-lro";
 /** Interface representing a KnowledgeBases operations. */
 export interface KnowledgeBasesOperations {
   /** Delete a KnowledgeBase. */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
-  delete: (
+  deleteKnowledgeBase: (
     knowledgeBaseName: string,
     options?: KnowledgeBasesDeleteOptionalParams,
   ) => PollerLike<OperationState<void>, void>;
@@ -85,8 +80,10 @@ export interface KnowledgeBasesOperations {
 }
 function _getKnowledgeBases(context: BookshelfContext) {
   return {
-    delete: (knowledgeBaseName: string, options?: KnowledgeBasesDeleteOptionalParams) =>
-      $delete(context, knowledgeBaseName, options),
+    deleteKnowledgeBase: (
+      knowledgeBaseName: string,
+      options?: KnowledgeBasesDeleteOptionalParams,
+    ) => $delete(context, knowledgeBaseName, options),
     search: (
       knowledgeBaseName: string,
       body: SearchRequest,

--- a/sdk/discovery/ai-discovery/src/index.ts
+++ b/sdk/discovery/ai-discovery/src/index.ts
@@ -8,8 +8,8 @@ import {
 } from "./static-helpers/pagingHelpers.js";
 
 export { WorkspaceClient } from "./workspace/workspaceClient.js";
-export type { RestorePollerOptions } from "./workspace/restorePollerHelpers.js";
-export { restorePoller } from "./workspace/restorePollerHelpers.js";
+export type { RestorePollerOptions as WorkspaceClientRestorePollerOptions } from "./workspace/restorePollerHelpers.js";
+export { restorePoller as workspaceClientRestorePoller } from "./workspace/restorePollerHelpers.js";
 export type {
   OperationState,
   PagedInvestigation,
@@ -137,7 +137,7 @@ export type { PageSettings, ContinuablePage, PagedAsyncIterableIterator };
 export { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { BookshelfClient } from "./bookshelf/bookshelfClient.js";
 export type { RestorePollerOptions as BookshelfClientRestorePollerOptions } from "./bookshelf/restorePollerHelpers.js";
-export { restorePoller as BookshelfClientRestorePoller } from "./bookshelf/restorePollerHelpers.js";
+export { restorePoller as bookshelfClientRestorePoller } from "./bookshelf/restorePollerHelpers.js";
 export type { BookshelfClientOptionalParams } from "./bookshelf/api/index.js";
 export type {
   KnowledgeBasesDeleteOptionalParams,

--- a/sdk/discovery/ai-discovery/src/workspace/classic/conversations/index.ts
+++ b/sdk/discovery/ai-discovery/src/workspace/classic/conversations/index.ts
@@ -21,12 +21,11 @@ export interface ConversationsOperations {
   /** List Conversation resources */
   list: (options?: ConversationsListOptionalParams) => PagedAsyncIterableIterator<Conversation>;
   /** Deletes a Conversation. */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
-  delete: (conversationName: string, options?: ConversationsDeleteOptionalParams) => Promise<void>;
+  /** Delete a conversation. */
+  deleteConversation: (
+    conversationName: string,
+    options?: ConversationsDeleteOptionalParams,
+  ) => Promise<void>;
   /** Updates a Conversation. */
   update: (
     conversationName: string,
@@ -47,7 +46,7 @@ export interface ConversationsOperations {
 function _getConversations(context: WorkspaceContext) {
   return {
     list: (options?: ConversationsListOptionalParams) => list(context, options),
-    delete: (conversationName: string, options?: ConversationsDeleteOptionalParams) =>
+    deleteConversation: (conversationName: string, options?: ConversationsDeleteOptionalParams) =>
       $delete(context, conversationName, options),
     update: (
       conversationName: string,

--- a/sdk/discovery/ai-discovery/src/workspace/classic/investigations/index.ts
+++ b/sdk/discovery/ai-discovery/src/workspace/classic/investigations/index.ts
@@ -78,12 +78,7 @@ export interface InvestigationsOperations {
     options?: InvestigationsListOptionalParams,
   ) => PagedAsyncIterableIterator<Investigation>;
   /** Delete a Investigation. */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
-  delete: (
+  deleteInvestigation: (
     projectName: string,
     investigationName: string,
     options?: InvestigationsDeleteOptionalParams,
@@ -146,7 +141,7 @@ function _getInvestigations(context: WorkspaceContext) {
     ) => getDiscoveryEngine(context, projectName, investigationName, options),
     list: (projectName: string, options?: InvestigationsListOptionalParams) =>
       list(context, projectName, options),
-    delete: (
+    deleteInvestigation: (
       projectName: string,
       investigationName: string,
       options?: InvestigationsDeleteOptionalParams,

--- a/sdk/discovery/ai-discovery/src/workspace/classic/tasks/index.ts
+++ b/sdk/discovery/ai-discovery/src/workspace/classic/tasks/index.ts
@@ -56,12 +56,7 @@ export interface TasksOperations {
     options?: TasksStartOptionalParams,
   ) => Promise<Task>;
   /** Delete a task by ID. */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
-  delete: (
+  deleteTask: (
     projectName: string,
     investigationName: string,
     taskName: string,
@@ -118,7 +113,7 @@ function _getTasks(context: WorkspaceContext) {
       taskName: string,
       options?: TasksStartOptionalParams,
     ) => start(context, projectName, investigationName, taskName, options),
-    delete: (
+    deleteTask: (
       projectName: string,
       investigationName: string,
       taskName: string,

--- a/sdk/discovery/ai-discovery/test/public/conversations.spec.ts
+++ b/sdk/discovery/ai-discovery/test/public/conversations.spec.ts
@@ -86,7 +86,7 @@ describe("Conversations operations (WorkspaceClient)", () => {
   });
 
   it("delete removes a conversation", async () => {
-    const result = await client.conversations.delete(createdConversationName);
+    const result = await client.conversations.deleteConversation(createdConversationName);
     assert.isUndefined(result);
   });
 });

--- a/sdk/discovery/ai-discovery/test/public/investigations.spec.ts
+++ b/sdk/discovery/ai-discovery/test/public/investigations.spec.ts
@@ -92,7 +92,7 @@ describe("Investigations operations (WorkspaceClient)", () => {
       description: "Task for engine start test",
     });
     const engine = await client.investigations.startDiscoveryEngine(projectName, investigationName);
-    await client.tasks.delete(projectName, investigationName, task.name);
+    await client.tasks.deleteTask(projectName, investigationName, task.name);
     assert.isDefined(engine);
     assert.property(engine, "discoveryEngineStatus");
   });
@@ -143,7 +143,7 @@ describe("Investigations operations (WorkspaceClient)", () => {
 
     // Start the delete LRO without waiting and capture its operation id.
     const capture = captureOperationId();
-    const poller = client.investigations.delete(projectName, opStatusName, {
+    const poller = client.investigations.deleteInvestigation(projectName, opStatusName, {
       onResponse: capture.onResponse,
     });
     await poller.submitted();
@@ -165,7 +165,7 @@ describe("Investigations operations (WorkspaceClient)", () => {
       displayName: "Delete Status Test",
     });
 
-    const poller = client.investigations.delete(projectName, deleteName);
+    const poller = client.investigations.deleteInvestigation(projectName, deleteName);
     await poller.pollUntilDone();
     assert.isTrue(poller.isDone);
     assert.equal(poller.operationState?.status, "succeeded");

--- a/sdk/discovery/ai-discovery/test/public/knowledgeBases.spec.ts
+++ b/sdk/discovery/ai-discovery/test/public/knowledgeBases.spec.ts
@@ -223,7 +223,7 @@ describe("KnowledgeBases operations (BookshelfClient)", () => {
       })
       .pollUntilDone();
 
-    const poller = client.knowledgeBases.delete(sacrificialName);
+    const poller = client.knowledgeBases.deleteKnowledgeBase(sacrificialName);
     await poller.pollUntilDone();
     assert.equal(poller.operationState?.status, "succeeded");
 

--- a/sdk/discovery/ai-discovery/test/public/tasks.spec.ts
+++ b/sdk/discovery/ai-discovery/test/public/tasks.spec.ts
@@ -50,7 +50,7 @@ describe("Tasks operations (WorkspaceClient)", () => {
 
   async function deleteTaskQuiet(taskName: string): Promise<void> {
     try {
-      await client.tasks.delete(projectName, investigationName, taskName);
+      await client.tasks.deleteTask(projectName, investigationName, taskName);
     } catch {
       // best-effort cleanup
     }
@@ -113,7 +113,7 @@ describe("Tasks operations (WorkspaceClient)", () => {
 
   it("delete removes a task", async () => {
     const created = await createTask("task-for-delete-test");
-    const result = await client.tasks.delete(projectName, investigationName, created.name);
+    const result = await client.tasks.deleteTask(projectName, investigationName, created.name);
     assert.isUndefined(result);
   });
 


### PR DESCRIPTION
Follow-up to #39406 to address GA APIView review feedback from @maorleger and establish package ownership.

## APIView feedback (all "ShouldFix")
- **Reserved-word `delete` methods** renamed via in-SDK customization (removes the `@fixme` the emitter generated):
  - `conversations.delete` → `deleteConversation`
  - `investigations.delete` → `deleteInvestigation`
  - `tasks.delete` → `deleteTask`
  - `knowledgeBases.delete` → `deleteKnowledgeBase`
- **Restore poller exports camelCased** per reviewer guidance:
  - `BookshelfClientRestorePoller` → `bookshelfClientRestorePoller`
  - workspace `restorePoller` → `workspaceClientRestorePoller` (+ options type `WorkspaceClientRestorePollerOptions`)

## CODEOWNERS
- Added the `%Discovery` entry for `/sdk/discovery/ai-discovery` (@ahall-msft @mike-menaker), matching the .NET PR and JS data-plane format.

## Validation
- Build: 0 errors · Lint: 0 errors · Playback tests: 40/40
- API report regenerated