### PR TITLE
Redirect Linux CI tool caches off the constrained root disk

### DIFF
--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -13,7 +13,7 @@ steps:
   # hardlinking instead of copying. The df output makes the disk layout visible
   # in the log so the redirection can be confirmed to actually free root space.
   - pwsh: |
-      $cacheRoot = Join-Path $env:AGENT_BUILDDIRECTORY 'cache'
+      $cacheRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'cache'
       $npmCache = Join-Path $cacheRoot 'npm'
       $pnpmStore = Join-Path $cacheRoot 'pnpm/store'
       $playwrightBrowsers = Join-Path $cacheRoot 'ms-playwright'

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -6,12 +6,17 @@
 steps:
   # Linux CI agents have limited space on the root disk ('/'), where many Node
   # tools cache under the home directory. Redirect the largest caches to
-  # Agent.BuildDirectory, which lives on a roomier disk, by configuring each
+  # Agent.TempDirectory, which lives on a roomier disk, by configuring each
   # tool through its own supported environment variable. HOME is left untouched
   # so credentials and unrelated tool state are unaffected. The pnpm store stays
-  # under the same directory tree as the workspace node_modules so pnpm can keep
+  # on the same filesystem as the workspace node_modules so pnpm can keep
   # hardlinking instead of copying. The df output makes the disk layout visible
   # in the log so the redirection can be confirmed to actually free root space.
+  #
+  # NOTE: Tools invoked inside `turbo run` (e.g. `playwright install` during
+  # test:browser) only see env vars that turbo is configured to pass through.
+  # PLAYWRIGHT_BROWSERS_PATH is added to the test:browser task's passThroughEnv
+  # in the root turbo.json so the browser download honors this redirect.
   - pwsh: |
       $cacheRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'cache'
       $npmCache = Join-Path $cacheRoot 'npm'
@@ -27,8 +32,8 @@ steps:
       Write-Host "##vso[task.setvariable variable=pnpm_config_store_dir]$pnpmStore"
       Write-Host "##vso[task.setvariable variable=PLAYWRIGHT_BROWSERS_PATH]$playwrightBrowsers"
 
-      Write-Host "Filesystem usage for HOME ($env:HOME) and Agent.BuildDirectory ($env:AGENT_BUILDDIRECTORY):"
-      df -h $env:HOME $env:AGENT_BUILDDIRECTORY
+      Write-Host "Filesystem usage for HOME ($env:HOME) and Agent.TempDirectory ($env:AGENT_TEMPDIRECTORY):"
+      df -h $env:HOME $env:AGENT_TEMPDIRECTORY
     displayName: "Redirect tool caches off root disk (Linux)"
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -4,6 +4,34 @@
 # include it from a step template - ADO does not de-duplicate step templates, so
 # nesting it causes UseNode and npmAuthenticate to run several times per job.
 steps:
+  # Linux CI agents have limited space on the root disk ('/'), where many Node
+  # tools cache under the home directory. Redirect the largest caches to
+  # Agent.BuildDirectory, which lives on a roomier disk, by configuring each
+  # tool through its own supported environment variable. HOME is left untouched
+  # so credentials and unrelated tool state are unaffected. The pnpm store stays
+  # under the same directory tree as the workspace node_modules so pnpm can keep
+  # hardlinking instead of copying. The df output makes the disk layout visible
+  # in the log so the redirection can be confirmed to actually free root space.
+  - pwsh: |
+      $cacheRoot = Join-Path $env:AGENT_BUILDDIRECTORY 'cache'
+      $npmCache = Join-Path $cacheRoot 'npm'
+      $pnpmStore = Join-Path $cacheRoot 'pnpm/store'
+      $playwrightBrowsers = Join-Path $cacheRoot 'ms-playwright'
+
+      foreach ($dir in @($npmCache, $pnpmStore, $playwrightBrowsers)) {
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+      }
+
+      Write-Host "Redirecting Linux tool caches under $cacheRoot"
+      Write-Host "##vso[task.setvariable variable=npm_config_cache]$npmCache"
+      Write-Host "##vso[task.setvariable variable=pnpm_config_store_dir]$pnpmStore"
+      Write-Host "##vso[task.setvariable variable=PLAYWRIGHT_BROWSERS_PATH]$playwrightBrowsers"
+
+      Write-Host "Filesystem usage for HOME ($env:HOME) and Agent.BuildDirectory ($env:AGENT_BUILDDIRECTORY):"
+      df -h $env:HOME $env:AGENT_BUILDDIRECTORY
+    displayName: "Redirect tool caches off root disk (Linux)"
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
     parameters:
       AgentImage: $(OSVmImage)

--- a/turbo.json
+++ b/turbo.json
@@ -55,7 +55,7 @@
     },
     "test:browser": {
       "dependsOn": ["build"],
-      "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage"]
+      "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage", "PLAYWRIGHT_BROWSERS_PATH"]
     },
     "test:node": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Why

Our Linux Azure DevOps CI agents have limited space on the root disk (`/`). Many Node tools default to caching under the home directory (`~/`), which sits on that constrained disk, contributing to disk-exhaustion failures. `Agent.TempDirectory` lives on a separate, roomier disk (`/mnt/vss/_work`, confirmed on a real Linux runner).

## What

Adds a single Linux-only step at the start of the shared job prelude (`eng/pipelines/templates/steps/common.yml`), so it applies to the main SDK build, analyze, unit-test, and live-test jobs that consume the prelude. The step redirects each tool's cache through that tool's own supported environment variable, published as job variables so all downstream steps inherit them:

- npm/npx: `npm_config_cache` -> `$(Agent.TempDirectory)/cache/npm`
- pnpm store: `pnpm_config_store_dir` -> `$(Agent.TempDirectory)/cache/pnpm/store`
- Playwright browsers: `PLAYWRIGHT_BROWSERS_PATH` -> `$(Agent.TempDirectory)/cache/ms-playwright`

It also adds `PLAYWRIGHT_BROWSERS_PATH` to the `test:browser` task's `passThroughEnv` in the root `turbo.json`.

## Notes for reviewers

- **`HOME` is deliberately left untouched** (and generic XDG dirs are not redirected), so credentials and unrelated tool state are unaffected. This keeps the blast radius small.
- **pnpm store stays on the same filesystem as the workspace `node_modules`** (both under `/mnt/vss/_work`), so pnpm keeps hardlinking rather than falling back to copying.
- **Turbo strips env vars in strict mode.** `playwright install` runs inside `turbo run test:browser`, so a job-level `PLAYWRIGHT_BROWSERS_PATH` did not reach it and browsers still downloaded to `~/.cache/ms-playwright`. Adding it to that task's `passThroughEnv` fixes this. `passThroughEnv` values do not contribute to the task cache hash, so caching is unaffected.
- **Runtime `condition:`**, not a compile-time `${{ if }}`: `Agent.OS` is only known at runtime, so a template expression would silently drop the step. macOS and Windows jobs are unaffected.
- **The `df -h` line is intentional**: it prints HOME vs `Agent.TempDirectory` filesystem usage into each Linux job log for ongoing visibility that the redirection is landing on the roomier disk.
- **Scope**: standalone automation pipelines that bypass the shared prelude (weekly automation, run-for-all-packages, docindex, aggregate-reports, sdk-regenerate) are intentionally out of scope for this change.
- Some `~/.cache` consumers (e.g. dev-tool's test-proxy download via `XDG_CACHE_HOME`, `.dotnet`) are not redirected here; they can be follow-ups if root pressure persists.