### PR TITLE
[storage-datalake] fix issue where FileAppendOptions.transactionalContentMD5 doesn't work

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31491,8 +31491,8 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       '@azure/storage-blob':
-        specifier: 12.34.0-beta.1
-        version: 12.34.0-beta.1
+        specifier: 12.34.0-beta.2
+        version: link:../storage-blob
       '@azure/storage-common':
         specifier: ^12.5.0
         version: link:../storage-common
@@ -35967,10 +35967,6 @@ packages:
 
   '@azure/storage-blob@12.33.0':
     resolution: {integrity: sha1-EK1FhvSSJzG4t5zIa+ytp1Z6H6s=}
-    engines: {node: '>=22.0.0'}
-
-  '@azure/storage-blob@12.34.0-beta.1':
-    resolution: {integrity: sha1-0gVTr+tAG/GHgwVtQNNeInQSE8A=}
     engines: {node: '>=22.0.0'}
 
   '@azure/storage-common@12.5.0':
@@ -42608,26 +42604,6 @@ snapshots:
       '@azure/core-xml': 1.6.0
       '@azure/logger': 1.4.0
       '@azure/storage-common': 12.5.0(@azure/core-client@1.11.0)
-      events: 3.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/storage-blob@12.34.0-beta.1':
-    dependencies:
-      '@azure/abort-controller': 2.2.0
-      '@azure/core-auth': 1.11.0
-      '@azure/core-client': 1.11.0
-      '@azure/core-http-compat': 2.5.0(@azure/core-client@1.11.0)(@azure/core-rest-pipeline@sdk+core+core-rest-pipeline)
-      '@azure/core-lro': 2.7.2
-      '@azure/core-paging': 1.7.0
-      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
-      '@azure/core-tracing': 1.4.0
-      '@azure/core-util': 1.14.0
-      '@azure/core-xml': 1.6.0
-      '@azure/logger': 1.4.0
-      '@azure/storage-common': 12.5.0(@azure/core-client@1.11.0)
-      apache-arrow: 21.2.0
       events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:

--- a/sdk/storage/storage-file-datalake/assets.json
+++ b/sdk/storage/storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/storage/storage-file-datalake",
-  "Tag": "js/storage/storage-file-datalake_019badd8c8"
+  "Tag": "js/storage/storage-file-datalake_9a893b5784"
 }

--- a/sdk/storage/storage-file-datalake/assets.json
+++ b/sdk/storage/storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/storage/storage-file-datalake",
-  "Tag": "js/storage/storage-file-datalake_89a68d62cc"
+  "Tag": "js/storage/storage-file-datalake_019badd8c8"
 }

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -96,7 +96,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/core-xml": "^1.4.3",
     "@azure/logger": "^1.1.4",
-    "@azure/storage-blob": "12.34.0-beta.1",
+    "@azure/storage-blob": "12.34.0-beta.2",
     "@azure/storage-common": "^12.5.0",
     "events": "^3.3.0",
     "tslib": "^2.8.1"

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -759,7 +759,7 @@ export async function setUploadChecksumParameters(
   if (contentChecksumAlgorithm === "Customized") {
     if (parameters.pathHttpHeaders === undefined) {
       parameters.pathHttpHeaders = {
-        contentMD5: uploadOptions.transactionalContentMD5,
+        transactionalContentHash: uploadOptions.transactionalContentMD5,
       };
     } else {
       parameters.pathHttpHeaders.transactionalContentHash = uploadOptions.transactionalContentMD5;

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -1408,6 +1408,31 @@ describe("DataLakePathClient", () => {
     await tempFileClient.delete();
   });
 
+  it("append with incorrect MD5 should fail", async () => {
+    const body = "HelloWorld";
+    const bodyMD5 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    const tempFileName = recorder.variable("tempfile3", getUniqueName("tempfile3"));
+    const tempFileClient = fileSystemClient.getFileClient(tempFileName);
+
+    await tempFileClient.create();
+    try {
+      await tempFileClient.append(body, 0, body.length, {
+        transactionalContentMD5: bodyMD5,
+      });
+      assert.fail("Appending with incorrect MD5 should fail.");
+    } catch (error) {
+      assert.include(
+        (error as any).message,
+        "The MD5 value specified in the request did not match with the MD5 value calculated by the server",
+      );
+    }
+
+    const properties = await tempFileClient.getProperties();
+    assert.deepStrictEqual(properties.contentLength, 0);
+
+    await tempFileClient.delete();
+  });
+
   it("exists returns true on an existing file", async () => {
     const result = await fileClient.exists();
     assert.isTrue(result, "exists() should return true for an existing file");

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -1272,20 +1272,22 @@ describe("DataLakePathClient", () => {
 
   it("append with flush should work", async () => {
     const body = "HelloWorld";
-
+    const bodyMD5 = new Uint8Array([
+      104, 225, 9, 240, 244, 12, 167, 42, 21, 224, 92, 194, 39, 134, 248, 230,
+    ]);
     const tempFileName = recorder.variable("tempfile2", getUniqueName("tempfile2"));
     const tempFileClient = fileSystemClient.getFileClient(tempFileName);
 
     await tempFileClient.create();
 
     await tempFileClient.append(body, 0, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length * 2, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
       flush: true,
     });
 
@@ -1297,6 +1299,9 @@ describe("DataLakePathClient", () => {
 
   it("append & flush should work", async () => {
     const body = "HelloWorld";
+    const bodyMD5 = new Uint8Array([
+      104, 225, 9, 240, 244, 12, 167, 42, 21, 224, 92, 194, 39, 134, 248, 230,
+    ]);
 
     const tempFileName = recorder.variable("tempfile2", getUniqueName("tempfile2"));
     const tempFileClient = fileSystemClient.getFileClient(tempFileName);
@@ -1304,13 +1309,13 @@ describe("DataLakePathClient", () => {
     await tempFileClient.create();
 
     await tempFileClient.append(body, 0, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length * 2, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
 
     await tempFileClient.flush(body.length * 3);
@@ -1323,6 +1328,9 @@ describe("DataLakePathClient", () => {
 
   it("append & flush should work with all parameters", async () => {
     const body = "HelloWorld";
+    const bodyMD5 = new Uint8Array([
+      104, 225, 9, 240, 244, 12, 167, 42, 21, 224, 92, 194, 39, 134, 248, 230,
+    ]);
 
     const tempFileName = recorder.variable("tempfile2", getUniqueName("tempfile2"));
     const tempFileClient = fileSystemClient.getFileClient(tempFileName);
@@ -1366,13 +1374,13 @@ describe("DataLakePathClient", () => {
     assert.deepStrictEqual(acl.permissions, permissions);
 
     await tempFileClient.append(body, 0, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
     await tempFileClient.append(body, body.length * 2, body.length, {
-      transactionalContentMD5: new Uint8Array([]),
+      transactionalContentMD5: bodyMD5,
     });
 
     pathHttpHeaders = {


### PR DESCRIPTION
The generated code expected the value to be passed via "options.pathHttpHeaders.transactionalContentHash`: https://github.com/Azure/azure-sdk-for-js/blob/61762a8e7c15ebf4e2e2bec32fff7d1f297add1a/sdk/storage/storage-file-datalake/src/generated/src/models/parameters.ts#L988

However, in some case we are not setting it correctly: https://github.com/Azure/azure-sdk-for-js/blob/61762a8e7c15ebf4e2e2bec32fff7d1f297add1a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts#L760-L764

This PR fixes the issue by setting the expected property properly, and update tests to send real MD5 bytes.  Test recordings have been updated too.
