### PR TITLE
[EngSys] Surface per-package ci-runner failures as GitHub check annotations

### DIFF
--- a/eng/tools/check-snippet-changes.ps1
+++ b/eng/tools/check-snippet-changes.ps1
@@ -6,7 +6,33 @@ if($LastExitCode -ne 0) {
     Write-Host "Contents of $diffFile"
     Get-Content -Path $diffFile | % { Write-Host $_ }
     Write-Host " "
-    Write-Host "Please do 'npm run update-snippets' then add the changes to the PR."
+
+    $changedPackages = @(
+        git diff --name-only -- . ":(exclude).npmrc" |
+            ForEach-Object {
+                if ($_ -match '^(sdk[\\/][^\\/]+[\\/][^\\/]+)[\\/]') {
+                    $Matches[1] -replace '\\', '/'
+                }
+            } |
+            Sort-Object -Unique
+    )
+    if ($changedPackages.Count -gt 0) {
+        $packageList = $changedPackages -join ", "
+        $directoryInstruction = if ($changedPackages.Count -eq 1) {
+            "that package directory"
+        } else {
+            "each listed package directory"
+        }
+        $remediation = "Generated snippets are out of date in $packageList. Run `"pnpm update-snippets`" from $directoryInstruction and commit the resulting changes."
+    } else {
+        $remediation = "Generated snippets are out of date. Run `"pnpm update-snippets`" from each affected package directory and commit the resulting changes."
+    }
+
+    Write-Host $remediation
+    if ($env:TF_BUILD) {
+        $escapedRemediation = $remediation.Replace("%", "%AZP25").Replace("`r", "%0D").Replace("`n", "%0A")
+        Write-Host "##vso[task.logissue type=error]$escapedRemediation"
+    }
     Write-Host ""
     exit 1
 }

--- a/eng/tools/ci-runner/src/actions.js
+++ b/eng/tools/ci-runner/src/actions.js
@@ -73,11 +73,12 @@ export function executeActions(
         exitCode = runInPackageDirs(action, packageDirs);
         break;
       case "check-format":
-        exitCode = runInPackageDirs(action, packageDirs, (packageDir) => {
-          console.log(
-            `\nInvoke "npm run format" inside ${tryGetPkgRelativePath(packageDir)} to fix formatting\n`,
-          );
-        });
+        exitCode = runInPackageDirs(
+          action,
+          packageDirs,
+          (packageDir) =>
+            `Formatting check failed in ${tryGetPkgRelativePath(packageDir)}. Run "pnpm format" from that directory and commit the resulting changes.`,
+        );
         break;
 
       case "check-package-version":

--- a/eng/tools/ci-runner/src/actions.js
+++ b/eng/tools/ci-runner/src/actions.js
@@ -69,8 +69,15 @@ export function executeActions(
 
       case "pack":
       case "lint":
-      case "update-snippets":
         exitCode = runInPackageDirs(action, packageDirs);
+        break;
+      case "update-snippets":
+        exitCode = runInPackageDirs(
+          action,
+          packageDirs,
+          (packageDir) =>
+            `Snippet update failed in ${tryGetPkgRelativePath(packageDir)}. Run "pnpm update-snippets" from that directory and commit the resulting changes.`,
+        );
         break;
       case "check-format":
         exitCode = runInPackageDirs(

--- a/eng/tools/ci-runner/src/actions.js
+++ b/eng/tools/ci-runner/src/actions.js
@@ -69,15 +69,8 @@ export function executeActions(
 
       case "pack":
       case "lint":
-        exitCode = runInPackageDirs(action, packageDirs);
-        break;
       case "update-snippets":
-        exitCode = runInPackageDirs(
-          action,
-          packageDirs,
-          (packageDir) =>
-            `Snippet update failed in ${tryGetPkgRelativePath(packageDir)}. Run "pnpm update-snippets" from that directory and commit the resulting changes.`,
-        );
+        exitCode = runInPackageDirs(action, packageDirs);
         break;
       case "check-format":
         exitCode = runInPackageDirs(

--- a/eng/tools/ci-runner/src/reporting.js
+++ b/eng/tools/ci-runner/src/reporting.js
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// @ts-check
+
+/**
+ * Log an actionable failure and publish it as an Azure Pipelines issue when
+ * running in CI. Pipeline issues are forwarded to the associated GitHub check.
+ *
+ * @param {string} message
+ */
+export function reportFailure(message) {
+  console.error(message);
+
+  if (process.env.TF_BUILD) {
+    const escapedMessage = message
+      .replaceAll("%", "%AZP25")
+      .replaceAll("\r", "%0D")
+      .replaceAll("\n", "%0A");
+    console.log(`##vso[task.logissue type=error]${escapedMessage}`);
+  }
+}

--- a/eng/tools/ci-runner/src/runner.js
+++ b/eng/tools/ci-runner/src/runner.js
@@ -5,26 +5,9 @@
 
 import { spawnPnpm, spawnPnpmRun, spawnPnpmWithOutput } from "./spawn.js";
 import { getBaseDir } from "./env.js";
+import { reportFailure } from "./reporting.js";
 import { runTestProxyRestore } from "./testProxyRestore.js";
 import { relative, resolve, sep } from "node:path";
-
-/**
- * Log an actionable failure and publish it as an Azure Pipelines issue when
- * running in CI. Pipeline issues are forwarded to the associated GitHub check.
- *
- * @param {string} message
- */
-function reportFailure(message) {
-  console.error(message);
-
-  if (process.env.TF_BUILD) {
-    const escapedMessage = message
-      .replaceAll("%", "%AZP25")
-      .replaceAll("\r", "%0D")
-      .replaceAll("\n", "%0A");
-    console.log(`##vso[task.logissue type=error]${escapedMessage}`);
-  }
-}
 
 /**
  * Helper to run a global pnpm command

--- a/eng/tools/ci-runner/src/runner.js
+++ b/eng/tools/ci-runner/src/runner.js
@@ -6,6 +6,25 @@
 import { spawnPnpm, spawnPnpmRun, spawnPnpmWithOutput } from "./spawn.js";
 import { getBaseDir } from "./env.js";
 import { runTestProxyRestore } from "./testProxyRestore.js";
+import { relative, resolve, sep } from "node:path";
+
+/**
+ * Log an actionable failure and publish it as an Azure Pipelines issue when
+ * running in CI. Pipeline issues are forwarded to the associated GitHub check.
+ *
+ * @param {string} message
+ */
+function reportFailure(message) {
+  console.error(message);
+
+  if (process.env.TF_BUILD) {
+    const escapedMessage = message
+      .replaceAll("%", "%AZP25")
+      .replaceAll("\r", "%0D")
+      .replaceAll("\n", "%0A");
+    console.log(`##vso[task.logissue type=error]${escapedMessage}`);
+  }
+}
 
 /**
  * Helper to run a global pnpm command
@@ -146,14 +165,18 @@ export function runAllWithDirection(action, filters, extraParams, ciFlag) {
  *
  * @param {string} action - which action to execute
  * @param {string[]} packageDirs - An array of package folder paths
- * @param { (dir: string) => void} [onError] - An error callback when a command fails in a directory
+ * @param {(dir: string, exitCode: number) => string} [getFailureMessage] - Creates an actionable failure message
  */
-export function runInPackageDirs(action, packageDirs, onError) {
+export function runInPackageDirs(action, packageDirs, getFailureMessage) {
   let exitCode = 0;
   for (const packageDir of packageDirs) {
     let dirExitCode = spawnPnpmRun(packageDir, action);
-    if (dirExitCode !== 0 && onError) {
-      onError(packageDir);
+    if (dirExitCode !== 0) {
+      const relativePackageDir = relative(getBaseDir(), resolve(packageDir)).split(sep).join("/");
+      const failureMessage = getFailureMessage
+        ? getFailureMessage(packageDir, dirExitCode)
+        : `Command "pnpm run ${action}" failed with exit code ${dirExitCode} in ${relativePackageDir}.`;
+      reportFailure(failureMessage);
     }
     exitCode = exitCode || dirExitCode;
   }

--- a/eng/tools/ci-runner/src/verifyPackages.js
+++ b/eng/tools/ci-runner/src/verifyPackages.js
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import { spawnGitWithOutput, spawnPnpmWithOutput } from "./spawn.js";
 import { getBaseDir } from "./env.js";
+import { reportFailure } from "./reporting.js";
 
 /**
  * Checks if a specific version of a package is published on the npm registry.
@@ -147,7 +148,9 @@ export function verifyPackages(packageNames, packageDirs) {
 
     const packageJsonPath = path.join(packageDir, "package.json");
     if (!fs.existsSync(packageJsonPath)) {
-      console.error(`package.json not found at ${packageJsonPath}`);
+      reportFailure(
+        `Package version check failed for ${packageName}: package.json not found at ${packageJsonPath}.`,
+      );
       exitCode = 1;
       continue;
     }
@@ -170,8 +173,8 @@ export function verifyPackages(packageNames, packageDirs) {
     try {
       modifiedFiles = getModifiedFilesSinceTag(tag, packageDir);
     } catch (err) {
-      console.error(
-        `  ✗ Could not diff against tag "${tag}": ${err instanceof Error ? err.message : String(err)}`,
+      reportFailure(
+        `Package version check failed for ${packageName}@${version}: could not diff against tag "${tag}": ${err instanceof Error ? err.message : String(err)}`,
       );
       exitCode = 1;
       continue;
@@ -184,15 +187,12 @@ export function verifyPackages(packageNames, packageDirs) {
     if (relevantFiles.length === 0) {
       console.log(`  ✓ Version ${version} is published and no files modified since release — OK`);
     } else {
-      console.error(
-        `  ✗ Version ${version} is already published but files have been modified since tag "${tag}":`,
+      reportFailure(
+        `Package version check failed for ${packageName}@${version}: source files changed after published tag "${tag}". Run "npx dev-tool package increment-version" from ${relativePackageDir} and commit the resulting changes.`,
       );
       for (const file of relevantFiles) {
         console.error(`    - ${file}`);
       }
-      console.error(
-        `  Please bump the version in ${packageJsonPath}. You can do this using "dev-tool package increment-version" from the package folder.`,
-      );
       exitCode = 1;
     }
   }

--- a/eng/tools/ci-runner/test/actions.spec.js
+++ b/eng/tools/ci-runner/test/actions.spec.js
@@ -103,6 +103,30 @@ describe("executeActions", () => {
     assert.strictEqual(resultCode, 1);
   });
 
+  it("should report actionable remediation when formatting fails", () => {
+    vi.mocked(spawnPnpmRun).mockReturnValueOnce(1);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const resultCode = executeActions(
+      "check-format",
+      ["storage"],
+      [],
+      "azure-storage-file-datalake",
+    );
+
+    assert.strictEqual(resultCode, 1);
+    assert.ok(
+      errorSpy.mock.calls.some((call) =>
+        String(call[0])
+          .replaceAll("\\", "/")
+          .includes(
+            'Formatting check failed in sdk/storage/storage-file-datalake. Run "pnpm format"',
+          ),
+      ),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("should route check-package-version to verifyPackages function", () => {
     vi.mocked(verifyPackages).mockReturnValueOnce(0);
     const resultCode = executeActions(

--- a/eng/tools/ci-runner/test/actions.spec.js
+++ b/eng/tools/ci-runner/test/actions.spec.js
@@ -127,6 +127,30 @@ describe("executeActions", () => {
     errorSpy.mockRestore();
   });
 
+  it("should report actionable remediation when updating snippets fails", () => {
+    vi.mocked(spawnPnpmRun).mockReturnValueOnce(1);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const resultCode = executeActions(
+      "update-snippets",
+      ["storage"],
+      [],
+      "azure-storage-file-datalake",
+    );
+
+    assert.strictEqual(resultCode, 1);
+    assert.ok(
+      errorSpy.mock.calls.some((call) =>
+        String(call[0])
+          .replaceAll("\\", "/")
+          .includes(
+            'Snippet update failed in sdk/storage/storage-file-datalake. Run "pnpm update-snippets"',
+          ),
+      ),
+    );
+    errorSpy.mockRestore();
+  });
+
   it("should route check-package-version to verifyPackages function", () => {
     vi.mocked(verifyPackages).mockReturnValueOnce(0);
     const resultCode = executeActions(

--- a/eng/tools/ci-runner/test/actions.spec.js
+++ b/eng/tools/ci-runner/test/actions.spec.js
@@ -127,30 +127,6 @@ describe("executeActions", () => {
     errorSpy.mockRestore();
   });
 
-  it("should report actionable remediation when updating snippets fails", () => {
-    vi.mocked(spawnPnpmRun).mockReturnValueOnce(1);
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const resultCode = executeActions(
-      "update-snippets",
-      ["storage"],
-      [],
-      "azure-storage-file-datalake",
-    );
-
-    assert.strictEqual(resultCode, 1);
-    assert.ok(
-      errorSpy.mock.calls.some((call) =>
-        String(call[0])
-          .replaceAll("\\", "/")
-          .includes(
-            'Snippet update failed in sdk/storage/storage-file-datalake. Run "pnpm update-snippets"',
-          ),
-      ),
-    );
-    errorSpy.mockRestore();
-  });
-
   it("should route check-package-version to verifyPackages function", () => {
     vi.mocked(verifyPackages).mockReturnValueOnce(0);
     const resultCode = executeActions(

--- a/eng/tools/ci-runner/test/actions.spec.js
+++ b/eng/tools/ci-runner/test/actions.spec.js
@@ -3,7 +3,7 @@
 
 // @ts-check
 
-import { afterEach, assert, describe, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { executeActions } from "../src/actions.js";
 import { spawnPnpmRun, spawnPnpm } from "../src/spawn.js";
 import { verifyPackages } from "../src/verifyPackages.js";
@@ -26,8 +26,13 @@ vi.mock("../src/verifyPackages.js", async () => {
 });
 
 describe("executeActions", () => {
+  beforeEach(() => {
+    vi.stubEnv("TF_BUILD", "");
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("should pass global actions directly to", () => {

--- a/eng/tools/ci-runner/test/runner.spec.js
+++ b/eng/tools/ci-runner/test/runner.spec.js
@@ -3,7 +3,7 @@
 
 // @ts-check
 
-import { afterEach, assert, describe, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { join as pathJoin } from "node:path";
 import { getBaseDir } from "../src/env.js";
 import { runAllWithDirection, runInPackageDirs } from "../src/runner.js";
@@ -237,6 +237,10 @@ describe("runAllWithDirection two-pass resolution", () => {
 });
 
 describe("runInPackageDirs failure reporting", () => {
+  beforeEach(() => {
+    vi.stubEnv("TF_BUILD", "");
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();

--- a/eng/tools/ci-runner/test/runner.spec.js
+++ b/eng/tools/ci-runner/test/runner.spec.js
@@ -4,8 +4,10 @@
 // @ts-check
 
 import { afterEach, assert, describe, it, vi } from "vitest";
-import { runAllWithDirection } from "../src/runner.js";
-import { spawnPnpm, spawnPnpmWithOutput } from "../src/spawn.js";
+import { join as pathJoin } from "node:path";
+import { getBaseDir } from "../src/env.js";
+import { runAllWithDirection, runInPackageDirs } from "../src/runner.js";
+import { spawnPnpm, spawnPnpmRun, spawnPnpmWithOutput } from "../src/spawn.js";
 
 vi.mock("../src/spawn.js", async () => {
   return {
@@ -22,6 +24,7 @@ vi.mock("../src/testProxyRestore.js", async () => {
 describe("runAllWithDirection two-pass resolution", () => {
   afterEach(() => {
     vi.resetAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("should use direct filters when command is short", () => {
@@ -230,5 +233,47 @@ describe("runAllWithDirection two-pass resolution", () => {
     const filterIdx = testCall.indexOf("@azure/app-configuration");
     const paramIdx = testCall.indexOf("--concurrency=1");
     assert.ok(paramIdx > filterIdx, "extra params should come after filters");
+  });
+});
+
+describe("runInPackageDirs failure reporting", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("publishes an actionable Azure Pipelines issue for a failed package command", () => {
+    vi.stubEnv("TF_BUILD", "True");
+    vi.mocked(spawnPnpmRun).mockReturnValueOnce(1);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = runInPackageDirs(
+      "check-format",
+      ["sdk/storage/storage-file-datalake"],
+      () => 'Formatting failed 100%.\nRun "pnpm format".',
+    );
+
+    assert.strictEqual(result, 1);
+    assert.deepStrictEqual(errorSpy.mock.calls, [['Formatting failed 100%.\nRun "pnpm format".']]);
+    assert.ok(
+      logSpy.mock.calls.some(
+        (call) =>
+          call[0] ===
+          '##vso[task.logissue type=error]Formatting failed 100%AZP25.%0ARun "pnpm format".',
+      ),
+    );
+  });
+
+  it("reports the command, exit code, and directory when no specialized message is provided", () => {
+    vi.mocked(spawnPnpmRun).mockReturnValueOnce(2);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = runInPackageDirs("lint", [pathJoin(getBaseDir(), "sdk/storage/storage-blob")]);
+
+    assert.strictEqual(result, 2);
+    assert.deepStrictEqual(errorSpy.mock.calls, [
+      ['Command "pnpm run lint" failed with exit code 2 in sdk/storage/storage-blob.'],
+    ]);
   });
 });

--- a/eng/tools/ci-runner/test/verifyPackages.spec.js
+++ b/eng/tools/ci-runner/test/verifyPackages.spec.js
@@ -309,6 +309,8 @@ describe("filterRelevantFiles", () => {
 describe("verifyPackages", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("returns 0 when version is not published (new version)", () => {
@@ -379,6 +381,9 @@ describe("verifyPackages", () => {
   });
 
   it("returns 1 when version is published and files ARE modified", () => {
+    vi.stubEnv("TF_BUILD", "True");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.mocked(fs.default.existsSync).mockReturnValueOnce(true);
     vi.mocked(fs.default.readFileSync).mockReturnValueOnce(
       JSON.stringify({ name: "@azure/storage-blob", version: "1.2.3" }),
@@ -399,6 +404,20 @@ describe("verifyPackages", () => {
 
     const result = verifyPackages(["@azure/storage-blob"], ["/repo/sdk/storage/storage-blob"]);
     assert.strictEqual(result, 1);
+    assert.ok(
+      errorSpy.mock.calls.some(
+        (call) =>
+          call[0] ===
+          'Package version check failed for @azure/storage-blob@1.2.3: source files changed after published tag "@azure/storage-blob_1.2.3". Run "npx dev-tool package increment-version" from sdk/storage/storage-blob and commit the resulting changes.',
+      ),
+    );
+    assert.ok(
+      logSpy.mock.calls.some(
+        (call) =>
+          call[0] ===
+          '##vso[task.logissue type=error]Package version check failed for @azure/storage-blob@1.2.3: source files changed after published tag "@azure/storage-blob_1.2.3". Run "npx dev-tool package increment-version" from sdk/storage/storage-blob and commit the resulting changes.',
+      ),
+    );
   });
 
   it("handles multiple packages with mixed pass/fail", () => {


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng):

## Problem

When `Build Analyze` checks fail, the associated GitHub check often shows only:

```
PowerShell exited with code '1'.
```

...even though the Azure DevOps log contains useful detail — which package failed and how to fix it. Examples include [formatting build 6689138](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6689138&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=41ebd71b-51d6-5ceb-9733-d7c7221dc8b4) and [package-version build 6693023](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6693023&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=283a2759-1081-5133-7b39-658b88b0d06a).

**Root cause:** Azure Pipelines forwards only *timeline issues* to the associated GitHub check run. Timeline issues come from `##vso[task.logissue ...]` logging commands (or the task's own terminal error). Plain stdout/stderr is written to the build log but never reaches GitHub. The useful diagnostics were never emitted as timeline issues, so they could not propagate.

Confirmed empirically: each failing task's timeline record had exactly one issue (`PowerShell exited with code '1'`, source `TaskInternal`).

## Fix

### Shared reporting

Added `eng/tools/ci-runner/src/reporting.js` with a `reportFailure(message)` helper. It always writes to stderr and additionally emits `##vso[task.logissue type=error]<message>` when `TF_BUILD` is set. The guard keeps Azure Pipelines control strings out of local developer terminals.

Escaping follows the documented Azure Pipelines rules — `%` → `%AZP25` **first**, then `\r` → `%0D` and `\n` → `%0A`. Order matters; escaping `%` last would corrupt the `%0D`/`%0A` sequences. This matches the existing pattern in `eng/common/scripts/logging.ps1`.

### Per-package command failures

Changed `runInPackageDirs(action, packageDirs, onError)` to `runInPackageDirs(action, packageDirs, getFailureMessage)`. The third parameter now *returns* a message `(dir, exitCode) => string` rather than logging as a side effect, so reporting mechanics live in the runner and actions only own the semantic message.

`check-format` supplies an actionable message naming the package and directing contributors to run `pnpm format` and commit the changes. `lint`, `pack`, and genuine `update-snippets` command failures receive a generic annotation naming the action, exit code, and package.

### Stale generated snippets

The `update-snippets` command normally succeeds and updates documentation; the subsequent **Check snippet changes** step is what fails when those generated changes were not committed. `eng/tools/check-snippet-changes.ps1` now:

- derives the affected `sdk/<service>/<package>` directories from the generated diff;
- emits one Azure Pipelines timeline issue listing those packages; and
- tells contributors to run `pnpm update-snippets` from the listed package directories and commit the resulting changes.

This keeps the actionable snippet remediation on the step that detects stale generated output.

### Package-version validation

`check-package-version` bypasses `runInPackageDirs`, so its failures now call the shared reporter directly. When a published package has source changes, GitHub receives the package name, current version, published tag, package directory, and the `npx dev-tool package increment-version` remediation. Missing `package.json` and tag/diff failures are promoted too.

The detailed changed-file list remains in the Azure DevOps log; the GitHub annotation stays concise and package-scoped.

## Before / after

Before:

```
PowerShell exited with code '1'.
```

After (`check-format`):

```
Formatting check failed in sdk/storage/storage-file-datalake. Run "pnpm format" from that directory and commit the resulting changes.
```

After (`Check snippet changes`):

```
Generated snippets are out of date in sdk/storage/storage-blob. Run "pnpm update-snippets" from that package directory and commit the resulting changes.
```

After (`check-package-version`):

```
Package version check failed for @azure/storage-common@12.5.0: source files changed after published tag "@azure/storage-common_12.5.0". Run "npx dev-tool package increment-version" from sdk/storage/storage-common and commit the resulting changes.
```

## Known limitations (deliberate scope choice)

- GitHub annotations are package-scoped rather than listing every affected source file. Forwarding real child-process output would require changing `spawnWithLog`'s `stdio: "inherit"` to piped capture, which is a materially larger change. Package-level location was judged sufficient here.
- `runInPackageDirs` does not short-circuit, so a repo-wide regression could emit one annotation per failing package. Worth revisiting with aggregation/capping if that becomes a problem in practice.
- The pre-existing `##[error]PowerShell exited with code '1'` annotation still fires; this adds signal alongside it rather than replacing it.

## Validation

From `eng/tools/ci-runner`: 66 tests pass, `tsc` clean, `eslint` clean, and Prettier clean. Regression coverage includes specialized formatting and package-version messages, the generic default message, and exact Azure Pipelines logging-command escaping.

The snippet drift path was exercised in a temporary Git repository with `TF_BUILD` set, confirming that it exits non-zero and emits the expected package-scoped `task.logissue` annotation.

## Note for reviewers (unrelated, pre-existing)

`eng/tools/ci-runner/eslint.config.mjs` imports `globals`, but `package.json` never declares it, so `pnpm run lint` fails on a clean checkout with `Cannot find package 'globals'`. Not fixed here to keep the diff focused.