### PR TITLE
[App Configuration] Fix user agent prefix ordering

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fixed a regression introduced in 1.12.0 that placed the App Configuration SDK identifier before
+  custom User-Agent prefixes.
+
 ### Other Changes
 
 ## 1.12.1 (2026-06-22)

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed a regression introduced in 1.12.0 that placed the App Configuration SDK identifier before
-  custom User-Agent prefixes.
+- Fixed a bug that placed the App Configuration SDK identifier before custom User-Agent prefixes.
 
 ### Other Changes
 

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -188,11 +188,9 @@ export class AppConfigurationClient {
       ...appConfigOptions,
       userAgentOptions: {
         ...appConfigOptions.userAgentOptions,
-        userAgentPrefix: `azsdk-js-app-configuration/${packageVersion}${
-          appConfigOptions.userAgentOptions?.userAgentPrefix
-            ? ` ${appConfigOptions.userAgentOptions.userAgentPrefix}`
-            : ""
-        }`,
+        userAgentPrefix: appConfigOptions.userAgentOptions?.userAgentPrefix
+          ? `${appConfigOptions.userAgentOptions.userAgentPrefix} azsdk-js-app-configuration/${packageVersion}`
+          : `azsdk-js-app-configuration/${packageVersion}`,
       },
       loggingOptions: {
         logger: logger.info,

--- a/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/package.spec.ts
@@ -8,7 +8,8 @@ import { describe, it, assert } from "vitest";
 describe("packagejson related tests", () => {
   // if this test is failing you need to update the contant `packageVersion` referenced above
   // in the generated code.
-  it("user agent string matches the package version", async () => {
+  it("user agent string preserves a custom prefix and matches the package version", async () => {
+    const customUserAgentPrefix = "custom-user-agent/1.0.0";
     let userAgent: string | undefined;
     const client = new AppConfigurationClient(
       "https://myresource.azconfig.io",
@@ -21,6 +22,7 @@ describe("packagejson related tests", () => {
         },
       } as TokenCredential,
       {
+        userAgentOptions: { userAgentPrefix: customUserAgentPrefix },
         httpClient: {
           sendRequest: async (request) => {
             userAgent = request.headers.get("user-agent") ?? request.headers.get("x-ms-useragent");
@@ -36,6 +38,11 @@ describe("packagejson related tests", () => {
       // no-op, we don't care about the response, only the user-agent header
     }
     assert.exists(userAgent, "Expected a User-Agent header to be sent");
-    assert.include(userAgent!, `azsdk-js-app-configuration/${packageVersion}`);
+    assert.isTrue(
+      userAgent!.startsWith(
+        `${customUserAgentPrefix} azsdk-js-app-configuration/${packageVersion} `,
+      ),
+      "Expected the custom User-Agent prefix before the App Configuration SDK identifier",
+    );
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/app-configuration

### Describe the problem that is addressed by this PR

Starting with @azure/app-configuration 1.12.0, the SDK began placing its own identifier before a caller-provided custom User-Agent prefix:

Previously, and consistently with other Azure JavaScript SDKs, the custom prefix appeared first:

This regression causes telemetry systems that classify requests using the first User-Agent product token to report JavaScript Provider traffic as direct JavaScript SDK traffic. 

