### PR TITLE
Use @Azure/azure-sdk-for-js-core team as codeowner for orphaned paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # Orphaned paths
 ################
 
-/** @xirzec @jeremymeng @maorleger @Azure/azure-sdk-eng
+/** @Azure/azure-sdk-for-js-core @Azure/azure-sdk-eng
 
 ################
 # Misc.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # Orphaned paths
 ################
 
-/** @xirzec @jeremymeng @Azure/azure-sdk-eng
+/** @xirzec @jeremymeng @maorleger @Azure/azure-sdk-eng
 
 ################
 # Misc.


### PR DESCRIPTION
Replaces the individual usernames on the `/**` orphaned-paths entry in `.github/CODEOWNERS` with the [`@Azure/azure-sdk-for-js-core`](https://github.com/orgs/Azure/teams/azure-sdk-for-js-core) team.

```diff
-/** @xirzec @jeremymeng @Azure/azure-sdk-eng
+/** @Azure/azure-sdk-for-js-core @Azure/azure-sdk-eng
```

The team already contains the right set of central owners, so this keeps membership in one place instead of having to edit this file every time the core team changes. Review requests for orphaned/default paths now round-robin across the team rather than always pinging the same two people.