### PR TITLE
[engSys] Remove duplicate package properties step

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -52,9 +52,17 @@ steps:
     displayName: "Install library dependencies after setting dev version"
 
   # Update the package info file to include dev version
-  - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
-    parameters:
-      ServiceDirectory: ${{parameters.ServiceDirectory}}
+  - task: Powershell@2
+    displayName: Save package properties with dev version
+    condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
+      arguments: >
+        -ServiceDirectory '${{parameters.ServiceDirectory}}'
+        -OutDirectory '$(Build.ArtifactStagingDirectory)/PackageInfo'
+        -AddDevVersion:($env:SETDEVVERSION -eq 'true')
+      pwsh: true
+      workingDirectory: $(Build.SourcesDirectory)
 
   - script: |
       pnpm install


### PR DESCRIPTION
PR builds currently expand `save-package-properties.yml` twice even though package versions do not change between the calls. The second save is only needed after `set-dev.js` updates versions.

I replaced that second template invocation with the equivalent PowerShell task gated on `SetDevVersion`, so PR builds skip the redundant work while daily/dev builds still preserve the original `Version` and add the recomputed `DevVersion`. This also keeps `eng/common` untouched while Azure/azure-sdk-tools#16640 is still open.

Resolves #39484