### PR TITLE
[Identity] Bump @azure/msal-node to ^5.1.5 to drop vulnerable uuid transitive dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16718,7 +16718,7 @@ importers:
         specifier: ^5.5.0
         version: 5.17.3
       '@azure/msal-node':
-        specifier: ^5.1.0
+        specifier: ^5.1.5
         version: 5.4.3
       open:
         specifier: ^10.1.0

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.13.2 (2026-08-10)
+
+### Bugs Fixed
+
+- Bumped the minimum `@azure/msal-node` dependency to `^5.1.5` so installs no longer resolve older `5.1.x` versions that pull in the vulnerable `uuid@8.3.0` transitive dependency.
+
 ## 4.13.1 (2026-03-18)
 
 ### Other Changes

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 4.13.2 (2026-08-10)
+## 4.13.2 (2026-08-12)
 
-### Bugs Fixed
+### Other Changes
 
 - Bumped the minimum `@azure/msal-node` dependency to `^5.1.5` so installs no longer resolve older `5.1.x` versions that pull in the vulnerable `uuid@8.3.0` transitive dependency.
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Bumped the minimum `@azure/msal-node` dependency to `^5.1.5` so installs no longer resolve older `5.1.x` versions that pull in the vulnerable `uuid@8.3.0` transitive dependency.
+- Bumped the minimum `@azure/msal-node` dependency to `^5.1.5` so installs no longer resolve older `5.1.x` versions that pull in the vulnerable `uuid@8.3.0` transitive dependency. [#39569](https://github.com/Azure/azure-sdk-for-js/pull/39569)
 
 ## 4.13.1 (2026-03-18)
 

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "4.13.1",
+  "version": "4.13.2",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Microsoft Entra ID",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
@@ -83,7 +83,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.0.0",
     "@azure/msal-browser": "^5.5.0",
-    "@azure/msal-node": "^5.1.0",
+    "@azure/msal-node": "^5.1.5",
     "open": "^10.1.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the `@azure/identity` package.
  */
-export const SDK_VERSION = `4.13.1`;
+export const SDK_VERSION = `4.13.2`;
 
 /**
  * The default client ID for authentication

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -258,7 +258,7 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       });
 
       it("handles an unreachable network error", async function () {
-        acquireTokenStub.mockRejectedValue(new AuthError("network_error"));
+        acquireTokenStub.mockRejectedValue(new AuthError("network_error", "testID"));
         const credential = new ManagedIdentityCredential();
         await expect(credential.getToken("scope")).rejects.toThrow(CredentialUnavailableError);
       });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/identity`

### Description

Bumps the minimum `@azure/msal-node` dependency from `^5.1.0` to `^5.1.5` and refreshes the pnpm lockfile so installs resolve msal-node `5.1.5`, which drops the vulnerable `uuid@8.3.0` transitive dependency pulled in by older `5.1.x` releases.