### PR TITLE
[engSys] Include Node version in test cache keys

### DIFF
--- a/eng/tools/run-turbo-test.mjs
+++ b/eng/tools/run-turbo-test.mjs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const [task, ...args] = process.argv.slice(2);
+if (!task) {
+  console.error("A Turborepo test task is required.");
+  process.exit(1);
+}
+
+const turboCli = createRequire(import.meta.url).resolve("turbo/bin/turbo");
+const result = spawnSync(process.execPath, [turboCli, "run", task, ...args], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    AZURE_SDK_NODE_VERSION: process.versions.node,
+  },
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "lint:fix": "turbo run lint:fix",
     "preinstall": "npx only-allow pnpm",
     "purge": "rimraf --glob \"sdk/**/node_modules/\"",
-    "test": "turbo run test",
-    "test:node": "turbo run test:node",
-    "test:browser": "turbo run test:browser",
+    "test": "node eng/tools/run-turbo-test.mjs test",
+    "test:node": "node eng/tools/run-turbo-test.mjs test:node",
+    "test:browser": "node eng/tools/run-turbo-test.mjs test:browser",
     "test:esm": "turbo run test:esm",
     "test:vitest": "vitest",
     "update-snippets": "turbo run update-snippets"

--- a/turbo.json
+++ b/turbo.json
@@ -51,14 +51,17 @@
       "cache": false
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "env": ["AZURE_SDK_NODE_VERSION"]
     },
     "test:browser": {
       "dependsOn": ["build"],
+      "env": ["AZURE_SDK_NODE_VERSION"],
       "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage"]
     },
     "test:node": {
       "dependsOn": ["build"],
+      "env": ["AZURE_SDK_NODE_VERSION"],
       "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage"]
     },
     "update-snippets": {


### PR DESCRIPTION
### Packages impacted by this PR

Engineering system / Turborepo test tasks

### Issues associated with this PR

Resolves #39485

### Describe the problem that is addressed by this PR

Turborepo currently hashes test inputs without the active Node runtime. This is latent in CI today, but sharing test caches across matrix legs (or switching Node locally) could replay a result produced by a different Node version.

I now route the three cached test entry points through a small Node wrapper that sets `AZURE_SDK_NODE_VERSION` from `process.versions.node`, then include that exact value in the `test`, `test:node`, and `test:browser` hashes.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

I considered hashing `npm_config_user_agent`, but that also includes the package manager and platform and relies on package-manager-populated state. The wrapper supplies the exact runtime version consistently in local and CI execution without invalidating unrelated tasks.

### Are there test cases added in this PR? _(If not, why?)_

No standalone test was added for the configuration. I ran the targeted ESLint plugin test task through the wrapper and used Turbo dry runs to verify that Node `22.0.0` and `24.0.0` produce different hashes for all three test variants.
