### PR TITLE
[dev-tool] Add sample configuration schema check

### DIFF
--- a/common/tools/dev-tool/src/checks/sampleConfiguration.ts
+++ b/common/tools/dev-tool/src/checks/sampleConfiguration.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+import { assert, packageJsonCheck } from "../framework/check.ts";
+import { METADATA_KEY } from "../util/resolveProject.ts";
+import { validateSampleConfiguration } from "../util/samples/configuration.ts";
+
+/**
+ * Validates the package's sample configuration against the documented
+ * `SampleConfiguration` schema.
+ *
+ * The sample tooling reads this configuration to decide which samples to
+ * generate and publish. Because it is read with plain property access, a
+ * misspelled or mistyped property (for example `skipFolders` instead of
+ * `skipFolder`) is silently ignored, which can cause the wrong samples to be
+ * generated or published. This check surfaces such drift as an actionable
+ * error.
+ *
+ * Both the current location (`"//metadata".sampleConfiguration`) and the
+ * deprecated top-level `"//sampleConfiguration"` location are validated. Using
+ * the deprecated location is intentionally tolerated here (a large number of
+ * packages still use it); this check only validates the shape, it does not
+ * enforce a migration.
+ */
+export const sampleConfiguration = packageJsonCheck({
+  description: "sampleConfiguration must match the documented SampleConfiguration schema",
+  check({ packageJson }) {
+    const locations: Array<{ label: string; value: unknown }> = [];
+
+    const metadataConfiguration = packageJson[METADATA_KEY]?.sampleConfiguration;
+    if (metadataConfiguration !== undefined) {
+      locations.push({
+        label: `${METADATA_KEY}.sampleConfiguration`,
+        value: metadataConfiguration,
+      });
+    }
+
+    const legacyConfiguration = packageJson["//sampleConfiguration"];
+    if (legacyConfiguration !== undefined) {
+      locations.push({ label: "//sampleConfiguration", value: legacyConfiguration });
+    }
+
+    const details: string[] = [];
+    for (const { label, value } of locations) {
+      for (const problem of validateSampleConfiguration(value)) {
+        const suffix = problem.path === "." ? "" : `.${problem.path}`;
+        details.push(`${label}${suffix}: ${problem.message}`);
+      }
+    }
+
+    assert(
+      details.length === 0,
+      "sample configuration does not match the expected schema",
+      details.join("\n"),
+    );
+  },
+});

--- a/common/tools/dev-tool/src/util/samples/configuration.ts
+++ b/common/tools/dev-tool/src/util/samples/configuration.ts
@@ -136,6 +136,134 @@ export function getSampleConfiguration(packageJson: PackageJson): SampleConfigur
 }
 
 /**
+ * A single problem discovered while validating a sample configuration against
+ * its expected schema.
+ */
+export interface SampleConfigurationProblem {
+  /**
+   * A dot-path to the offending property, relative to the sample configuration
+   * object. The root object itself is represented by ".".
+   */
+  path: string;
+  /**
+   * A human-readable, actionable description of the problem.
+   */
+  message: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A validator returns `undefined` when a value is acceptable, or a short
+ * message describing why it is not.
+ */
+type PropertyValidator = (value: unknown) => string | undefined;
+
+const isString: PropertyValidator = (value) =>
+  typeof value === "string" ? undefined : "must be a string";
+
+const isBoolean: PropertyValidator = (value) =>
+  typeof value === "boolean" ? undefined : "must be a boolean";
+
+const isStringArray: PropertyValidator = (value) =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? undefined
+    : "must be an array of strings";
+
+const isStringRecord: PropertyValidator = (value) =>
+  isPlainObject(value) && Object.values(value).every((entry) => typeof entry === "string")
+    ? undefined
+    : "must be an object mapping strings to strings";
+
+const isStringArrayRecord: PropertyValidator = (value) =>
+  isPlainObject(value) &&
+  Object.values(value).every(
+    (entry) => Array.isArray(entry) && entry.every((item) => typeof item === "string"),
+  )
+    ? undefined
+    : "must be an object mapping strings to arrays of strings";
+
+const KNOWN_CUSTOM_SNIPPET_KEYS = ["header", "prerequisites", "footer"];
+
+const isCustomSnippets: PropertyValidator = (value) => {
+  if (!isPlainObject(value)) {
+    return "must be an object";
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (!KNOWN_CUSTOM_SNIPPET_KEYS.includes(key)) {
+      return `has unknown property "${key}" (known properties: ${KNOWN_CUSTOM_SNIPPET_KEYS.join(", ")})`;
+    }
+    if (typeof entry !== "string") {
+      return `property "${key}" must be a string`;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The expected schema for a sample configuration, derived from the
+ * {@link SampleConfiguration} interface. Every recognized property maps to a
+ * validator that checks the property's value.
+ */
+const SAMPLE_CONFIGURATION_SCHEMA: Record<keyof SampleConfiguration, PropertyValidator> = {
+  skipFolder: isBoolean,
+  skip: isStringArray,
+  productName: isString,
+  productSlugs: isStringArray,
+  disableDocsMs: isBoolean,
+  apiRefLink: isString,
+  dependencyOverrides: isStringRecord,
+  requiredResources: isStringRecord,
+  customSnippets: isCustomSnippets,
+  extraFiles: isStringArrayRecord,
+  overridePublicationLinkFragment: isString,
+};
+
+const KNOWN_SAMPLE_CONFIGURATION_KEYS = Object.keys(SAMPLE_CONFIGURATION_SCHEMA);
+
+/**
+ * Validates a sample configuration object against the {@link SampleConfiguration}
+ * schema, returning a list of problems.
+ *
+ * A misspelled or misplaced property (for example `skipFolders` instead of
+ * `skipFolder`) is silently ignored by {@link getSampleConfiguration}, which can
+ * cause samples to be generated or published incorrectly. This function makes
+ * such drift visible by rejecting unknown properties and values whose types do
+ * not match the schema.
+ *
+ * @param configuration - the value of a `sampleConfiguration` field to validate
+ * @returns an array of problems; an empty array means the configuration is valid
+ */
+export function validateSampleConfiguration(configuration: unknown): SampleConfigurationProblem[] {
+  const problems: SampleConfigurationProblem[] = [];
+
+  if (!isPlainObject(configuration)) {
+    problems.push({ path: ".", message: "sample configuration must be a JSON object" });
+    return problems;
+  }
+
+  for (const [key, value] of Object.entries(configuration)) {
+    const validator = SAMPLE_CONFIGURATION_SCHEMA[key as keyof SampleConfiguration];
+    if (!validator) {
+      problems.push({
+        path: key,
+        message: `unknown property "${key}" (known properties: ${KNOWN_SAMPLE_CONFIGURATION_KEYS.join(", ")})`,
+      });
+      continue;
+    }
+
+    const message = validator(value);
+    if (message) {
+      problems.push({ path: key, message: `"${key}" ${message}` });
+    }
+  }
+
+  return problems;
+}
+
+/**
  * A helper function for removing ".js"/".ts" from the end of a string
  */
 const removeJsTsExtensions = (name: string): string => name.replace(/\.[jt]s$/, "");

--- a/common/tools/dev-tool/test/sampleConfiguration.spec.ts
+++ b/common/tools/dev-tool/test/sampleConfiguration.spec.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, expect } from "vitest";
+import { sampleConfiguration } from "../src/checks/sampleConfiguration.ts";
+import { validateSampleConfiguration } from "../src/util/samples/configuration.ts";
+import { isCheckFailedError } from "../src/framework/check.ts";
+import type { ProjectInfo } from "../src/util/resolveProject.ts";
+
+function makeProject(packageJson: Partial<PackageJson>): ProjectInfo {
+  const fullPackageJson = {
+    name: "@azure/test-package",
+    version: "1.0.0",
+    ...packageJson,
+  } as PackageJson;
+  return {
+    name: fullPackageJson.name,
+    version: fullPackageJson.version,
+    path: "/virtual/sdk/test/test-package",
+    packageJson: fullPackageJson,
+  };
+}
+
+async function runCheck(packageJson: Partial<PackageJson>): Promise<void> {
+  await sampleConfiguration.check({
+    fix: false,
+    verbose: false,
+    project: makeProject(packageJson),
+  });
+}
+
+describe("validateSampleConfiguration", () => {
+  it("accepts an empty configuration", () => {
+    assert.deepEqual(validateSampleConfiguration({}), []);
+  });
+
+  it("accepts a fully-populated valid configuration", () => {
+    const problems = validateSampleConfiguration({
+      skipFolder: false,
+      skip: ["sampleA", "sampleB"],
+      productName: "Azure Test",
+      productSlugs: ["azure", "azure-test"],
+      disableDocsMs: true,
+      apiRefLink: "https://learn.microsoft.com/javascript/api/@azure/test",
+      dependencyOverrides: { "@azure/identity": "^4.0.0" },
+      requiredResources: { "Azure Test Instance": "https://example.com/docs" },
+      customSnippets: { header: "./header.md", footer: "./footer.md" },
+      extraFiles: { "./assets": ["typescript/assets", "javascript/assets"] },
+      overridePublicationLinkFragment: "test",
+    });
+    assert.deepEqual(problems, []);
+  });
+
+  it("rejects an unknown property (typo)", () => {
+    const problems = validateSampleConfiguration({ skipFolders: true });
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].path, "skipFolders");
+    assert.match(problems[0].message, /unknown property "skipFolders"/);
+  });
+
+  it("rejects a property with the wrong type", () => {
+    const problems = validateSampleConfiguration({ skipFolder: "true" });
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].path, "skipFolder");
+    assert.match(problems[0].message, /must be a boolean/);
+  });
+
+  it("rejects skip when it is not an array of strings", () => {
+    const problems = validateSampleConfiguration({ skip: "sampleA" });
+    assert.equal(problems.length, 1);
+    assert.match(problems[0].message, /must be an array of strings/);
+  });
+
+  it("rejects an unknown customSnippets property", () => {
+    const problems = validateSampleConfiguration({ customSnippets: { middle: "./middle.md" } });
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].path, "customSnippets");
+    assert.match(problems[0].message, /unknown property "middle"/);
+  });
+
+  it("rejects a non-object configuration", () => {
+    const problems = validateSampleConfiguration("nope");
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].path, ".");
+    assert.match(problems[0].message, /must be a JSON object/);
+  });
+
+  it("reports every problem at once", () => {
+    const problems = validateSampleConfiguration({
+      skipFolder: "true",
+      bogus: 1,
+      skip: 5,
+    });
+    assert.equal(problems.length, 3);
+  });
+});
+
+describe("sampleConfiguration check", () => {
+  it("passes when there is no sample configuration", async () => {
+    await expect(runCheck({})).resolves.toBeUndefined();
+  });
+
+  it("passes for a valid configuration in the metadata location", async () => {
+    await expect(
+      runCheck({
+        "//metadata": { sampleConfiguration: { skipFolder: true, skip: ["a"] } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("tolerates the deprecated top-level location when valid", async () => {
+    // Using the deprecated `//sampleConfiguration` location is intentionally
+    // allowed; the check only validates shape, it does not force a migration.
+    await expect(
+      runCheck({
+        "//sampleConfiguration": { disableDocsMs: true },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails for an invalid configuration in the metadata location", async () => {
+    await expect(
+      runCheck({
+        "//metadata": { sampleConfiguration: { skipFolders: true } as never },
+      }),
+    ).rejects.toThrow(/schema/);
+  });
+
+  it("fails for an invalid configuration in the deprecated location", async () => {
+    let caught: unknown;
+    try {
+      await runCheck({ "//sampleConfiguration": { skip: "a" } as never });
+    } catch (e) {
+      caught = e;
+    }
+    assert.isTrue(isCheckFailedError(caught), "expected a CheckFailedError");
+  });
+
+  it("validates both locations and includes each label in the detail", async () => {
+    let caught: unknown;
+    try {
+      await runCheck({
+        "//metadata": { sampleConfiguration: { badMeta: 1 } as never },
+        "//sampleConfiguration": { badLegacy: 1 } as never,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    assert.isTrue(isCheckFailedError(caught), "expected a CheckFailedError");
+    if (isCheckFailedError(caught)) {
+      assert.match(caught.detail ?? "", /\/\/metadata\.sampleConfiguration\.badMeta/);
+      assert.match(caught.detail ?? "", /\/\/sampleConfiguration\.badLegacy/);
+    }
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/dev-tool`

### Issues associated with this PR

None — this is an improvement proposal rather than a fix for a specific issue.

### Describe the problem that is addressed by this PR

We have ~1,300 package manifests and a fair amount of configuration drift between them. I wanted to start chipping away at that with `dev-tool check`, but the trick is picking an invariant that gives real signal *without* lighting up hundreds of pre-existing failures on `main`.

The one I landed on is the `sampleConfiguration` metadata. The sample tooling reads it with plain property access (`getSampleConfiguration`), so a misspelled or mistyped key — `skipFolders` instead of `skipFolder`, `skip` as a string instead of an array — is silently ignored. That failure mode is nasty precisely because nothing complains: the samples just get generated or published in a way you didn't intend.

This PR adds a non-mutating check that validates `sampleConfiguration` against the documented `SampleConfiguration` interface and reports unknown properties and wrong-typed values as actionable errors. It validates both the current `"//metadata".sampleConfiguration` location and the deprecated top-level `"//sampleConfiguration"`. Example output:

```
❌ sampleConfiguration - sample configuration does not match the expected schema
  > //metadata.sampleConfiguration.skipFolders: unknown property "skipFolders" (known properties: skipFolder, skip, productName, ...)
  > //metadata.sampleConfiguration.skip: "skip" must be an array of strings
```

**On scope:** I deliberately kept this small. I measured the invariant against every manifest first — 399 sample configurations across the repo, **0 failures** — so this is genuinely fix-forward: it catches the *next* typo, it doesn't dump a backlog on anyone. It's also intentionally read-only (no `--fix`), because there's no safe way to guess what a misspelled key was supposed to be.

I did *not* try to standardize hundreds of packages here. In particular, ~384 packages still use the deprecated top-level `"//sampleConfiguration"` location, and this check happily tolerates that — it only validates shape, it does not force a migration. That felt like the right call to keep the diff honest and the baseline green.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The audit surfaced a few candidate invariants. I measured each against the current baseline before choosing:

- **`sampleConfiguration` schema (this PR)** — objectively correct (validates against the interface the tooling itself consumes), 0 pre-existing failures, catches a real silent-publish bug. This won.
- **`repository.directory` must match the package's on-disk path** — also 0 mismatches among the 431 published libs, but the existing `repository` check already covers most of this, so the marginal value was lower. Good follow-up candidate.
- **Migrate `//sampleConfiguration` → `//metadata.sampleConfiguration`** — ~384 failures. That's a wall, not a check. Better as a separate `--fix`-able migration.
- **Duplicated SDK script-sets / near-empty api-extractor stubs / `echo skipped` scripts** — these have lots of *intentional* variation (package-type differences, deliberate skips), so a naive rule here would be mostly false positives. Not worth it without an established exception mechanism.

I wired it in as a plain `packageJsonCheck` with no tags, exactly like the existing `license`/`author`/`repository` checks, so it runs on `dev-tool check` alongside the other package.json validators — no new CI plumbing invented.

### Are there test cases added in this PR? _(If not, why?)_

Yes — `test/sampleConfiguration.spec.ts` covers the valid case, invalid cases (unknown key, wrong type, non-object, nested `customSnippets`), the intentional-exception case (the deprecated location is tolerated when valid), and that both locations are validated with their labels in the error detail. Full dev-tool suite is green (63 tests).

### Provide a list of related PRs _(if any)_

None.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [ ] Added a changelog (if necessary) — `@azure/dev-tool` is a private internal tool, so no changelog entry.
