### PR TITLE
Add typed OneSettings feature evaluation

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Other Changes
 
 - Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. Requests honor the standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY`). This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
-- Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve a feature's enabled state from its default and override rules. This is groundwork with no user-facing behavior yet. [#39502](https://github.com/Azure/azure-sdk-for-js/pull/39502)
+- Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve typed setting values from defaults and override rules, including JSON-encoded configurations and list-valued conditions. This is groundwork with no user-facing behavior yet. [#39502](https://github.com/Azure/azure-sdk-for-js/pull/39502)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Other Changes
 
 - Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. Requests honor the standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY`). This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
-- Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve typed setting values from defaults and override rules, including JSON-encoded configurations and list-valued conditions. This is groundwork with no user-facing behavior yet. [#39502](https://github.com/Azure/azure-sdk-for-js/pull/39502)
+- Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve typed setting values from defaults and override rules, including JSON-encoded configurations and list-valued conditions. This is groundwork with no user-facing behavior yet. [#39617](https://github.com/Azure/azure-sdk-for-js/pull/39617)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 - Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. Requests honor the standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY`). This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
+- Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve a feature's enabled state from its default and override rules. This is groundwork with no user-facing behavior yet. [#39502](https://github.com/Azure/azure-sdk-for-js/pull/39502)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationProfile.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationProfile.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Attributes describing the running SDK, matched against OneSettings feature override rules to
+ * decide whether a feature is enabled for this process. Every field defaults to an empty string
+ * until populated via {@link ConfigurationProfile.fill}.
+ * @internal
+ */
+export interface ConfigurationProfileValues {
+  /** Operating system, e.g. `windows`, `linux`, `darwin`. */
+  os: string;
+  /** Resource provider, e.g. `appsvc`, `fn`, `aks`. */
+  rp: string;
+  /** Attach type, e.g. `manual`, `integratedauto`. */
+  attach: string;
+  /** SDK version string, e.g. `1.0.0-beta.45`. */
+  version: string;
+  /** Component type: `dst` (distro), `ext` (exporter), or `mot` (Microsoft distro). */
+  component: string;
+  /** Azure region, e.g. `eastus`. */
+  region: string;
+  /** Instrumentation key (GUID). */
+  ikey: string;
+}
+
+function emptyProfile(): ConfigurationProfileValues {
+  return { os: "", rp: "", attach: "", version: "", component: "", region: "", ikey: "" };
+}
+
+/**
+ * Process-wide, write-once profile of the running SDK.
+ *
+ * {@link ConfigurationProfile.fill} sets each field only the first time it is provided, so the
+ * first component to initialize (distro or exporter) wins and later initializers cannot clobber an
+ * already-established value. The profile is read by OneSettings feature evaluation. Use
+ * {@link ConfigurationProfile.getInstance} rather than constructing this directly.
+ * @internal
+ */
+export class ConfigurationProfile {
+  private static instance: ConfigurationProfile | undefined;
+  private values: ConfigurationProfileValues = emptyProfile();
+
+  /**
+   * Use {@link ConfigurationProfile.getInstance} to obtain the singleton instance.
+   */
+  private constructor() {}
+
+  /**
+   * Return the process-wide singleton, creating it on first use.
+   */
+  public static getInstance(): ConfigurationProfile {
+    if (!ConfigurationProfile.instance) {
+      ConfigurationProfile.instance = new ConfigurationProfile();
+    }
+    return ConfigurationProfile.instance;
+  }
+
+  /**
+   * Set profile fields that have not been set yet. Fields already holding a non-empty value, and
+   * fields omitted from `values`, are left unchanged so the first writer wins.
+   */
+  public fill(values: Partial<ConfigurationProfileValues>): void {
+    for (const key of Object.keys(this.values) as (keyof ConfigurationProfileValues)[]) {
+      const incoming = values[key];
+      if (incoming !== undefined && this.values[key] === "") {
+        this.values[key] = incoming;
+      }
+    }
+  }
+
+  /**
+   * Return a read-only snapshot of the current profile values.
+   */
+  public snapshot(): Readonly<ConfigurationProfileValues> {
+    return { ...this.values };
+  }
+
+  /**
+   * Reset every field to its empty default. Primarily intended for tests that need to establish a
+   * known profile, since {@link ConfigurationProfile.fill} otherwise never overwrites a set value.
+   */
+  public reset(): void {
+    this.values = emptyProfile();
+  }
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
@@ -1,56 +1,143 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { diag } from "@opentelemetry/api";
 import type { ConfigurationProfileValues } from "./configurationProfile.js";
 import { ConfigurationProfile } from "./configurationProfile.js";
 
+interface OverrideRule {
+  conditions: Record<string, unknown>;
+  value?: string;
+}
+
+interface FeatureConfig {
+  defaultValue: string;
+  overrides: OverrideRule[];
+}
+
+type ValueConverter<T> = (value: string) => T;
+
 /**
- * Determine whether a feature should be enabled from a OneSettings settings payload and the
- * process-wide {@link ConfigurationProfile}.
+ * Evaluate a setting from a OneSettings payload and the process-wide {@link ConfigurationProfile}.
  *
- * Each feature entry has a `default` state (`enabled`/`disabled`) and an optional `override` list.
- * Every override rule is an independent set of conditions; if all conditions of any single rule
- * match the current profile, the feature's state is flipped from its default. If no rule matches,
- * the default is returned.
+ * Each feature entry has a string `default` and an optional `override` list. A matching override
+ * can provide its own string `value`. Legacy `enabled`/`disabled` values are converted to booleans,
+ * while other values are preserved or converted by `valueConverter`.
  *
- * @param featureKey - The feature name to evaluate, e.g. `FEATURE_SDK_STATS`.
+ * @param featureKey - The setting name to evaluate, e.g. `FEATURE_SDK_STATS`.
  * @param settings - The `settings` object from a OneSettings response.
- * @returns `true` or `false` for the resolved state, or `undefined` when the inputs are invalid or
- *   the feature is absent, so callers can distinguish "no opinion" from an explicit disable.
+ * @param valueConverter - Optional converter applied to the default or matching override value.
+ * @returns The evaluated value, or `undefined` when the input or conversion is invalid.
  * @internal
  */
+export function evaluateFeature<T>(
+  featureKey: string,
+  settings: Record<string, unknown>,
+  valueConverter: ValueConverter<T>,
+): T | undefined;
 export function evaluateFeature(
   featureKey: string,
   settings: Record<string, unknown>,
-): boolean | undefined {
+): boolean | string | undefined;
+export function evaluateFeature<T>(
+  featureKey: string,
+  settings: Record<string, unknown>,
+  valueConverter?: ValueConverter<T>,
+): boolean | string | T | undefined {
   if (!featureKey || !isRecord(settings) || !Object.hasOwn(settings, featureKey)) {
     return undefined;
   }
 
-  const featureConfig = settings[featureKey];
-  if (!isRecord(featureConfig)) {
+  const featureConfig = parseFeatureConfig(settings[featureKey]);
+  if (!featureConfig) {
     return undefined;
   }
 
-  // Coerce with String() before comparing: the payload is only JSON-decoded, so a malformed
-  // "default" (e.g. a JSON boolean) would otherwise be compared as a non-string. A well-formed
-  // string is unchanged; anything else safely resolves to the default-disabled state.
-  const defaultState = String(featureConfig["default"] ?? "disabled").toLowerCase() === "enabled";
-
-  const overrideList = featureConfig["override"];
-  if (!Array.isArray(overrideList) || overrideList.length === 0) {
-    return defaultState;
-  }
+  const defaultValue = normalizeSettingValue(featureConfig.defaultValue, valueConverter);
 
   const profile = ConfigurationProfile.getInstance().snapshot();
-  for (const rule of overrideList) {
-    if (isRecord(rule) && matchesOverrideRule(rule, profile)) {
-      // A rule matched: flip the default state.
-      return !defaultState;
+  for (const rule of featureConfig.overrides) {
+    if (matchesOverrideRule(rule.conditions, profile)) {
+      if (rule.value !== undefined) {
+        const overrideValue = normalizeSettingValue(rule.value, valueConverter);
+        return overrideValue === undefined ? defaultValue : overrideValue;
+      }
+      if (typeof defaultValue === "boolean") {
+        return !defaultValue;
+      }
+      break;
     }
   }
 
-  return defaultState;
+  return defaultValue;
+}
+
+function parseFeatureConfig(rawConfig: unknown): FeatureConfig | undefined {
+  let config = rawConfig;
+  if (typeof config === "string") {
+    try {
+      config = JSON.parse(config);
+    } catch (error) {
+      diag.debug("Failed to parse OneSettings feature configuration:", error);
+      return undefined;
+    }
+  }
+
+  if (!isRecord(config) || typeof config["default"] !== "string") {
+    return undefined;
+  }
+
+  const rawOverrides = Array.isArray(config["override"]) ? config["override"] : [];
+  const overrides: OverrideRule[] = [];
+  for (const rawOverride of rawOverrides) {
+    const override = parseOverrideRule(rawOverride);
+    if (override) {
+      overrides.push(override);
+    }
+  }
+  return { defaultValue: config["default"], overrides };
+}
+
+function parseOverrideRule(rawRule: unknown): OverrideRule | undefined {
+  if (!isRecord(rawRule)) {
+    return undefined;
+  }
+
+  const conditions = Object.fromEntries(Object.entries(rawRule).filter(([key]) => key !== "value"));
+  if (Object.keys(conditions).length === 0) {
+    return undefined;
+  }
+
+  if (Object.hasOwn(rawRule, "value")) {
+    const value = rawRule["value"];
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    return { conditions, value };
+  }
+  return { conditions };
+}
+
+function normalizeSettingValue<T>(
+  value: string,
+  valueConverter?: ValueConverter<T>,
+): boolean | string | T | undefined {
+  if (valueConverter) {
+    try {
+      return valueConverter(value);
+    } catch (error) {
+      diag.debug("Failed to convert OneSettings value:", error);
+      return undefined;
+    }
+  }
+
+  if (value.toLowerCase() === "enabled") {
+    return true;
+  }
+  if (value.toLowerCase() === "disabled") {
+    return false;
+  }
+  return value;
 }
 
 /**
@@ -90,6 +177,9 @@ function matchesCondition(
 ): boolean {
   if (!key || value === null || value === undefined) {
     return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.some((candidate) => matchesCondition(key, candidate, profile));
   }
   const expected = String(value);
   switch (key) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ConfigurationProfileValues } from "./configurationProfile.js";
+import { ConfigurationProfile } from "./configurationProfile.js";
+
+/**
+ * Determine whether a feature should be enabled from a OneSettings settings payload and the
+ * process-wide {@link ConfigurationProfile}.
+ *
+ * Each feature entry has a `default` state (`enabled`/`disabled`) and an optional `override` list.
+ * Every override rule is an independent set of conditions; if all conditions of any single rule
+ * match the current profile, the feature's state is flipped from its default. If no rule matches,
+ * the default is returned.
+ *
+ * @param featureKey - The feature name to evaluate, e.g. `FEATURE_SDK_STATS`.
+ * @param settings - The `settings` object from a OneSettings response.
+ * @returns `true` or `false` for the resolved state, or `undefined` when the inputs are invalid or
+ *   the feature is absent, so callers can distinguish "no opinion" from an explicit disable.
+ * @internal
+ */
+export function evaluateFeature(
+  featureKey: string,
+  settings: Record<string, unknown>,
+): boolean | undefined {
+  if (!featureKey || !isRecord(settings) || !Object.hasOwn(settings, featureKey)) {
+    return undefined;
+  }
+
+  const featureConfig = settings[featureKey];
+  if (!isRecord(featureConfig)) {
+    return undefined;
+  }
+
+  // Coerce with String() before comparing: the payload is only JSON-decoded, so a malformed
+  // "default" (e.g. a JSON boolean) would otherwise be compared as a non-string. A well-formed
+  // string is unchanged; anything else safely resolves to the default-disabled state.
+  const defaultState = String(featureConfig["default"] ?? "disabled").toLowerCase() === "enabled";
+
+  const overrideList = featureConfig["override"];
+  if (!Array.isArray(overrideList) || overrideList.length === 0) {
+    return defaultState;
+  }
+
+  const profile = ConfigurationProfile.getInstance().snapshot();
+  for (const rule of overrideList) {
+    if (isRecord(rule) && matchesOverrideRule(rule, profile)) {
+      // A rule matched: flip the default state.
+      return !defaultState;
+    }
+  }
+
+  return defaultState;
+}
+
+/**
+ * Return true when every condition in a single override rule matches the profile.
+ *
+ * A `ver` condition is only honored when the rule also carries a `component` condition (per the
+ * OneSettings schema, `ver` requires `component`); a rule with `ver` but no `component` never
+ * matches. An empty rule never matches.
+ */
+function matchesOverrideRule(
+  rule: Record<string, unknown>,
+  profile: Readonly<ConfigurationProfileValues>,
+): boolean {
+  const keys = Object.keys(rule);
+  if (keys.length === 0) {
+    return false;
+  }
+  if ("ver" in rule && !("component" in rule)) {
+    return false;
+  }
+  for (const key of keys) {
+    if (!matchesCondition(key, rule[key], profile)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Return true when a single condition matches the profile. Unknown keys, empty keys, and
+ * null/undefined values never match. Matching is exact, and case-insensitive for `os` and `ikey`.
+ */
+function matchesCondition(
+  key: string,
+  value: unknown,
+  profile: Readonly<ConfigurationProfileValues>,
+): boolean {
+  if (!key || value === null || value === undefined) {
+    return false;
+  }
+  const expected = String(value);
+  switch (key) {
+    case "os":
+      return profile.os.toLowerCase() === expected.toLowerCase();
+    case "ver":
+      return profile.version === expected;
+    case "component":
+      return profile.component === expected;
+    case "rp":
+      return profile.rp === expected;
+    case "region":
+      return profile.region === expected;
+    case "attach":
+      return profile.attach === expected;
+    case "ikey":
+      return profile.ikey.toLowerCase() === expected.toLowerCase();
+    default:
+      return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
@@ -67,19 +67,90 @@ describe("OneSettings feature evaluation", () => {
   });
 
   describe("evaluateFeature", () => {
+    function parseInteger(value: string): number {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed)) {
+        throw new TypeError(`Expected an integer, received ${value}`);
+      }
+      return parsed;
+    }
+
     it("returns the default state when there are no overrides", () => {
       assert.strictEqual(evaluateFeature("F", { F: { default: "enabled" } }), true);
       assert.strictEqual(evaluateFeature("F", { F: { default: "disabled" } }), false);
     });
 
-    it("treats a missing or malformed default as disabled", () => {
-      assert.strictEqual(evaluateFeature("F", { F: {} }), false);
-      assert.strictEqual(evaluateFeature("F", { F: { default: true } }), false);
-      assert.strictEqual(evaluateFeature("F", { F: { default: null } }), false);
+    it("returns undefined for a missing or malformed default", () => {
+      assert.strictEqual(evaluateFeature("F", { F: {} }), undefined);
+      assert.strictEqual(evaluateFeature("F", { F: { default: true } }), undefined);
+      assert.strictEqual(evaluateFeature("F", { F: { default: null } }), undefined);
     });
 
     it("is case-insensitive on the default value", () => {
       assert.strictEqual(evaluateFeature("F", { F: { default: "ENABLED" } }), true);
+    });
+
+    it("preserves arbitrary string defaults without a converter", () => {
+      assert.strictEqual(evaluateFeature("INTERVAL", { INTERVAL: { default: "60" } }), "60");
+    });
+
+    it("converts arbitrary defaults to the requested type", () => {
+      assert.strictEqual(
+        evaluateFeature("INTERVAL", { INTERVAL: { default: "60" } }, parseInteger),
+        60,
+      );
+    });
+
+    it("returns an explicit value from a matching override", () => {
+      profile.fill({ rp: "fn", region: "westus" });
+      const settings = {
+        INTERVAL: {
+          default: "60",
+          override: [{ rp: ["aks", "fn"], region: ["eastus", "westus"], value: "300" }],
+        },
+      };
+      assert.strictEqual(evaluateFeature("INTERVAL", settings, parseInteger), 300);
+    });
+
+    it("falls back to the default when an override value cannot be converted", () => {
+      profile.fill({ os: "windows" });
+      const settings = {
+        INTERVAL: {
+          default: "60",
+          override: [{ os: ["windows"], value: "invalid" }],
+        },
+      };
+      assert.strictEqual(evaluateFeature("INTERVAL", settings, parseInteger), 60);
+    });
+
+    it("returns undefined when the default cannot be converted", () => {
+      assert.strictEqual(
+        evaluateFeature("INTERVAL", { INTERVAL: { default: "invalid" } }, parseInteger),
+        undefined,
+      );
+    });
+
+    it("normalizes explicit enabled and disabled override values", () => {
+      profile.fill({ os: "windows" });
+      const settings = {
+        F: { default: "enabled", override: [{ os: ["windows"], value: "disabled" }] },
+      };
+      assert.strictEqual(evaluateFeature("F", settings), false);
+    });
+
+    it("evaluates a JSON-encoded feature configuration", () => {
+      profile.fill({ os: "windows" });
+      const settings = {
+        INTERVAL: JSON.stringify({
+          default: "60",
+          override: [{ os: "windows", value: "300" }],
+        }),
+      };
+      assert.strictEqual(evaluateFeature("INTERVAL", settings, parseInteger), 300);
+    });
+
+    it("returns undefined for malformed JSON feature configuration", () => {
+      assert.strictEqual(evaluateFeature("F", { F: "not-json" }), undefined);
     });
 
     it("flips the default when an override rule matches", () => {
@@ -121,6 +192,11 @@ describe("OneSettings feature evaluation", () => {
       profile.fill({ os: "windows" });
       const settings = { F: { default: "disabled", override: { os: "windows" } } };
       assert.strictEqual(evaluateFeature("F", settings), false);
+    });
+
+    it("ignores an override containing only a value", () => {
+      const settings = { INTERVAL: { default: "60", override: [{ value: "300" }] } };
+      assert.strictEqual(evaluateFeature("INTERVAL", settings, parseInteger), 60);
     });
 
     it.each([
@@ -228,6 +304,12 @@ describe("OneSettings feature evaluation", () => {
 
     it("never matches a null condition value", () => {
       assert.isFalse(conditionMatches({ os: null }));
+    });
+
+    it("matches any candidate in a non-empty condition list", () => {
+      assert.isTrue(conditionMatches({ rp: ["aks", "fn"] }));
+      assert.isFalse(conditionMatches({ region: ["eastus", "centralus"] }));
+      assert.isFalse(conditionMatches({ region: [] }));
     });
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, assert, beforeEach, describe, it } from "vitest";
+import { ConfigurationProfile } from "../../src/_configuration/configurationProfile.js";
+import { evaluateFeature } from "../../src/_configuration/featureEvaluation.js";
+
+describe("OneSettings feature evaluation", () => {
+  const profile = ConfigurationProfile.getInstance();
+
+  afterEach(() => {
+    profile.reset();
+  });
+
+  describe("ConfigurationProfile", () => {
+    it("fills every field on an empty profile", () => {
+      profile.fill({
+        os: "windows",
+        rp: "fn",
+        attach: "manual",
+        version: "1.0.0",
+        component: "ext",
+        region: "westus",
+        ikey: "12345678-1234-1234-1234-123456789abc",
+      });
+
+      assert.deepStrictEqual(profile.snapshot(), {
+        os: "windows",
+        rp: "fn",
+        attach: "manual",
+        version: "1.0.0",
+        component: "ext",
+        region: "westus",
+        ikey: "12345678-1234-1234-1234-123456789abc",
+      });
+    });
+
+    it("leaves omitted fields empty when filling partially", () => {
+      profile.fill({ os: "linux", version: "2.0.0" });
+
+      const snapshot = profile.snapshot();
+      assert.strictEqual(snapshot.os, "linux");
+      assert.strictEqual(snapshot.version, "2.0.0");
+      assert.strictEqual(snapshot.rp, "");
+      assert.strictEqual(snapshot.attach, "");
+      assert.strictEqual(snapshot.component, "");
+      assert.strictEqual(snapshot.region, "");
+      assert.strictEqual(snapshot.ikey, "");
+    });
+
+    it("does not overwrite already-set fields but still sets new ones", () => {
+      profile.fill({ os: "windows", version: "1.0.0" });
+      profile.fill({ os: "linux", version: "2.0.0", rp: "fn" });
+
+      const snapshot = profile.snapshot();
+      assert.strictEqual(snapshot.os, "windows");
+      assert.strictEqual(snapshot.version, "1.0.0");
+      assert.strictEqual(snapshot.rp, "fn");
+    });
+
+    it("returns a snapshot that does not mutate internal state", () => {
+      profile.fill({ os: "windows" });
+      const snapshot = profile.snapshot();
+      (snapshot as { os: string }).os = "linux";
+      assert.strictEqual(profile.snapshot().os, "windows");
+    });
+  });
+
+  describe("evaluateFeature", () => {
+    it("returns the default state when there are no overrides", () => {
+      assert.strictEqual(evaluateFeature("F", { F: { default: "enabled" } }), true);
+      assert.strictEqual(evaluateFeature("F", { F: { default: "disabled" } }), false);
+    });
+
+    it("treats a missing or malformed default as disabled", () => {
+      assert.strictEqual(evaluateFeature("F", { F: {} }), false);
+      assert.strictEqual(evaluateFeature("F", { F: { default: true } }), false);
+      assert.strictEqual(evaluateFeature("F", { F: { default: null } }), false);
+    });
+
+    it("is case-insensitive on the default value", () => {
+      assert.strictEqual(evaluateFeature("F", { F: { default: "ENABLED" } }), true);
+    });
+
+    it("flips the default when an override rule matches", () => {
+      profile.fill({ os: "windows", component: "ext" });
+      const settings = {
+        F: { default: "disabled", override: [{ os: "windows", component: "ext" }] },
+      };
+      assert.strictEqual(evaluateFeature("F", settings), true);
+    });
+
+    it("keeps the default when no override rule matches", () => {
+      profile.fill({ os: "windows", component: "ext" });
+      const settings = {
+        F: { default: "enabled", override: [{ os: "linux", component: "dst" }] },
+      };
+      assert.strictEqual(evaluateFeature("F", settings), true);
+    });
+
+    it("flips the default as soon as any rule in the list matches", () => {
+      profile.fill({ os: "windows", component: "ext", rp: "fn" });
+      const settings = {
+        F: {
+          default: "disabled",
+          override: [{ os: "linux" }, { component: "ext", rp: "fn" }, { region: "eastus" }],
+        },
+      };
+      assert.strictEqual(evaluateFeature("F", settings), true);
+    });
+
+    it("ignores non-object override rules", () => {
+      profile.fill({ os: "windows" });
+      const settings = {
+        F: { default: "disabled", override: ["not-an-object", 5, null, { os: "windows" }] },
+      };
+      assert.strictEqual(evaluateFeature("F", settings), true);
+    });
+
+    it("returns the default when the override value is not an array", () => {
+      profile.fill({ os: "windows" });
+      const settings = { F: { default: "disabled", override: { os: "windows" } } };
+      assert.strictEqual(evaluateFeature("F", settings), false);
+    });
+
+    it.each([
+      ["empty feature key", "", {} as Record<string, unknown>],
+      ["feature absent from settings", "missing", {} as Record<string, unknown>],
+      ["feature config is not an object", "F", { F: "invalid" } as Record<string, unknown>],
+    ])("returns undefined for invalid input (%s)", (_desc, featureKey, settings) => {
+      assert.strictEqual(evaluateFeature(featureKey, settings), undefined);
+    });
+  });
+
+  describe("override rule matching (via evaluateFeature)", () => {
+    // A feature that is disabled by default and enabled only when the single rule matches, so a
+    // `true` result means "the rule matched" and `false` means "it did not".
+    function ruleMatches(rule: Record<string, unknown>): boolean {
+      return evaluateFeature("F", { F: { default: "disabled", override: [rule] } }) === true;
+    }
+
+    beforeEach(() => {
+      profile.fill({ os: "windows", version: "1.0.0", component: "ext" });
+    });
+
+    it("matches when all conditions in the rule match", () => {
+      assert.isTrue(ruleMatches({ os: "windows", component: "ext" }));
+    });
+
+    it("does not match when any condition in the rule fails", () => {
+      assert.isFalse(ruleMatches({ os: "windows", component: "dst" }));
+    });
+
+    it("ignores a ver condition that has no accompanying component condition", () => {
+      assert.isFalse(ruleMatches({ ver: "1.0.0" }));
+      assert.isFalse(ruleMatches({ os: "windows", ver: "1.0.0" }));
+    });
+
+    it("honors ver when a matching component condition is present", () => {
+      assert.isTrue(ruleMatches({ ver: "1.0.0", component: "ext" }));
+    });
+
+    it("fails when ver is present but the component does not match", () => {
+      assert.isFalse(ruleMatches({ ver: "1.0.0", component: "dst" }));
+    });
+
+    it("never matches an empty rule", () => {
+      assert.isFalse(ruleMatches({}));
+    });
+  });
+
+  describe("condition matching (via evaluateFeature)", () => {
+    function conditionMatches(rule: Record<string, unknown>): boolean {
+      return evaluateFeature("F", { F: { default: "disabled", override: [rule] } }) === true;
+    }
+
+    beforeEach(() => {
+      profile.fill({
+        os: "windows",
+        version: "1.0.0",
+        component: "ext",
+        rp: "fn",
+        region: "westus",
+        attach: "manual",
+        ikey: "12345678-1234-1234-1234-123456789abc",
+      });
+    });
+
+    it("matches os case-insensitively", () => {
+      assert.isTrue(conditionMatches({ os: "WINDOWS" }));
+      assert.isFalse(conditionMatches({ os: "linux" }));
+    });
+
+    it("matches ver exactly (with component present)", () => {
+      assert.isTrue(conditionMatches({ ver: "1.0.0", component: "ext" }));
+      assert.isFalse(conditionMatches({ ver: "2.0.0", component: "ext" }));
+    });
+
+    it("matches component exactly", () => {
+      assert.isTrue(conditionMatches({ component: "ext" }));
+      assert.isFalse(conditionMatches({ component: "dst" }));
+    });
+
+    it("matches rp exactly", () => {
+      assert.isTrue(conditionMatches({ rp: "fn" }));
+      assert.isFalse(conditionMatches({ rp: "appsvc" }));
+    });
+
+    it("matches region exactly", () => {
+      assert.isTrue(conditionMatches({ region: "westus" }));
+      assert.isFalse(conditionMatches({ region: "eastus" }));
+    });
+
+    it("matches attach exactly", () => {
+      assert.isTrue(conditionMatches({ attach: "manual" }));
+      assert.isFalse(conditionMatches({ attach: "integratedauto" }));
+    });
+
+    it("matches ikey case-insensitively", () => {
+      assert.isTrue(conditionMatches({ ikey: "12345678-1234-1234-1234-123456789abc" }));
+      assert.isTrue(conditionMatches({ ikey: "12345678-1234-1234-1234-123456789ABC" }));
+      assert.isFalse(conditionMatches({ ikey: "00000000-0000-0000-0000-000000000000" }));
+    });
+
+    it("never matches an unknown condition key", () => {
+      assert.isFalse(conditionMatches({ unknown: "value" }));
+    });
+
+    it("never matches a null condition value", () => {
+      assert.isFalse(conditionMatches({ os: null }));
+    });
+  });
+
+  describe("integration", () => {
+    beforeEach(() => {
+      profile.fill({
+        os: "windows",
+        rp: "fn",
+        attach: "manual",
+        version: "1.0.0b20",
+        component: "ext",
+        region: "westus",
+      });
+    });
+
+    it("resolves multiple features with mixed defaults and overrides", () => {
+      const settings = {
+        FEATURE_LIVE_METRICS: {
+          default: "disabled",
+          override: [
+            { os: "windows" },
+            { os: "linux", ver: "1.0.0b20", component: "dst" },
+            { component: "dst", rp: "fn" },
+          ],
+        },
+        FEATURE_SDK_STATS: {
+          default: "enabled",
+          override: [{ os: "windows" }],
+        },
+        FEATURE_PROFILING: {
+          default: "disabled",
+          override: [
+            { os: "windows", ver: "2.0.0", component: "ext" },
+            { component: "ext", rp: "fn", region: "westus" },
+          ],
+        },
+      };
+
+      // Disabled by default, but the Windows override matches -> enabled.
+      assert.strictEqual(evaluateFeature("FEATURE_LIVE_METRICS", settings), true);
+      // Enabled by default, but the OS override matches -> disabled.
+      assert.strictEqual(evaluateFeature("FEATURE_SDK_STATS", settings), false);
+      // Disabled by default; first rule's version fails, second matches -> enabled.
+      assert.strictEqual(evaluateFeature("FEATURE_PROFILING", settings), true);
+    });
+  });
+});

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/featureEvaluation.spec.ts
@@ -227,7 +227,7 @@ describe("OneSettings feature evaluation", () => {
       assert.isFalse(ruleMatches({ os: "windows", component: "dst" }));
     });
 
-    it("ignores a ver condition that has no accompanying component condition", () => {
+    it("rejects a rule with ver but no accompanying component condition", () => {
       assert.isFalse(ruleMatches({ ver: "1.0.0" }));
       assert.isFalse(ruleMatches({ os: "windows", ver: "1.0.0" }));
     });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry-exporter`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The exporter needs internal OneSettings evaluation support that can resolve both legacy `enabled`/`disabled` feature flags and typed configuration values. OneSettings feature configurations may be JSON-encoded, include explicit override values, and target multiple profile values per condition.

This PR adds a process-wide, first-writer-wins `ConfigurationProfile` and an internal `evaluateFeature` implementation that:

- preserves legacy boolean feature behavior
- returns arbitrary string defaults or converts them with a caller-provided converter
- returns explicit values from matching overrides
- accepts JSON-encoded and in-memory feature configurations
- supports list-valued profile conditions
- falls back to the default when override conversion fails

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The evaluator could expose separate boolean and typed APIs. A single generic evaluator was chosen to match the Azure Monitor Python implementation while keeping legacy boolean behavior compatible and centralizing parsing, matching, and conversion rules.

### Are there test cases added in this PR? _(If not, why?)_

Yes. Unit tests cover profile initialization, legacy booleans, typed defaults and overrides, converters and conversion failures, JSON parsing, list conditions, malformed input, condition matching, and multi-feature integration.

### Provide a list of related PRs _(if any)_

- Azure SDK for Python: https://github.com/Azure/azure-sdk-for-python/pull/48595

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog (if necessary).