### PR TITLE
[monitor-opentelemetry] Skip the IMDS probe when the hosting platform is already detected

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### Features Added
 
 - `instrumentationOptions.console` now accepts a `logSeverity` value, allowing the console log severity to be configured programmatically instead of only through the `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` environment variable. [#39483](https://github.com/Azure/azure-sdk-for-js/pull/39483)
+- Added support for the Azure Container Apps resource detector from `@opentelemetry/resource-detector-azure`. [#39510](https://github.com/Azure/azure-sdk-for-js/issues/39510)
 
 ### Bugs Fixed
 
 - Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time. [#39520](https://github.com/Azure/azure-sdk-for-js/pull/39520)
-- Fixed a failed IMDS request being recorded as a dependency when running on App Service and Functions. The Azure VM resource detector now runs only when no other detector has identified the platform. [#39510](https://github.com/Azure/azure-sdk-for-js/issues/39510)
+- Fixed a failed IMDS request being recorded as a dependency when running on App Service, Functions, and Container Apps. The Azure VM resource detector now runs only when no other detector has identified the platform. [#39510](https://github.com/Azure/azure-sdk-for-js/issues/39510)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time. [#39520](https://github.com/Azure/azure-sdk-for-js/pull/39520)
+- Fixed a failed IMDS request being recorded as a dependency when running on App Service and Functions. The Azure VM resource detector now runs only when no other detector has identified the platform. [#39510](https://github.com/Azure/azure-sdk-for-js/issues/39510)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -25,6 +25,7 @@ import {
   azureFunctionsDetector,
   azureVmDetector,
 } from "@opentelemetry/resource-detector-azure";
+import { SEMRESATTRS_CLOUD_PLATFORM } from "@opentelemetry/semantic-conventions";
 
 /**
  * Azure Monitor OpenTelemetry Client Configuration
@@ -218,9 +219,14 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     });
     this._resource = resource.merge(aksResource).merge(azureResource);
 
-    // Handle VM resource detection asynchronously to avoid warnings
-    // about accessing resource attributes before async attributes are settled
-    this._initializeVmResourceAsync();
+    // The IMDS probe fails on App Service and Functions, and on AKS it describes
+    // the node VM rather than the cluster.
+    const platformDetected =
+      aksResource.attributes[SEMRESATTRS_CLOUD_PLATFORM] ??
+      azureResource.attributes[SEMRESATTRS_CLOUD_PLATFORM];
+    if (!platformDetected) {
+      this._initializeVmResourceAsync();
+    }
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -22,6 +22,7 @@ import { isAksResourceDetectorPopulated } from "../utils/common.js";
 import {
   azureAksDetector,
   azureAppServiceDetector,
+  azureContainerAppsDetector,
   azureFunctionsDetector,
   azureVmDetector,
 } from "@opentelemetry/resource-detector-azure";
@@ -215,12 +216,12 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     this._aksResourceDetectorPopulated = isAksResourceDetectorPopulated(aksResource.attributes);
 
     const azureResource: Resource = detectResources({
-      detectors: [azureAppServiceDetector, azureFunctionsDetector],
+      detectors: [azureAppServiceDetector, azureContainerAppsDetector, azureFunctionsDetector],
     });
     this._resource = resource.merge(aksResource).merge(azureResource);
 
-    // The IMDS probe fails on App Service and Functions, and on AKS it describes
-    // the node VM rather than the cluster.
+    // The IMDS probe fails on App Service, Functions, and Container Apps, and on AKS
+    // it describes the node VM rather than the cluster.
     const platformDetected =
       aksResource.attributes[SEMRESATTRS_CLOUD_PLATFORM] ??
       azureResource.attributes[SEMRESATTRS_CLOUD_PLATFORM];

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -480,6 +480,53 @@ describe("OpenTelemetry Resource", () => {
     }, 1000);
   });
 
+  describe("VM resource detection", () => {
+    // This describe has no afterEach, so spies survive between tests and an earlier test's
+    // calls would otherwise be visible on the ones created here.
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    // Swap in a clean environment so ambient App Service variables on the machine running
+    // the tests cannot decide the outcome.
+    function createConfigWithEnv(env: { [id: string]: string }): InternalConfig {
+      const originalEnv = process.env;
+      process.env = env;
+      try {
+        return new InternalConfig();
+      } finally {
+        process.env = originalEnv;
+      }
+    }
+
+    it("skips the IMDS probe on App Service", () => {
+      const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
+      createConfigWithEnv({ WEBSITE_SITE_NAME: "test-site" });
+      expect(detect).not.toHaveBeenCalled();
+    });
+
+    it("skips the IMDS probe on Azure Functions", () => {
+      const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
+      createConfigWithEnv({ WEBSITE_SITE_NAME: "test-site", FUNCTIONS_EXTENSION_VERSION: "~4" });
+      expect(detect).not.toHaveBeenCalled();
+    });
+
+    it("skips the IMDS probe on AKS", () => {
+      const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
+      createConfigWithEnv({
+        CLUSTER_RESOURCE_ID:
+          "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+      });
+      expect(detect).not.toHaveBeenCalled();
+    });
+
+    it("probes IMDS when no platform is detected", () => {
+      const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
+      createConfigWithEnv({});
+      expect(detect).toHaveBeenCalled();
+    });
+  });
+
   it("OTEL_RESOURCE_ATTRIBUTES", () => {
     vi.stubEnv(
       "OTEL_RESOURCE_ATTRIBUTES",

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -520,6 +520,19 @@ describe("OpenTelemetry Resource", () => {
       expect(detect).not.toHaveBeenCalled();
     });
 
+    it("skips the IMDS probe on Container Apps", () => {
+      const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
+      createConfigWithEnv({
+        CONTAINER_APP_NAME: "test-app",
+        CONTAINER_APP_REVISION: "test-app--rev1",
+        CONTAINER_APP_HOSTNAME: "test-app.internal",
+        CONTAINER_APP_ENV_DNS_SUFFIX: "test.azurecontainerapps.io",
+        CONTAINER_APP_PORT: "80",
+        CONTAINER_APP_REPLICA_NAME: "test-app--rev1-abc",
+      });
+      expect(detect).not.toHaveBeenCalled();
+    });
+
     it("probes IMDS when no platform is detected", () => {
       const detect = vi.spyOn(azureVmDetector, "detect").mockReturnValue({ attributes: {} });
       createConfigWithEnv({});

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -481,10 +481,14 @@ describe("OpenTelemetry Resource", () => {
   });
 
   describe("VM resource detection", () => {
-    // This describe has no afterEach, so spies survive between tests and an earlier test's
-    // calls would otherwise be visible on the ones created here.
+    // The spy in the VM test above is never restored, so clear its call history before each
+    // case here, and restore afterwards so these mocks do not leak into later tests.
     beforeEach(() => {
       vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
     // Swap in a clean environment so ambient App Service variables on the machine running


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/monitor-opentelemetry`

### Issues associated with this PR

Fixes #39510

### Describe the problem that is addressed by this PR

`_setDefaultResource()` runs the Azure platform detectors, then calls `_initializeVmResourceAsync()` unconditionally. That probes IMDS at `169.254.169.254` on every process start regardless of the platform the detectors just identified.

On App Service, Functions, and Container Apps the probe fails on every process start, and the failure lands in the customer's own Application Insights as a dependency they cannot turn off. `azureVmDetector` wraps the request in `suppressTracing`, but the detector runs before `sdk.start()` registers a context manager, so the suppression has nothing to act on. Repro and KQL are in #39510.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Two commits, separable:

**1. Skip the probe when a detector already identified the platform.**

```ts
const platformDetected =
  aksResource.attributes[SEMRESATTRS_CLOUD_PLATFORM] ??
  azureResource.attributes[SEMRESATTRS_CLOUD_PLATFORM];
if (!platformDetected) {
  this._initializeVmResourceAsync();
}
```

Both detected resources are checked because #39469 split AKS detection out into its own `detectResources()` call.

This is the policy statsbeat already applies in `@azure/monitor-opentelemetry-exporter`, where `getResourceProvider()` checks for AKS, App Service, and Functions and only falls through to `getAzureComputeMetadata()` when none match.

I sketched an environment-variable guard in #39510. Gating on the detector output is better: `azureAksDetector` keys on `CLUSTER_RESOURCE_ID`, not the `AKS_ARM_NAMESPACE_ID` I had proposed, and it also detects from the `aks-cluster-metadata` ConfigMap mounted at `/etc/kubernetes/aks-cluster-metadata`, which no environment check can see. Asking the detectors what they found avoids restating their internals in a second place, and `isAzureContainerApps()` is not exported, so the same would apply to Container Apps.

**2. Add `azureContainerAppsDetector` to the detector list.**

Container Apps has the same bug, and without this it is the one affected platform left probing. `azureAppServiceDetector` declines when `isAzureContainerApps()` is true, so nothing in the current list claims Container Apps and `cloud.platform` stays unset. The detector already ships in `@opentelemetry/resource-detector-azure` 0.28.0 and was never wired up here.

Additive, so it is its own commit. Drop it and the first commit still stands.

Notes:

- All four platform detectors are synchronous, so reading their attributes immediately does not trip the async-attribute warning the surrounding code avoids.
- Nothing loses attributes. `_initializeVmResourceAsync()` merges into `this._resource` after `useAzureMonitor()` has already read `config.resource` into the SDK, so the VM detector's attributes were not reaching exported telemetry on any platform. On the platforms now skipped, the probe was paying a network call for a result that was discarded.
- A bare VM and self-managed Kubernetes on Azure VMs set no `cloud.platform`, so both still probe.
- `OTEL_NODE_RESOURCE_DETECTORS=azure_vm` goes through `parseResourceDetectorsFromEnvVar()` and is untouched, so anyone opting into VM detection explicitly still gets it.

### Are there test cases added in this PR? _(If not, why?)_

Yes, a `VM resource detection` block in `test/internal/unit/shared/config.test.ts`, one case per platform:

- skips the IMDS probe on App Service
- skips the IMDS probe on Azure Functions
- skips the IMDS probe on AKS
- skips the IMDS probe on Container Apps
- probes IMDS when no platform is detected

The four skip cases fail against `main`. The last passes either way and pins the no-regression case. Each swaps in a clean `process.env` so ambient App Service variables cannot decide the outcome.

Verified locally: package build, the unit suite, `pnpm check-format`, and `pnpm lint`.

### Provide a list of related PRs _(if any)_

None.

### Checklists

- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary)
