### PR TITLE
Set a matrix filter value to limit the number of confidential ledger tests that are run on a nightly build

### DIFF
--- a/sdk/confidentialledger/tests.yml
+++ b/sdk/confidentialledger/tests.yml
@@ -10,3 +10,10 @@ extends:
         LEDGER_URI: $(LEDGER_URI)
         LEDGER_NAME: $(LEDGER_NAME)
         IDENTITY_SERVICE_URL: $(IDENTITY_SERVICE_URL)
+      # Confidential Ledger test resources are expensive to provision: every matrix leg stands
+      # up a dedicated three-replica CCF cluster on confidential (SNP) hardware, which takes
+      # roughly eight minutes. Run one representative leg on the nightly pipeline and keep the
+      # full platform matrix on tests-weekly.
+      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
+        MatrixFilters:
+          - DependencyVersion=max


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Confidential ledger resources are expensive (in terms of provisioning time) to create. The JS nightly build runs 8 tests (built from a matrix of different OS versions and dependencies). Most of the time, these tests fail due to provisioning errors and impact the SLA. 

This PR adds a filter condition to limit the number of tests that are run on nightly basis. However, it does not affect the weekly run where all the combinations are run. 

### Are there test cases added in this PR? _(If not, why?)_
This PR did not add any new features.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [ ] Added a changelog (if necessary)
