### PR TITLE
[ContentUnderstanding] Stamp release date on 1.2.0-beta.3 CHANGELOG

### DIFF
--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0-beta.3 (Unreleased)
+## 1.2.0-beta.3 (2026-08-13)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/ai-content-understanding` (`sdk/contentunderstanding/ai-content-understanding/`)

### Describe the problem that is addressed by this PR

Follow-up to #39589 (merged as commit `2fac849`). The CHANGELOG header for the `1.2.0-beta.3` release still reads `(Unreleased)`. Update to `(2026-08-13)` so the released package's CHANGELOG shows the actual publish date instead of the placeholder.

### Command used to generate this PR

Manual edit \u2014 single-line change to `CHANGELOG.md`.

### Checklists

- [x] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator? \u2014 no.
- [x] Added a changelog (if necessary) \u2014 this **is** the changelog update.