### PR TITLE
[core] Apply request timeout to buffered response bodies

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 0.3.9 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- `NodeHttpClient` request timeouts now remain active while buffered response bodies are being read. [Issue #39519](https://github.com/Azure/azure-sdk-for-js/issues/39519)
+
+### Other Changes
+
 ## 0.3.8 (2026-07-29)
 
 ### Features Added

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/ts-http-runtime",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/ts-http-runtime/src/constants.ts
+++ b/sdk/core/ts-http-runtime/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "0.3.8";
+export const SDK_VERSION: string = "0.3.9";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -140,10 +140,6 @@ class NodeHttpClient implements HttpClient {
 
       const res = await this.makeRequest(request, abortController, body);
 
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-
       const headers = getResponseHeaders(res);
 
       const status = res.statusCode ?? 0;
@@ -186,6 +182,10 @@ class NodeHttpClient implements HttpClient {
 
       return response;
     } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+
       // clean up event listener
       if (request.abortSignal && abortListener) {
         let uploadStreamDone = Promise.resolve();

--- a/sdk/core/ts-http-runtime/test/public/node/nodeHttpClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/node/nodeHttpClient.spec.ts
@@ -112,7 +112,7 @@ function yieldHttpResponse(response: IncomingMessage): void {
 
 describe("NodeHttpClient", function () {
   beforeEach(function () {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const clientRequest = createRequest();
     vi.mocked(https.request).mockReturnValue(clientRequest);
     vi.mocked(http.request).mockReturnValue(clientRequest);
@@ -221,6 +221,60 @@ describe("NodeHttpClient", function () {
     } catch (e: any) {
       assert.strictEqual(e.name, "AbortError");
     }
+  });
+
+  it("should honor timeout while reading a buffered response body", async function () {
+    const client = createDefaultHttpClient();
+    const timeoutLength = 2000;
+    const streamResponse = new FakeResponse();
+    const clientRequest = createRequest();
+    clientRequest.destroy = function (this: FakeRequest, e: Error) {
+      streamResponse.destroy(e);
+      return clientRequest;
+    };
+    vi.mocked(https.request).mockReturnValueOnce(clientRequest);
+
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      timeout: timeoutLength,
+    });
+    const promise = client.sendRequest(request);
+    streamResponse.headers = {};
+    streamResponse.statusCode = 200;
+    streamResponse.write("The start of an HTTP body");
+    yieldHttpsResponse(streamResponse as unknown as IncomingMessage);
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(timeoutLength);
+
+    try {
+      await promise;
+      assert.fail("Expected await to throw");
+    } catch (e: any) {
+      assert.strictEqual(e.name, "AbortError");
+    }
+  });
+
+  it("should clear timeout before returning a streamed response body", async function () {
+    const client = createDefaultHttpClient();
+    const timeoutLength = 2000;
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      timeout: timeoutLength,
+      streamResponseStatusCodes: new Set([200]),
+    });
+    const promise = client.sendRequest(request);
+    const streamResponse = new FakeResponse();
+    streamResponse.headers = {};
+    streamResponse.statusCode = 200;
+    streamResponse.write("The start of an HTTP body");
+    yieldHttpsResponse(streamResponse as unknown as IncomingMessage);
+
+    const response = await promise;
+
+    assert.isDefined(response.readableStreamBody);
+    assert.strictEqual(vi.getTimerCount(), 0);
+    streamResponse.destroy();
   });
 
   it("should stream response body on matching status code", async function () {


### PR DESCRIPTION
### Packages impacted by this PR

- `@typespec/ts-http-runtime` (used by `@azure/core-rest-pipeline`)

### Issues associated with this PR

Fixes #39519

### Describe the problem that is addressed by this PR

`NodeHttpClient` cleared the request timeout as soon as response headers arrived. Buffered responses could therefore wait indefinitely if the server stalled while sending the body. This change keeps the timeout active until `sendRequest` settles, while still clearing it immediately when a streamed response is returned.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The timer could be cleared at each response return point. Clearing it in the existing `finally` block centralizes cleanup and also prevents a body-read failure from leaving a live timer behind.

### Are there test cases added in this PR? _(If not, why?)_

Yes. Tests cover a timeout after headers arrive during a buffered body read and verify that streamed responses are returned without an active timeout.

### Provide a list of related PRs _(if any)_

N/A

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog (if necessary).