### PR TITLE
Update README CLA link to opensource.microsoft.com/cla

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 For details on contributing to this repository, see the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/main/CONTRIBUTING.md).
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit
-<https://cla.microsoft.com>.
+<https://opensource.microsoft.com/cla>.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 


### PR DESCRIPTION
## Summary
Updates the contributing CLA link in the root README from `https://cla.microsoft.com` to `https://opensource.microsoft.com/cla`, which is the canonical destination.

Fixes #36792

## Test plan
- [x] Confirmed the README now points at `https://opensource.microsoft.com/cla`
- [ ] Spot check the link opens the Microsoft CLA page