### PR TITLE
Fix performance counter sampling in monitor-opentelemetry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22337,7 +22337,7 @@ importers:
         specifier: ^1.3.0
         version: link:../../core/logger
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.44
+        specifier: 1.0.0-beta.45
         version: link:../monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.1.0-beta.1

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `instrumentationOptions.console` now accepts a `logSeverity` value, allowing the console log severity to be configured programmatically instead of only through the `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` environment variable. [#39483](https://github.com/Azure/azure-sdk-for-js/pull/39483)
 
+### Bugs Fixed
+
+- Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time.
+
 ## 1.19.0 (2026-07-29)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time. [#39520](https://github.com/Azure/azure-sdk-for-js/pull/39520)
 
+### Other Changes
+
+- Updated to using exporter version 1.0.0-beta.45.
+
 ## 1.19.0 (2026-07-29)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time.
+- Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time. [#39520](https://github.com/Azure/azure-sdk-for-js/pull/39520)
 
 ## 1.19.0 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -88,7 +88,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/identity": "^4.13.1",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.45",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.1.0-beta.1",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.1",

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/performanceCounters.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/performanceCounters.ts
@@ -50,7 +50,7 @@ export class PerformanceCounterMetrics {
   private processTimeGaugeCallback: ObservableCallback;
   private exceptionCountGauge: ObservableGauge;
   private exceptionCountGaugeCallback: ObservableCallback;
-  private lastExceptionRate: { count: number; time: number } = { count: 0, time: 0 };
+  private lastExceptionRate: { count: number; time: number };
   private totalCount: number = 0;
   private intervalExecutionTime = 0;
   private lastRequestRate: { count: number; time: number; executionInterval: number };
@@ -62,6 +62,13 @@ export class PerformanceCounterMetrics {
     times: { user: number; nice: number; sys: number; idle: number; irq: number };
   }[];
   private lastCpusProcess: {
+    model: string;
+    speed: number;
+    times: { user: number; nice: number; sys: number; idle: number; irq: number };
+  }[];
+  private lastAppCpuUsageNormalized: { user: number; system: number };
+  private lastHrtimeNormalized: number[];
+  private lastCpusProcessNormalized: {
     model: string;
     speed: number;
     times: { user: number; nice: number; sys: number; idle: number; irq: number };
@@ -79,12 +86,16 @@ export class PerformanceCounterMetrics {
     this.lastCpusProcess = os.cpus();
     this.lastAppCpuUsage = process.cpuUsage();
     this.lastHrtime = process.hrtime();
+    this.lastCpusProcessNormalized = os.cpus();
+    this.lastAppCpuUsageNormalized = process.cpuUsage();
+    this.lastHrtimeNormalized = process.hrtime();
 
     this.lastRequestRate = {
       count: this.totalCount,
       time: +new Date(),
       executionInterval: this.intervalExecutionTime,
     };
+    this.lastExceptionRate = { count: this.totalExceptionCount, time: +new Date() };
 
     this.azureExporter = new AzureMonitorMetricExporter(
       this.internalConfig.azureMonitorExporterOptions,
@@ -99,8 +110,6 @@ export class PerformanceCounterMetrics {
     };
     this.meterProvider = new MeterProvider(meterProviderConfig);
     this.meter = this.meterProvider.getMeter("AzureMonitorPerformanceCountersMeter");
-
-    this.lastRequestRate = { count: 0, time: 0, executionInterval: 0 };
 
     // Create Instruments
     this.requestDurationHistogram = this.meter.createHistogram(
@@ -314,8 +323,8 @@ export class PerformanceCounterMetrics {
     if (
       cpus &&
       cpus.length &&
-      this.lastCpusProcess &&
-      cpus.length === this.lastCpusProcess.length
+      this.lastCpusProcessNormalized &&
+      cpus.length === this.lastCpusProcessNormalized.length
     ) {
       // Calculate % of total cpu time (user + system) this App Process used (Only supported by node v6.1.0+)
       let appCpuPercent: number | undefined = undefined;
@@ -323,19 +332,23 @@ export class PerformanceCounterMetrics {
       const hrtime = process.hrtime();
       const totalApp =
         appCpuUsage.user -
-          this.lastAppCpuUsage.user +
-          (appCpuUsage.system - this.lastAppCpuUsage.system) || 0;
+          this.lastAppCpuUsageNormalized.user +
+          (appCpuUsage.system - this.lastAppCpuUsageNormalized.system) || 0;
 
-      if (typeof this.lastHrtime !== "undefined" && this.lastHrtime.length === 2) {
+      if (
+        typeof this.lastHrtimeNormalized !== "undefined" &&
+        this.lastHrtimeNormalized.length === 2
+      ) {
         const elapsedTime =
-          (hrtime[0] - this.lastHrtime[0]) * 1e6 + (hrtime[1] - this.lastHrtime[1]) / 1e3 || 0; // convert to microseconds
+          (hrtime[0] - this.lastHrtimeNormalized[0]) * 1e6 +
+            (hrtime[1] - this.lastHrtimeNormalized[1]) / 1e3 || 0; // convert to microseconds
 
         appCpuPercent = (100 * totalApp) / (elapsedTime * cpus.length);
       }
       // Set previous
-      this.lastAppCpuUsage = appCpuUsage;
-      this.lastHrtime = hrtime;
-      const cpuTotals = this.getTotalCombinedCpu(cpus, this.lastCpusProcess);
+      this.lastAppCpuUsageNormalized = appCpuUsage;
+      this.lastHrtimeNormalized = hrtime;
+      const cpuTotals = this.getTotalCombinedCpu(cpus, this.lastCpusProcessNormalized);
       let value = 0;
       if (appCpuPercent !== undefined) {
         value = appCpuPercent;
@@ -344,7 +357,7 @@ export class PerformanceCounterMetrics {
       }
       observableResult.observe(value);
     }
-    this.lastCpusProcess = cpus;
+    this.lastCpusProcessNormalized = cpus;
   }
 
   private getProcessTime(observableResult: ObservableResult): void {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/performanceMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/performanceMetrics.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import type { MockInstance } from "vitest";
 import { afterEach, assert, beforeAll, beforeEach, afterAll, describe, it, vi } from "vitest";
 import { SpanKind } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
@@ -17,19 +16,21 @@ import process from "node:process";
 
 describe("PerformanceCounterMetricsHandler", () => {
   let autoCollect: PerformanceCounterMetrics;
-  let exportStub: MockInstance<(typeof autoCollect)["azureExporter"]["export"]>;
+  let exportedMetrics: any[];
 
   function stubExporter(
     performanceCounters: PerformanceCounterMetrics,
-  ): MockInstance<(typeof autoCollect)["azureExporter"]["export"]> {
-    return vi
-      .spyOn(performanceCounters["azureExporter"], "export")
-      .mockImplementation((metrics: any, resultCallback) => {
+    onExport?: (metrics: any) => void,
+  ): void {
+    vi.spyOn(performanceCounters["azureExporter"], "export").mockImplementation(
+      (metrics: any, resultCallback) => {
+        onExport?.(metrics);
         resultCallback({
           code: ExportResultCode.SUCCESS,
         });
         return Promise.resolve(metrics);
-      });
+      },
+    );
   }
 
   beforeAll(() => {
@@ -42,7 +43,8 @@ describe("PerformanceCounterMetricsHandler", () => {
   });
 
   beforeEach(() => {
-    exportStub = stubExporter(autoCollect);
+    exportedMetrics = [];
+    stubExporter(autoCollect, (metrics) => exportedMetrics.push(metrics));
   });
 
   afterEach(() => {
@@ -75,8 +77,8 @@ describe("PerformanceCounterMetricsHandler", () => {
       }
 
       await new Promise((resolve) => setTimeout(resolve, 120));
-      assert.isTrue(exportStub.mock.calls.length > 0, "export called");
-      const resourceMetrics = exportStub.mock.calls[0][0];
+      assert.isTrue(exportedMetrics.length > 0, "export called");
+      const resourceMetrics = exportedMetrics[0];
       const scopeMetrics = resourceMetrics.scopeMetrics;
       assert.strictEqual(scopeMetrics.length, 1, "scopeMetrics count");
       const metrics = scopeMetrics[0].metrics;

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/performanceMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/performanceMetrics.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import type { MockInstance } from "vitest";
-import { afterEach, assert, beforeAll, afterAll, describe, it, vi } from "vitest";
+import { afterEach, assert, beforeAll, beforeEach, afterAll, describe, it, vi } from "vitest";
 import { SpanKind } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
 import { PerformanceCounterMetrics } from "../../../../src/metrics/performanceCounters.js";
@@ -12,10 +12,25 @@ import {
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import type { Histogram } from "@opentelemetry/sdk-metrics";
 import { InternalConfig } from "../../../../src/shared/config.js";
+import os from "node:os";
+import process from "node:process";
 
 describe("PerformanceCounterMetricsHandler", () => {
   let autoCollect: PerformanceCounterMetrics;
   let exportStub: MockInstance<(typeof autoCollect)["azureExporter"]["export"]>;
+
+  function stubExporter(
+    performanceCounters: PerformanceCounterMetrics,
+  ): MockInstance<(typeof autoCollect)["azureExporter"]["export"]> {
+    return vi
+      .spyOn(performanceCounters["azureExporter"], "export")
+      .mockImplementation((metrics: any, resultCallback) => {
+        resultCallback({
+          code: ExportResultCode.SUCCESS,
+        });
+        return Promise.resolve(metrics);
+      });
+  }
 
   beforeAll(() => {
     const config = new InternalConfig({});
@@ -24,24 +39,21 @@ describe("PerformanceCounterMetricsHandler", () => {
     autoCollect = new PerformanceCounterMetrics(config || config, {
       collectionInterval: 100,
     });
-    exportStub = vi.spyOn(autoCollect["azureExporter"], "export").mockImplementation(
-      (spans: any, resultCallback) =>
-        new Promise((resolve) => {
-          resultCallback({
-            code: ExportResultCode.SUCCESS,
-          });
-          resolve(spans);
-        }),
-    );
+  });
+
+  beforeEach(() => {
+    exportStub = stubExporter(autoCollect);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   afterAll(async () => {
-    vi.restoreAllMocks();
+    stubExporter(autoCollect);
     await autoCollect.shutdown();
+    vi.restoreAllMocks();
   });
 
   const resource = resourceFromAttributes({});
@@ -119,6 +131,85 @@ describe("PerformanceCounterMetricsHandler", () => {
       );
       assert.isFalse(Number.isNaN(metrics[6].dataPoints[0].value), "Value should not be NaN");
       assert.deepStrictEqual(metrics[7].descriptor.name, "Exception_Rate");
+    });
+
+    it("should calculate the first request and exception rates from initialization", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-05T00:00:00.000Z"));
+      const config = new InternalConfig({});
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333;";
+      const performanceCounters = new PerformanceCounterMetrics(config, {
+        collectionInterval: 60000,
+      });
+      stubExporter(performanceCounters);
+      const spanWithException = {
+        ...serverSpan,
+        events: [{ name: "exception", attributes: {} }],
+      };
+      performanceCounters.recordSpan(spanWithException);
+      vi.advanceTimersByTime(1000);
+
+      let requestRate = 0;
+      let exceptionRate = 0;
+      performanceCounters["getRequestRate"]({
+        observe: (value) => {
+          requestRate = value;
+        },
+      });
+      performanceCounters["getExceptionRate"]({
+        observe: (value) => {
+          exceptionRate = value;
+        },
+      });
+
+      assert.strictEqual(requestRate, 1);
+      assert.strictEqual(exceptionRate, 1);
+      await performanceCounters.shutdown();
+    });
+
+    it("should sample standard and normalized process CPU independently", async () => {
+      const fakeCpus = Array.from({ length: 4 }, (_, index): os.CpuInfo => ({
+        model: `fake-${index}`,
+        speed: 3000,
+        times: { user: 1000, nice: 0, sys: 1000, idle: 8000, irq: 0 },
+      }));
+      vi.spyOn(os, "cpus").mockReturnValue(fakeCpus);
+      vi.spyOn(process, "cpuUsage")
+        .mockReturnValueOnce({ user: 0, system: 0 })
+        .mockReturnValueOnce({ user: 0, system: 0 })
+        .mockReturnValueOnce({ user: 100000, system: 0 })
+        .mockReturnValueOnce({ user: 100500, system: 0 });
+      vi.spyOn(process, "hrtime")
+        .mockReturnValueOnce([0, 0])
+        .mockReturnValueOnce([0, 0])
+        .mockReturnValueOnce([1, 0])
+        .mockReturnValueOnce([1, 1000000]);
+
+      const config = new InternalConfig({});
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333;";
+      const performanceCounters = new PerformanceCounterMetrics(config, {
+        collectionInterval: 60000,
+      });
+      stubExporter(performanceCounters);
+      let standardCpu = 0;
+      let normalizedCpu = 0;
+
+      performanceCounters["getProcessTime"]({
+        observe: (value) => {
+          standardCpu = value;
+        },
+      });
+      performanceCounters["getNormalizedProcessTime"]({
+        observe: (value) => {
+          normalizedCpu = value;
+        },
+      });
+
+      assert.strictEqual(standardCpu, 10);
+      assert.closeTo(normalizedCpu, 2.50999, 0.00001);
+      await performanceCounters.shutdown();
     });
   });
 });


### PR DESCRIPTION
## What

- give standard and normalized process CPU counters independent sampling state
- initialize request and exception rate intervals when performance counters are constructed
- add deterministic regression coverage for first-interval rates and CPU sampling
- align the distro dependency with workspace exporter beta.45 so Turbo builds the exporter first

## Why

The standard and normalized CPU callbacks shared their previous CPU/time samples, so whichever callback ran second measured a near-zero interval and could report an inflated value. Request and exception rates also used Unix epoch as the first interval start, making the first export effectively zero.

These shared defects were identified while validating microsoft/opentelemetry-distro-javascript#212 against the Azure Monitor distro.

The initial CI run also exposed that `@azure/monitor-opentelemetry` still depended on exporter beta.44 while the workspace exporter was beta.45. Because the versions did not match, Turbo omitted the exporter from the dependency graph and the distro build could not resolve its generated types. This PR now aligns the dependency and lockfile importer to beta.45.

## Validation

- `pnpm check-format`
- `pnpm lint` (0 errors; existing warnings remain)
- clean `pnpm turbo build --filter=@azure/monitor-opentelemetry... --token 1`, with exporter beta.45 built first
- `npx dev-tool check --tag=local`
- `vitest run test/internal/unit/metrics/performanceMetrics.test.ts`