### PR TITLE
[ai-translation-document] Address APIView feedback: list verbs, updatedAt, serviceVersion

### DIFF
--- a/sdk/translation/ai-translation-document/generated/documentTranslation/api/index.ts
+++ b/sdk/translation/ai-translation-document/generated/documentTranslation/api/index.ts
@@ -8,19 +8,19 @@ export type {
 export { createDocumentTranslation } from "./documentTranslationContext.js";
 export {
   getSupportedFormats,
-  getDocumentsStatus,
+  listDocumentStatuses,
   cancelTranslation,
   getTranslationStatus,
   getDocumentStatus,
-  getTranslationsStatus,
+  listTranslationStatuses,
   startTranslation,
 } from "./operations.js";
 export type {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./options.js";

--- a/sdk/translation/ai-translation-document/generated/documentTranslation/api/operations.ts
+++ b/sdk/translation/ai-translation-document/generated/documentTranslation/api/operations.ts
@@ -25,11 +25,11 @@ import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
 import {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./options.js";
 import {
@@ -88,10 +88,10 @@ export async function getSupportedFormats(
   return _getSupportedFormatsDeserialize(result);
 }
 
-export function _getDocumentsStatusSend(
+export function _listDocumentStatusesSend(
   context: Client,
   translationId: string,
-  options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+  options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
 ): StreamableMethod {
   const path = expandUrlTemplate(
     "/document/batches/{id}/documents{?api%2Dversion,top,skip,maxpagesize,ids,statuses,createdDateTimeUtcStart,createdDateTimeUtcEnd,orderby}",
@@ -135,7 +135,7 @@ export function _getDocumentsStatusSend(
     });
 }
 
-export async function _getDocumentsStatusDeserialize(
+export async function _listDocumentStatusesDeserialize(
   result: PathUncheckedResponse,
 ): Promise<_DocumentsStatus> {
   const expectedStatuses = ["200"];
@@ -193,15 +193,15 @@ export async function _getDocumentsStatusDeserialize(
  * This reduces the risk of the client making assumptions about
  * the data returned.
  */
-export function getDocumentsStatus(
+export function listDocumentStatuses(
   context: Client,
   translationId: string,
-  options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+  options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
 ): PagedAsyncIterableIterator<DocumentStatus> {
   return buildPagedAsyncIterator(
     context,
-    () => _getDocumentsStatusSend(context, translationId, options),
-    _getDocumentsStatusDeserialize,
+    () => _listDocumentStatusesSend(context, translationId, options),
+    _listDocumentStatusesDeserialize,
     ["200"],
     { itemName: "value", nextLinkName: "nextLink", apiVersion: context.apiVersion ?? "2026-03-01" },
   );
@@ -356,9 +356,9 @@ export async function getDocumentStatus(
   return _getDocumentStatusDeserialize(result);
 }
 
-export function _getTranslationsStatusSend(
+export function _listTranslationStatusesSend(
   context: Client,
-  options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
 ): StreamableMethod {
   const path = expandUrlTemplate(
     "/document/batches{?api%2Dversion,top,skip,maxpagesize,ids,statuses,createdDateTimeUtcStart,createdDateTimeUtcEnd,orderby}",
@@ -401,7 +401,7 @@ export function _getTranslationsStatusSend(
     });
 }
 
-export async function _getTranslationsStatusDeserialize(
+export async function _listTranslationStatusesDeserialize(
   result: PathUncheckedResponse,
 ): Promise<_TranslationsStatus> {
   const expectedStatuses = ["200"];
@@ -465,14 +465,14 @@ export async function _getTranslationsStatusDeserialize(
  * This reduces the risk of the client
  * making assumptions about the data returned.
  */
-export function getTranslationsStatus(
+export function listTranslationStatuses(
   context: Client,
-  options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
 ): PagedAsyncIterableIterator<TranslationStatus> {
   return buildPagedAsyncIterator(
     context,
-    () => _getTranslationsStatusSend(context, options),
-    _getTranslationsStatusDeserialize,
+    () => _listTranslationStatusesSend(context, options),
+    _listTranslationStatusesDeserialize,
     ["200"],
     { itemName: "value", nextLinkName: "nextLink", apiVersion: context.apiVersion ?? "2026-03-01" },
   );

--- a/sdk/translation/ai-translation-document/generated/documentTranslation/api/options.ts
+++ b/sdk/translation/ai-translation-document/generated/documentTranslation/api/options.ts
@@ -6,7 +6,7 @@ import { OperationOptions } from "@azure-rest/core-client";
 /** Optional parameters. */
 export interface GetSupportedFormatsOptionalParams extends OperationOptions {}
 /** Optional parameters. */
-export interface GetDocumentsStatusOptionalParams extends OperationOptions {
+export interface ListDocumentStatusesOptionalParams extends OperationOptions {
   /**
    * top indicates the total number of records the user wants to be returned across
    * all pages.
@@ -67,7 +67,7 @@ export interface GetTranslationStatusOptionalParams extends OperationOptions {}
 /** Optional parameters. */
 export interface GetDocumentStatusOptionalParams extends OperationOptions {}
 /** Optional parameters. */
-export interface GetTranslationsStatusOptionalParams extends OperationOptions {
+export interface ListTranslationStatusesOptionalParams extends OperationOptions {
   /**
    * top indicates the total number of records the user wants to be returned across
    * all pages.

--- a/sdk/translation/ai-translation-document/generated/documentTranslation/documentTranslationClient.ts
+++ b/sdk/translation/ai-translation-document/generated/documentTranslation/documentTranslationClient.ts
@@ -16,20 +16,20 @@ import {
 import { PagedAsyncIterableIterator } from "../static-helpers/pagingHelpers.js";
 import {
   getSupportedFormats,
-  getDocumentsStatus,
+  listDocumentStatuses,
   cancelTranslation,
   getTranslationStatus,
   getDocumentStatus,
-  getTranslationsStatus,
+  listTranslationStatuses,
   startTranslation,
 } from "./api/operations.js";
 import {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./api/options.js";
 import { KeyCredential, TokenCredential } from "@azure/core-auth";
@@ -114,11 +114,11 @@ export class DocumentTranslationClient {
    * This reduces the risk of the client making assumptions about
    * the data returned.
    */
-  getDocumentsStatus(
+  listDocumentStatuses(
     translationId: string,
-    options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+    options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
   ): PagedAsyncIterableIterator<DocumentStatus> {
-    return getDocumentsStatus(this._client, translationId, options);
+    return listDocumentStatuses(this._client, translationId, options);
   }
 
   /**
@@ -217,10 +217,10 @@ export class DocumentTranslationClient {
    * This reduces the risk of the client
    * making assumptions about the data returned.
    */
-  getTranslationsStatus(
-    options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  listTranslationStatuses(
+    options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
   ): PagedAsyncIterableIterator<TranslationStatus> {
-    return getTranslationsStatus(this._client, options);
+    return listTranslationStatuses(this._client, options);
   }
 
   /**

--- a/sdk/translation/ai-translation-document/generated/documentTranslation/index.ts
+++ b/sdk/translation/ai-translation-document/generated/documentTranslation/index.ts
@@ -8,10 +8,10 @@ export type {
   DocumentTranslationContext,
   DocumentTranslationClientOptionalParams,
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./api/index.js";

--- a/sdk/translation/ai-translation-document/generated/index.ts
+++ b/sdk/translation/ai-translation-document/generated/index.ts
@@ -39,11 +39,11 @@ export { KnownVersions } from "./models/index.js";
 export type {
   DocumentTranslationClientOptionalParams,
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./documentTranslation/api/index.js";
 export type { PageSettings, ContinuablePage, PagedAsyncIterableIterator };

--- a/sdk/translation/ai-translation-document/generated/models/models.ts
+++ b/sdk/translation/ai-translation-document/generated/models/models.ts
@@ -186,7 +186,7 @@ export interface TranslationStatus {
   /** Operation created date time */
   createdAt: Date;
   /** Date time in which the operation's status has been updated */
-  lastActionAt: Date;
+  updatedAt: Date;
   /** List of possible statuses for job or document */
   status: Status;
   /**
@@ -202,7 +202,7 @@ export function translationStatusDeserializer(item: any): TranslationStatus {
   return {
     id: item["id"],
     createdAt: new Date(item["createdDateTimeUtc"]),
-    lastActionAt: new Date(item["lastActionDateTimeUtc"]),
+    updatedAt: new Date(item["lastActionDateTimeUtc"]),
     status: item["status"],
     error: !item["error"] ? item["error"] : translationErrorDeserializer(item["error"]),
     summary: translationStatusSummaryDeserializer(item["summary"]),

--- a/sdk/translation/ai-translation-document/metadata.json
+++ b/sdk/translation/ai-translation-document/metadata.json
@@ -2,7 +2,7 @@
   "apiVersions": {
     "DocumentTranslation": "2026-03-01"
   },
-  "emitterVersion": "0.55.1",
+  "emitterVersion": "0.55.2",
   "crossLanguageDefinitions": {
     "CrossLanguagePackageId": "DocumentTranslation",
     "CrossLanguageDefinitionId": {
@@ -33,11 +33,11 @@
       "@azure/ai-translation-document!KnownFileFormatType:enum": "DocumentTranslation.FileFormatType",
       "@azure/ai-translation-document!KnownVersions:enum": "DocumentTranslation.Versions",
       "@azure/ai-translation-document!DocumentTranslationClient#getSupportedFormats:member(1)": "ClientCustomizations.DocumentTranslationClient.getSupportedFormats",
-      "@azure/ai-translation-document!DocumentTranslationClient#getDocumentsStatus:member(1)": "ClientCustomizations.DocumentTranslationClient.getDocumentsStatus",
+      "@azure/ai-translation-document!DocumentTranslationClient#listDocumentStatuses:member(1)": "ClientCustomizations.DocumentTranslationClient.getDocumentsStatus",
       "@azure/ai-translation-document!DocumentTranslationClient#cancelTranslation:member(1)": "ClientCustomizations.DocumentTranslationClient.cancelTranslation",
       "@azure/ai-translation-document!DocumentTranslationClient#getTranslationStatus:member(1)": "ClientCustomizations.DocumentTranslationClient.getTranslationStatus",
       "@azure/ai-translation-document!DocumentTranslationClient#getDocumentStatus:member(1)": "ClientCustomizations.DocumentTranslationClient.getDocumentStatus",
-      "@azure/ai-translation-document!DocumentTranslationClient#getTranslationsStatus:member(1)": "ClientCustomizations.DocumentTranslationClient.getTranslationsStatus",
+      "@azure/ai-translation-document!DocumentTranslationClient#listTranslationStatuses:member(1)": "ClientCustomizations.DocumentTranslationClient.getTranslationsStatus",
       "@azure/ai-translation-document!DocumentTranslationClient#startTranslation:member(1)": "ClientCustomizations.DocumentTranslationClient.startTranslation",
       "@azure/ai-translation-document!SingleDocumentTranslationClient#translate:member(1)": "ClientCustomizations.SingleDocumentTranslationClient.documentTranslate"
     }

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-browser.api.diff.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-browser.api.diff.md
@@ -8,7 +8,7 @@ For the complete API surface, see the corresponding -node.api.md file.
 --- NodeJS
 +++ browser
 @@ -170,9 +170,9 @@
-     V20260301 = "2026-03-01"
+     translationIds?: string[];
  }
  
  // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-documentTranslation-api-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-documentTranslation-api-node.api.md
@@ -24,27 +24,12 @@ export function createDocumentTranslation(endpointParam: string, credential: Key
 
 // @public
 export interface DocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public
 export interface DocumentTranslationContext extends Client {
     apiVersion?: string;
-}
-
-// @public
-export function getDocumentsStatus(context: DocumentTranslationContext, translationId: string, options?: GetDocumentsStatusOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
-
-// @public
-export interface GetDocumentsStatusOptionalParams extends OperationOptions {
-    createdAfter?: Date;
-    createdBefore?: Date;
-    documentIds?: string[];
-    maxPageSize?: number;
-    orderBy?: string[];
-    skip?: number;
-    statuses?: string[];
-    top?: number;
 }
 
 // @public
@@ -62,10 +47,32 @@ export interface GetSupportedFormatsOptionalParams extends OperationOptions {
 }
 
 // @public
-export function getTranslationsStatus(context: DocumentTranslationContext, options?: GetTranslationsStatusOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
+export function getTranslationStatus(context: DocumentTranslationContext, translationId: string, options?: GetTranslationStatusOptionalParams): Promise<TranslationStatus>;
 
 // @public
-export interface GetTranslationsStatusOptionalParams extends OperationOptions {
+export interface GetTranslationStatusOptionalParams extends OperationOptions {
+}
+
+// @public
+export function listDocumentStatuses(context: DocumentTranslationContext, translationId: string, options?: ListDocumentStatusesOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
+
+// @public
+export interface ListDocumentStatusesOptionalParams extends OperationOptions {
+    createdAfter?: Date;
+    createdBefore?: Date;
+    documentIds?: string[];
+    maxPageSize?: number;
+    orderBy?: string[];
+    skip?: number;
+    statuses?: string[];
+    top?: number;
+}
+
+// @public
+export function listTranslationStatuses(context: DocumentTranslationContext, options?: ListTranslationStatusesOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
+
+// @public
+export interface ListTranslationStatusesOptionalParams extends OperationOptions {
     createdAfter?: Date;
     createdBefore?: Date;
     maxPageSize?: number;
@@ -74,13 +81,6 @@ export interface GetTranslationsStatusOptionalParams extends OperationOptions {
     statuses?: string[];
     top?: number;
     translationIds?: string[];
-}
-
-// @public
-export function getTranslationStatus(context: DocumentTranslationContext, translationId: string, options?: GetTranslationStatusOptionalParams): Promise<TranslationStatus>;
-
-// @public
-export interface GetTranslationStatusOptionalParams extends OperationOptions {
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-documentTranslation-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-documentTranslation-node.api.md
@@ -23,35 +23,23 @@ export interface CancelTranslationOptionalParams extends OperationOptions {
 export class DocumentTranslationClient {
     constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: DocumentTranslationClientOptionalParams);
     cancelTranslation(translationId: string, options?: CancelTranslationOptionalParams): Promise<TranslationStatus>;
-    getDocumentsStatus(translationId: string, options?: GetDocumentsStatusOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
     getDocumentStatus(translationId: string, documentId: string, options?: GetDocumentStatusOptionalParams): Promise<DocumentStatus>;
     getSupportedFormats(typeParam: FileFormatType, options?: GetSupportedFormatsOptionalParams): Promise<SupportedFileFormats>;
-    getTranslationsStatus(options?: GetTranslationsStatusOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
     getTranslationStatus(translationId: string, options?: GetTranslationStatusOptionalParams): Promise<TranslationStatus>;
+    listDocumentStatuses(translationId: string, options?: ListDocumentStatusesOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
+    listTranslationStatuses(options?: ListTranslationStatusesOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
     readonly pipeline: Pipeline;
     startTranslation(body: StartTranslationDetails, options?: StartTranslationOptionalParams): PollerLike<OperationState<TranslationStatus>, TranslationStatus>;
 }
 
 // @public
 export interface DocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public
 export interface DocumentTranslationContext extends Client {
     apiVersion?: string;
-}
-
-// @public
-export interface GetDocumentsStatusOptionalParams extends OperationOptions {
-    createdAfter?: Date;
-    createdBefore?: Date;
-    documentIds?: string[];
-    maxPageSize?: number;
-    orderBy?: string[];
-    skip?: number;
-    statuses?: string[];
-    top?: number;
 }
 
 // @public
@@ -63,7 +51,23 @@ export interface GetSupportedFormatsOptionalParams extends OperationOptions {
 }
 
 // @public
-export interface GetTranslationsStatusOptionalParams extends OperationOptions {
+export interface GetTranslationStatusOptionalParams extends OperationOptions {
+}
+
+// @public
+export interface ListDocumentStatusesOptionalParams extends OperationOptions {
+    createdAfter?: Date;
+    createdBefore?: Date;
+    documentIds?: string[];
+    maxPageSize?: number;
+    orderBy?: string[];
+    skip?: number;
+    statuses?: string[];
+    top?: number;
+}
+
+// @public
+export interface ListTranslationStatusesOptionalParams extends OperationOptions {
     createdAfter?: Date;
     createdBefore?: Date;
     maxPageSize?: number;
@@ -72,10 +76,6 @@ export interface GetTranslationsStatusOptionalParams extends OperationOptions {
     statuses?: string[];
     top?: number;
     translationIds?: string[];
-}
-
-// @public
-export interface GetTranslationStatusOptionalParams extends OperationOptions {
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-models-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-models-node.api.md
@@ -147,9 +147,9 @@ export interface TranslationStatus {
     createdAt: Date;
     error?: TranslationError;
     id: string;
-    lastActionAt: Date;
     status: Status;
     summary: TranslationStatusSummary;
+    updatedAt: Date;
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-node.api.md
@@ -80,18 +80,18 @@ export interface DocumentTranslateContent {
 export class DocumentTranslationClient {
     constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: DocumentTranslationClientOptionalParams);
     cancelTranslation(translationId: string, options?: CancelTranslationOptionalParams): Promise<TranslationStatus>;
-    getDocumentsStatus(translationId: string, options?: GetDocumentsStatusOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
     getDocumentStatus(translationId: string, documentId: string, options?: GetDocumentStatusOptionalParams): Promise<DocumentStatus>;
     getSupportedFormats(typeParam: FileFormatType, options?: GetSupportedFormatsOptionalParams): Promise<SupportedFileFormats>;
-    getTranslationsStatus(options?: GetTranslationsStatusOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
     getTranslationStatus(translationId: string, options?: GetTranslationStatusOptionalParams): Promise<TranslationStatus>;
+    listDocumentStatuses(translationId: string, options?: ListDocumentStatusesOptionalParams): PagedAsyncIterableIterator<DocumentStatus>;
+    listTranslationStatuses(options?: ListTranslationStatusesOptionalParams): PagedAsyncIterableIterator<TranslationStatus>;
     readonly pipeline: Pipeline;
     startTranslation(body: StartTranslationDetails, options?: StartTranslationOptionalParams): PollerLike<OperationState<TranslationStatus>, TranslationStatus>;
 }
 
 // @public
 export interface DocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public
@@ -111,35 +111,11 @@ export interface FileFormat {
 export type FileFormatType = "Document" | "Glossary";
 
 // @public
-export interface GetDocumentsStatusOptionalParams extends OperationOptions {
-    createdAfter?: Date;
-    createdBefore?: Date;
-    documentIds?: string[];
-    maxPageSize?: number;
-    orderBy?: string[];
-    skip?: number;
-    statuses?: string[];
-    top?: number;
-}
-
-// @public
 export interface GetDocumentStatusOptionalParams extends OperationOptions {
 }
 
 // @public
 export interface GetSupportedFormatsOptionalParams extends OperationOptions {
-}
-
-// @public
-export interface GetTranslationsStatusOptionalParams extends OperationOptions {
-    createdAfter?: Date;
-    createdBefore?: Date;
-    maxPageSize?: number;
-    orderBy?: string[];
-    skip?: number;
-    statuses?: string[];
-    top?: number;
-    translationIds?: string[];
 }
 
 // @public
@@ -168,6 +144,30 @@ export { isRestError }
 export enum KnownVersions {
     V20240501 = "2024-05-01",
     V20260301 = "2026-03-01"
+}
+
+// @public
+export interface ListDocumentStatusesOptionalParams extends OperationOptions {
+    createdAfter?: Date;
+    createdBefore?: Date;
+    documentIds?: string[];
+    maxPageSize?: number;
+    orderBy?: string[];
+    skip?: number;
+    statuses?: string[];
+    top?: number;
+}
+
+// @public
+export interface ListTranslationStatusesOptionalParams extends OperationOptions {
+    createdAfter?: Date;
+    createdBefore?: Date;
+    maxPageSize?: number;
+    orderBy?: string[];
+    skip?: number;
+    statuses?: string[];
+    top?: number;
+    translationIds?: string[];
 }
 
 // @public
@@ -206,7 +206,7 @@ export class SingleDocumentTranslationClient {
 
 // @public
 export interface SingleDocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public
@@ -281,9 +281,9 @@ export interface TranslationStatus {
     createdAt: Date;
     error?: TranslationError;
     id: string;
-    lastActionAt: Date;
     status: Status;
     summary: TranslationStatusSummary;
+    updatedAt: Date;
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-react-native.api.diff.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-react-native.api.diff.md
@@ -8,7 +8,7 @@ For the complete API surface, see the corresponding -node.api.md file.
 --- NodeJS
 +++ react-native
 @@ -170,9 +170,9 @@
-     V20260301 = "2026-03-01"
+     translationIds?: string[];
  }
  
  // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-singleDocumentTranslation-api-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-singleDocumentTranslation-api-node.api.md
@@ -15,7 +15,7 @@ export function createSingleDocumentTranslation(endpointParam: string, credentia
 
 // @public
 export interface SingleDocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/review/ai-translation-document-singleDocumentTranslation-node.api.md
+++ b/sdk/translation/ai-translation-document/review/ai-translation-document-singleDocumentTranslation-node.api.md
@@ -20,7 +20,7 @@ export class SingleDocumentTranslationClient {
 
 // @public
 export interface SingleDocumentTranslationClientOptionalParams extends ClientOptions {
-    apiVersion?: string;
+    serviceVersion?: `${KnownVersions}`;
 }
 
 // @public

--- a/sdk/translation/ai-translation-document/src/documentTranslation/api/documentTranslationContext.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/api/documentTranslationContext.ts
@@ -16,9 +16,8 @@ export interface DocumentTranslationContext extends Client {
 
 /** Optional parameters for the client. */
 export interface DocumentTranslationClientOptionalParams extends ClientOptions {
-  /** The API version to use for this operation. */
-  /** Known values of {@link KnownVersions} that the service accepts. */
-  apiVersion?: string;
+  /** The service API version to use for this operation. */
+  serviceVersion?: `${KnownVersions}`;
 }
 
 /** Client for the Azure AI Document Translation service, used to translate batches of documents stored in Azure Blob Storage. */
@@ -33,7 +32,7 @@ export function createDocumentTranslation(
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;
-  const { apiVersion: _, ...updatedOptions } = {
+  const { serviceVersion: _, ...updatedOptions } = {
     ...options,
     userAgentOptions: { userAgentPrefix },
     loggingOptions: { logger: options.loggingOptions?.logger ?? logger.info },
@@ -43,6 +42,6 @@ export function createDocumentTranslation(
     },
   };
   const clientContext = getClient(endpointUrl, credential, updatedOptions);
-  const apiVersion = options.apiVersion;
+  const apiVersion = options.serviceVersion;
   return { ...clientContext, apiVersion } as DocumentTranslationContext;
 }

--- a/sdk/translation/ai-translation-document/src/documentTranslation/api/index.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/api/index.ts
@@ -8,19 +8,19 @@ export type {
 export { createDocumentTranslation } from "./documentTranslationContext.js";
 export {
   getSupportedFormats,
-  getDocumentsStatus,
+  listDocumentStatuses,
   cancelTranslation,
   getTranslationStatus,
   getDocumentStatus,
-  getTranslationsStatus,
+  listTranslationStatuses,
   startTranslation,
 } from "./operations.js";
 export type {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./options.js";

--- a/sdk/translation/ai-translation-document/src/documentTranslation/api/operations.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/api/operations.ts
@@ -25,11 +25,11 @@ import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
 import type {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./options.js";
 import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
@@ -82,10 +82,10 @@ export async function getSupportedFormats(
   return _getSupportedFormatsDeserialize(result);
 }
 
-export function _getDocumentsStatusSend(
+export function _listDocumentStatusesSend(
   context: Client,
   translationId: string,
-  options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+  options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
 ): StreamableMethod {
   const path = expandUrlTemplate(
     "/document/batches/{id}/documents{?api%2Dversion,top,skip,maxpagesize,ids,statuses,createdDateTimeUtcStart,createdDateTimeUtcEnd,orderby}",
@@ -127,7 +127,7 @@ export function _getDocumentsStatusSend(
   });
 }
 
-export async function _getDocumentsStatusDeserialize(
+export async function _listDocumentStatusesDeserialize(
   result: PathUncheckedResponse,
 ): Promise<_DocumentsStatus> {
   const expectedStatuses = ["200"];
@@ -185,15 +185,15 @@ export async function _getDocumentsStatusDeserialize(
  * This reduces the risk of the client making assumptions about
  * the data returned.
  */
-export function getDocumentsStatus(
+export function listDocumentStatuses(
   context: Client,
   translationId: string,
-  options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+  options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
 ): PagedAsyncIterableIterator<DocumentStatus> {
   return buildPagedAsyncIterator(
     context,
-    () => _getDocumentsStatusSend(context, translationId, options),
-    _getDocumentsStatusDeserialize,
+    () => _listDocumentStatusesSend(context, translationId, options),
+    _listDocumentStatusesDeserialize,
     ["200"],
     { itemName: "value", nextLinkName: "nextLink", apiVersion: context.apiVersion ?? "2026-03-01" },
   );
@@ -342,9 +342,9 @@ export async function getDocumentStatus(
   return _getDocumentStatusDeserialize(result);
 }
 
-export function _getTranslationsStatusSend(
+export function _listTranslationStatusesSend(
   context: Client,
-  options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
 ): StreamableMethod {
   const path = expandUrlTemplate(
     "/document/batches{?api%2Dversion,top,skip,maxpagesize,ids,statuses,createdDateTimeUtcStart,createdDateTimeUtcEnd,orderby}",
@@ -385,7 +385,7 @@ export function _getTranslationsStatusSend(
   });
 }
 
-export async function _getTranslationsStatusDeserialize(
+export async function _listTranslationStatusesDeserialize(
   result: PathUncheckedResponse,
 ): Promise<_TranslationsStatus> {
   const expectedStatuses = ["200"];
@@ -449,14 +449,14 @@ export async function _getTranslationsStatusDeserialize(
  * This reduces the risk of the client
  * making assumptions about the data returned.
  */
-export function getTranslationsStatus(
+export function listTranslationStatuses(
   context: Client,
-  options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
 ): PagedAsyncIterableIterator<TranslationStatus> {
   return buildPagedAsyncIterator(
     context,
-    () => _getTranslationsStatusSend(context, options),
-    _getTranslationsStatusDeserialize,
+    () => _listTranslationStatusesSend(context, options),
+    _listTranslationStatusesDeserialize,
     ["200"],
     { itemName: "value", nextLinkName: "nextLink", apiVersion: context.apiVersion ?? "2026-03-01" },
   );

--- a/sdk/translation/ai-translation-document/src/documentTranslation/api/options.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/api/options.ts
@@ -6,7 +6,7 @@ import type { OperationOptions } from "@azure-rest/core-client";
 /** Optional parameters. */
 export interface GetSupportedFormatsOptionalParams extends OperationOptions {}
 /** Optional parameters. */
-export interface GetDocumentsStatusOptionalParams extends OperationOptions {
+export interface ListDocumentStatusesOptionalParams extends OperationOptions {
   /**
    * top indicates the total number of records the user wants to be returned across
    * all pages.
@@ -67,7 +67,7 @@ export interface GetTranslationStatusOptionalParams extends OperationOptions {}
 /** Optional parameters. */
 export interface GetDocumentStatusOptionalParams extends OperationOptions {}
 /** Optional parameters. */
-export interface GetTranslationsStatusOptionalParams extends OperationOptions {
+export interface ListTranslationStatusesOptionalParams extends OperationOptions {
   /**
    * top indicates the total number of records the user wants to be returned across
    * all pages.

--- a/sdk/translation/ai-translation-document/src/documentTranslation/documentTranslationClient.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/documentTranslationClient.ts
@@ -16,20 +16,20 @@ import type {
 import type { PagedAsyncIterableIterator } from "../static-helpers/pagingHelpers.js";
 import {
   getSupportedFormats,
-  getDocumentsStatus,
+  listDocumentStatuses,
   cancelTranslation,
   getTranslationStatus,
   getDocumentStatus,
-  getTranslationsStatus,
+  listTranslationStatuses,
   startTranslation,
 } from "./api/operations.js";
 import type {
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./api/options.js";
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
@@ -123,11 +123,11 @@ export class DocumentTranslationClient {
    * This reduces the risk of the client making assumptions about
    * the data returned.
    */
-  getDocumentsStatus(
+  listDocumentStatuses(
     translationId: string,
-    options: GetDocumentsStatusOptionalParams = { requestOptions: {} },
+    options: ListDocumentStatusesOptionalParams = { requestOptions: {} },
   ): PagedAsyncIterableIterator<DocumentStatus> {
-    return getDocumentsStatus(this._client, translationId, options);
+    return listDocumentStatuses(this._client, translationId, options);
   }
 
   /**
@@ -226,10 +226,10 @@ export class DocumentTranslationClient {
    * This reduces the risk of the client
    * making assumptions about the data returned.
    */
-  getTranslationsStatus(
-    options: GetTranslationsStatusOptionalParams = { requestOptions: {} },
+  listTranslationStatuses(
+    options: ListTranslationStatusesOptionalParams = { requestOptions: {} },
   ): PagedAsyncIterableIterator<TranslationStatus> {
-    return getTranslationsStatus(this._client, options);
+    return listTranslationStatuses(this._client, options);
   }
 
   /**

--- a/sdk/translation/ai-translation-document/src/documentTranslation/index.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/index.ts
@@ -8,10 +8,10 @@ export type {
   DocumentTranslationContext,
   DocumentTranslationClientOptionalParams,
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./api/index.js";

--- a/sdk/translation/ai-translation-document/src/index.ts
+++ b/sdk/translation/ai-translation-document/src/index.ts
@@ -45,11 +45,11 @@ export { KnownVersions } from "./models/index.js";
 export type {
   DocumentTranslationClientOptionalParams,
   GetSupportedFormatsOptionalParams,
-  GetDocumentsStatusOptionalParams,
+  ListDocumentStatusesOptionalParams,
   CancelTranslationOptionalParams,
   GetTranslationStatusOptionalParams,
   GetDocumentStatusOptionalParams,
-  GetTranslationsStatusOptionalParams,
+  ListTranslationStatusesOptionalParams,
   StartTranslationOptionalParams,
 } from "./documentTranslation/api/index.js";
 export type { PageSettings, ContinuablePage, PagedAsyncIterableIterator };

--- a/sdk/translation/ai-translation-document/src/models/models.ts
+++ b/sdk/translation/ai-translation-document/src/models/models.ts
@@ -187,7 +187,7 @@ export interface TranslationStatus {
   /** Operation created date time */
   createdAt: Date;
   /** Date time in which the operation's status has been updated */
-  lastActionAt: Date;
+  updatedAt: Date;
   /** List of possible statuses for job or document */
   status: Status;
   /**
@@ -203,7 +203,7 @@ export function translationStatusDeserializer(item: any): TranslationStatus {
   return {
     id: item["id"],
     createdAt: new Date(item["createdDateTimeUtc"]),
-    lastActionAt: new Date(item["lastActionDateTimeUtc"]),
+    updatedAt: new Date(item["lastActionDateTimeUtc"]),
     status: item["status"],
     error: !item["error"] ? item["error"] : translationErrorDeserializer(item["error"]),
     summary: translationStatusSummaryDeserializer(item["summary"]),

--- a/sdk/translation/ai-translation-document/src/singleDocumentTranslation/api/singleDocumentTranslationContext.ts
+++ b/sdk/translation/ai-translation-document/src/singleDocumentTranslation/api/singleDocumentTranslationContext.ts
@@ -16,9 +16,8 @@ export interface SingleDocumentTranslationContext extends Client {
 
 /** Optional parameters for the client. */
 export interface SingleDocumentTranslationClientOptionalParams extends ClientOptions {
-  /** The API version to use for this operation. */
-  /** Known values of {@link KnownVersions} that the service accepts. */
-  apiVersion?: string;
+  /** The service API version to use for this operation. */
+  serviceVersion?: `${KnownVersions}`;
 }
 
 /** Client for the Azure AI Document Translation service, used to translate a single document. */
@@ -33,7 +32,7 @@ export function createSingleDocumentTranslation(
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;
-  const { apiVersion: _, ...updatedOptions } = {
+  const { serviceVersion: _, ...updatedOptions } = {
     ...options,
     userAgentOptions: { userAgentPrefix },
     loggingOptions: { logger: options.loggingOptions?.logger ?? logger.info },
@@ -43,6 +42,6 @@ export function createSingleDocumentTranslation(
     },
   };
   const clientContext = getClient(endpointUrl, credential, updatedOptions);
-  const apiVersion = options.apiVersion;
+  const apiVersion = options.serviceVersion;
   return { ...clientContext, apiVersion } as SingleDocumentTranslationContext;
 }

--- a/sdk/translation/ai-translation-document/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/translation/ai-translation-document/test/internal/serviceVersionParameter.spec.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+  HttpClient,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest,
+} from "@azure/core-rest-pipeline";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
+import { AzureKeyCredential } from "@azure/core-auth";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DocumentTranslationClient, KnownVersions } from "../../src/index.js";
+
+describe("DocumentTranslationClient should send the serviceVersion as the api-version", () => {
+  const endpoint = "https://endpoint.cognitiveservices.azure.com";
+
+  const mockHttpClient: HttpClient = {
+    async sendRequest(httpRequest: PipelineRequest): Promise<PipelineResponse> {
+      return {
+        status: 200,
+        headers: createHttpHeaders(),
+        request: httpRequest,
+        bodyAsText: JSON.stringify({ value: [] }),
+      };
+    },
+  };
+
+  let spy: MockInstance<SendRequest>;
+  const credential = new AzureKeyCredential("fake-key");
+
+  beforeEach(() => {
+    spy = vi.spyOn(mockHttpClient, "sendRequest");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the latest service version", async () => {
+    const client = new DocumentTranslationClient(endpoint, credential, {
+      httpClient: mockHttpClient,
+    });
+
+    await client.getSupportedFormats("Document");
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining(`api-version=${KnownVersions.V20260301}`),
+      }),
+    );
+  });
+
+  it("uses a non-default serviceVersion when specified", async () => {
+    const client = new DocumentTranslationClient(endpoint, credential, {
+      serviceVersion: KnownVersions.V20240501,
+      httpClient: mockHttpClient,
+    });
+
+    await client.getSupportedFormats("Document");
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining(`api-version=${KnownVersions.V20240501}`),
+      }),
+    );
+  });
+});

--- a/sdk/translation/ai-translation-document/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/translation/ai-translation-document/test/internal/serviceVersionParameter.spec.ts
@@ -11,7 +11,11 @@ import { createHttpHeaders } from "@azure/core-rest-pipeline";
 import { AzureKeyCredential } from "@azure/core-auth";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DocumentTranslationClient, KnownVersions } from "../../src/index.js";
+import {
+  DocumentTranslationClient,
+  KnownVersions,
+  SingleDocumentTranslationClient,
+} from "../../src/index.js";
 
 describe("DocumentTranslationClient should send the serviceVersion as the api-version", () => {
   const endpoint = "https://endpoint.cognitiveservices.azure.com";
@@ -59,6 +63,61 @@ describe("DocumentTranslationClient should send the serviceVersion as the api-ve
     });
 
     await client.getSupportedFormats("Document");
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining(`api-version=${KnownVersions.V20240501}`),
+      }),
+    );
+  });
+});
+
+describe("SingleDocumentTranslationClient should send the serviceVersion as the api-version", () => {
+  const endpoint = "https://endpoint.cognitiveservices.azure.com";
+
+  const mockHttpClient: HttpClient = {
+    async sendRequest(httpRequest: PipelineRequest): Promise<PipelineResponse> {
+      return {
+        status: 200,
+        headers: createHttpHeaders(),
+        request: httpRequest,
+        bodyAsText: "",
+      };
+    },
+  };
+
+  let spy: MockInstance<SendRequest>;
+  const credential = new AzureKeyCredential("fake-key");
+
+  beforeEach(() => {
+    spy = vi.spyOn(mockHttpClient, "sendRequest");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the latest service version", async () => {
+    const client = new SingleDocumentTranslationClient(endpoint, credential, {
+      httpClient: mockHttpClient,
+    });
+
+    await client.translate("es", { document: "test content" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining(`api-version=${KnownVersions.V20260301}`),
+      }),
+    );
+  });
+
+  it("uses a non-default serviceVersion when specified", async () => {
+    const client = new SingleDocumentTranslationClient(endpoint, credential, {
+      serviceVersion: KnownVersions.V20240501,
+      httpClient: mockHttpClient,
+    });
+
+    await client.translate("es", { document: "test content" });
 
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/sdk/translation/ai-translation-document/test/public/node/documentFilterTest.spec.ts
+++ b/sdk/translation/ai-translation-document/test/public/node/documentFilterTest.spec.ts
@@ -36,7 +36,7 @@ describe("DocumentFilter tests", () => {
     const succeededStatusList = ["Succeeded"];
 
     // get DocumentsStatus
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       statuses: succeededStatusList,
     })) {
       assert.isTrue(succeededStatusList.includes(documentStatus.status));
@@ -51,12 +51,12 @@ describe("DocumentFilter tests", () => {
 
     // get Documents Status with operationID
     const testIds: string[] = [];
-    for await (const documentStatus of client.getDocumentsStatus(operationId)) {
+    for await (const documentStatus of client.listDocumentStatuses(operationId)) {
       testIds.push(documentStatus.id);
     }
 
     // get Documents Status with testIds filter
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       documentIds: testIds,
     })) {
       assert.isTrue(testIds.includes(documentStatus.id));
@@ -74,7 +74,7 @@ describe("DocumentFilter tests", () => {
 
     // get Documents Status w.r.t orderby
     const testCreatedOnDateTimes: Date[] = [];
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       orderBy: orderByList,
     })) {
       testCreatedOnDateTimes.push(documentStatus.createdAt);
@@ -82,7 +82,7 @@ describe("DocumentFilter tests", () => {
 
     // Asserting that only the last document is returned
     let itemCount = 0;
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       createdAfter: testCreatedOnDateTimes[4],
     })) {
       assert.isNotNull(documentStatus);
@@ -103,7 +103,7 @@ describe("DocumentFilter tests", () => {
 
     // get Documents Status w.r.t orderby
     const testCreatedOnDateTimes: Date[] = [];
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       orderBy: orderByList,
     })) {
       testCreatedOnDateTimes.push(documentStatus.createdAt);
@@ -111,7 +111,7 @@ describe("DocumentFilter tests", () => {
 
     // Asserting that only the first document is returned
     let itemCount2 = 0;
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       // Add 1ms: JS Date truncates the service's sub-millisecond createdDateTimeUtc,
       // so the raw value would fall just before the doc and exclude it from the range.
       createdBefore: new Date(testCreatedOnDateTimes[0].getTime() + 1),
@@ -124,7 +124,7 @@ describe("DocumentFilter tests", () => {
 
     // Asserting that the first 4/5 docs are returned
     let itemCount3 = 0;
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       // Add 1ms to compensate for JS Date sub-millisecond truncation (see above).
       createdBefore: new Date(testCreatedOnDateTimes[3].getTime() + 1),
     })) {
@@ -146,7 +146,7 @@ describe("DocumentFilter tests", () => {
 
     // get Documents Status
     const timestamp = new Date();
-    for await (const documentStatus of client.getDocumentsStatus(operationId, {
+    for await (const documentStatus of client.listDocumentStatuses(operationId, {
       orderBy: orderByList,
     })) {
       const createdDateTime = new Date(documentStatus.createdAt);

--- a/sdk/translation/ai-translation-document/test/public/node/documentTranslationTest.spec.ts
+++ b/sdk/translation/ai-translation-document/test/public/node/documentTranslationTest.spec.ts
@@ -177,7 +177,7 @@ describe("DocumentTranslation tests", () => {
     // get translation status (the translation has already reached a terminal state)
     const translationStatusOutput = await client.getTranslationStatus(operationId);
 
-    for await (const documentStatus of client.getDocumentsStatus(operationId)) {
+    for await (const documentStatus of client.listDocumentStatuses(operationId)) {
       assert.equal(documentStatus.status, translationStatusOutput.status);
       assert.equal(
         documentStatus.characterCharged,
@@ -197,7 +197,7 @@ describe("DocumentTranslation tests", () => {
     assert.isNotNull(operationId);
 
     // get Documents Status
-    for await (const document of client.getDocumentsStatus(operationId)) {
+    for await (const document of client.listDocumentStatuses(operationId)) {
       const documentStatus = await client.getDocumentStatus(operationId, document.id);
       validateDocumentStatus(documentStatus, document.to);
     }

--- a/sdk/translation/ai-translation-document/test/public/node/translationFilterTest.spec.ts
+++ b/sdk/translation/ai-translation-document/test/public/node/translationFilterTest.spec.ts
@@ -50,7 +50,7 @@ describe("TranslationFilter tests", { skip: true }, () => {
     const testStartTime = recorder.variable("testStartTime", new Date().toISOString());
 
     // get Translation Status
-    for await (const translationStatus of client.getTranslationsStatus({
+    for await (const translationStatus of client.listTranslationStatuses({
       statuses: cancelledStatusList,
       createdAfter: new Date(testStartTime),
     })) {
@@ -70,7 +70,7 @@ describe("TranslationFilter tests", { skip: true }, () => {
     targetIds.push((await allIds)[0]);
 
     // get Translation Status
-    for await (const translationStatus of client.getTranslationsStatus({
+    for await (const translationStatus of client.listTranslationStatuses({
       translationIds: targetIds,
     })) {
       assert.isTrue(targetIds.includes(translationStatus.id));
@@ -87,7 +87,7 @@ describe("TranslationFilter tests", { skip: true }, () => {
     );
 
     // get Translation Status
-    for await (const translationStatus of client.getTranslationsStatus({
+    for await (const translationStatus of client.listTranslationStatuses({
       createdAfter: new Date(testStartTime),
     })) {
       assert.isTrue((await targetIds).includes(translationStatus.id));
@@ -120,7 +120,7 @@ describe("TranslationFilter tests", { skip: true }, () => {
 
     // get Translation Status
     let idExists = false;
-    for await (const translationStatus of client.getTranslationsStatus({
+    for await (const translationStatus of client.listTranslationStatuses({
       createdAfter: new Date(startDateTime),
       createdBefore: new Date(endDateTime),
     })) {
@@ -150,7 +150,7 @@ describe("TranslationFilter tests", { skip: true }, () => {
 
     let timestamp = new Date(-8640000000000000); // Minimum valid Date value in JavaScript
 
-    for await (const translationStatus of client.getTranslationsStatus({
+    for await (const translationStatus of client.listTranslationStatuses({
       createdAfter: new Date(startDateTime),
       orderBy: orderByList,
     })) {

--- a/sdk/translation/ai-translation-document/tsp-location.yaml
+++ b/sdk/translation/ai-translation-document/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/translation/data-plane/DocumentTranslation
-commit: 68a80872a493e7a672b8f237f8459ec42793d4ad
+commit: 83f54c7b56487fbb2e8716795790228c5c454e25
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 

--- a/sdk/translation/ai-translation-document/tsp-location.yaml
+++ b/sdk/translation/ai-translation-document/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/translation/data-plane/DocumentTranslation
-commit: e7ef236186d1a72ce0f9cf41ce425d840568e477
+commit: 68a80872a493e7a672b8f237f8459ec42793d4ad
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 


### PR DESCRIPTION
## Summary

Addresses APIView feedback on `@azure/ai-translation-document` by regenerating from updated TypeSpec client customizations plus one local `src/` customization.

### Changes (from the spec `client.tsp`)
- `getDocumentsStatus` → **`listDocumentStatuses`** (paged collection ops use the `list` verb)
- `getTranslationsStatus` → **`listTranslationStatuses`**
- `TranslationStatus.lastActionAt` → **`updatedAt`**

### Local `src/` customization
- Client option `apiVersion?: string` → **`serviceVersion?: ${KnownVersions}`** on `DocumentTranslationClientOptionalParams` and `SingleDocumentTranslationClientOptionalParams`, constrained to supported versions per the service-versions guideline. Bridged onto the generated `apiVersion` in the client factory (keyvault/search pattern).

### Not changed (intentional)
- `DocumentStatus.lastActionAt` left as-is (only `TranslationStatus` renamed in spec).
- `SingleDocumentTranslationClient` remains a separate `@client` (TypeSpec multi-client design).
- `InnerTranslationError`/`TranslationError` remain data models (SDK throws `RestError`).

## Verification
- TypeScript type-check clean across all changed `src/`/`test/` files.
- `dev-tool customization apply` converged with no conflicts; `serviceVersion` is the only remaining `src/`-vs-`generated/` divergence.
