### PR TITLE
Docs: remove maxPageSize from core-paging README examples

### DIFF
--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.7.1 (Unreleased)
+
+### Other Changes
+
+- Document pagination best practices on `PageSettings` and remove `maxPageSize` from the README paging examples.
+
 ## 1.7.0 (2026-07-13)
 
 ### Other Changes

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -43,12 +43,12 @@ for await (const page of listSecrets().byPage()) {
 
 And using the types:
 
-```
-  for await (let page of client.listSecrets().byPage()) {
-    for (const secret of page) {
-      console.log("secret: ", secret);
-    }
+```typescript snippet:ReadmePagingUsageSample
+for await (const page of client.listSecrets().byPage()) {
+  for (const secret of page) {
+    console.log("secret: ", secret);
   }
+}
 ```
 
 ## Next steps

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -34,7 +34,7 @@ function listSecrets(
   };
 }
 
-for await (const page of listSecrets().byPage({ maxPageSize: 2 })) {
+for await (const page of listSecrets().byPage()) {
   for (const secret of page) {
     console.log("secret: ", secret);
   }
@@ -44,7 +44,7 @@ for await (const page of listSecrets().byPage({ maxPageSize: 2 })) {
 And using the types:
 
 ```
-  for await (let page of client.listSecrets().byPage({ maxPageSize: 2 })) {
+  for await (let page of client.listSecrets().byPage()) {
     for (const secret of page) {
       console.log("secret: ", secret);
     }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-paging",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Core types for paging async iterable iterators",
   "type": "module",
   "main": "./dist/commonjs/index.js",

--- a/sdk/core/core-paging/src/models.ts
+++ b/sdk/core/core-paging/src/models.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 /**
- * An interface that tracks the settings for paged iteration
+ * An interface that tracks the settings for paged iteration.
+ *
+ * See the {@link https://azure.github.io/azure-sdk/typescript_design.html#ts-pagination | pagination best practices}
+ * for guidance on page size and related options.
  */
 export interface PageSettings {
   /**

--- a/sdk/core/core-paging/test/snippets.spec.ts
+++ b/sdk/core/core-paging/test/snippets.spec.ts
@@ -15,6 +15,21 @@ function listSecretsPage(
 ): AsyncIterableIterator<SecretAttributes[]> {
   throw "stub";
 }
+function listSecrets(
+  options: ListSecretsOptions = {},
+): PagedAsyncIterableIterator<SecretAttributes> {
+  const iter = listSecretsAll(options);
+  return {
+    async next() {
+      return iter.next();
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    byPage: (settings: PageSettings = {}) => listSecretsPage(settings, options),
+  };
+}
+const client = { listSecrets };
 
 describe("snippets", () => {
   it("ReadmePagingSample", async () => {
@@ -34,6 +49,14 @@ describe("snippets", () => {
     }
     // @ts-preserve-whitespace
     for await (const page of listSecrets().byPage()) {
+      for (const secret of page) {
+        console.log("secret: ", secret);
+      }
+    }
+  });
+
+  it("ReadmePagingUsageSample", async () => {
+    for await (const page of client.listSecrets().byPage()) {
       for (const secret of page) {
         console.log("secret: ", secret);
       }

--- a/sdk/core/core-paging/test/snippets.spec.ts
+++ b/sdk/core/core-paging/test/snippets.spec.ts
@@ -33,7 +33,7 @@ describe("snippets", () => {
       };
     }
     // @ts-preserve-whitespace
-    for await (const page of listSecrets().byPage({ maxPageSize: 2 })) {
+    for await (const page of listSecrets().byPage()) {
       for (const secret of page) {
         console.log("secret: ", secret);
       }


### PR DESCRIPTION
## Summary
Fixes #34970

Removes `maxPageSize` from the `@azure/core-paging` README paging examples so they match current pagination guidance. Updates the matching snippet test to keep the README sample in sync.

## Test plan
* [ ] Confirm README examples call `byPage()` without `maxPageSize`
* [ ] Confirm `test/snippets.spec.ts` matches the README snippet