### PR TITLE
[keyvault-keys] Add local support for RSA-OAEP-256 in CryptographyClient

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 4.11.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Added local (non-network) support for the `RSA-OAEP-256` algorithm in `CryptographyClient`'s `encrypt` and `wrapKey` operations, matching the already-supported `RSA-OAEP` and `RSA1_5` algorithms. Previously, `RSA-OAEP-256` operations always required a network round-trip to the service even when local crypto material was available.
+
+### Other Changes
+
 ## 4.11.0-beta.1 (2026-07-07)
 
 ### Features Added

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.11.0-beta.1",
+  "version": "4.11.0-beta.2",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptography/rsaCryptographyProvider.ts
@@ -47,12 +47,13 @@ export class RsaCryptographyProvider implements CryptographyProvider {
 
     const padding =
       encryptParameters.algorithm === "RSA1_5" ? RSA_PKCS1_PADDING : RSA_PKCS1_OAEP_PADDING;
+    const oaepHash = encryptParameters.algorithm === "RSA-OAEP-256" ? "sha256" : undefined;
 
     return Promise.resolve({
       algorithm: encryptParameters.algorithm,
       keyID: this.key.kid,
       result: publicEncrypt(
-        { key: keyPEM, padding: padding },
+        { key: keyPEM, padding: padding, oaepHash },
         Buffer.from(encryptParameters.plaintext),
       ),
     });
@@ -76,10 +77,11 @@ export class RsaCryptographyProvider implements CryptographyProvider {
     const keyPEM = convertJWKtoPEM(this.key);
 
     const padding = algorithm === "RSA1_5" ? RSA_PKCS1_PADDING : RSA_PKCS1_OAEP_PADDING;
+    const oaepHash = algorithm === "RSA-OAEP-256" ? "sha256" : undefined;
 
     return Promise.resolve({
       algorithm: algorithm as KeyWrapAlgorithm,
-      result: publicEncrypt({ key: keyPEM, padding }, Buffer.from(keyToWrap)),
+      result: publicEncrypt({ key: keyPEM, padding, oaepHash }, Buffer.from(keyToWrap)),
       keyID: this.key.kid,
     });
   }
@@ -152,6 +154,7 @@ export class RsaCryptographyProvider implements CryptographyProvider {
   private applicableAlgorithms: string[] = [
     "RSA1_5",
     "RSA-OAEP",
+    "RSA-OAEP-256",
     "PS256",
     "RS256",
     "PS384",

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -6,14 +6,34 @@ import type { DecryptParameters, EncryptParameters, KeyVaultKey } from "../../sr
 import { CryptographyClient, KeyClient } from "../../src/index.js";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider.js";
 import type { JsonWebKey } from "../../src/index.js";
-import { stringToUint8Array } from "../public/utils/crypto.js";
+import { createRsaKey, stringToUint8Array } from "../public/utils/crypto.js";
 import type { CryptographyProvider } from "../../src/cryptography/models.js";
 import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider.js";
 import { NoOpCredential } from "@azure-tools/test-credential";
 import type { SendRequest } from "@azure/core-rest-pipeline";
 import { RestError, createHttpHeaders } from "@azure/core-rest-pipeline";
+import { constants as cryptoConstants, createPrivateKey, privateDecrypt } from "node:crypto";
 import type { MockInstance } from "vitest";
 import { describe, it, assert, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Converts the raw (Uint8Array-valued) RSA JsonWebKey fixture used elsewhere in these tests
+ * into the base64url-string JWK shape Node's `crypto.createPrivateKey` expects.
+ */
+function toNodePrivateKeyJwk(key: JsonWebKey): Record<string, string> {
+  const toBase64Url = (value?: Uint8Array): string => Buffer.from(value!).toString("base64url");
+  return {
+    kty: "RSA",
+    n: toBase64Url(key.n),
+    e: toBase64Url(key.e),
+    d: toBase64Url(key.d),
+    p: toBase64Url(key.p),
+    q: toBase64Url(key.q),
+    dp: toBase64Url(key.dp),
+    dq: toBase64Url(key.dq),
+    qi: toBase64Url(key.qi),
+  };
+}
 
 describe("internal crypto tests", () => {
   const tokenCredential: TokenCredential = {
@@ -215,6 +235,115 @@ describe("internal crypto tests", () => {
         () => rsaProvider.encrypt({ algorithm: "RSA1_5", plaintext: stringToUint8Array("foo") }),
         "Key type does not match the algorithm RSA",
       );
+    });
+
+    describe("RSA-OAEP-256", function () {
+      const rsaKey = createRsaKey();
+      const nodePrivateKey = createPrivateKey({
+        key: toNodePrivateKeyJwk(rsaKey),
+        format: "jwk",
+      });
+
+      it("is reported as locally supported for encrypt and wrapKey", () => {
+        const provider = new RsaCryptographyProvider(rsaKey);
+        assert.isTrue(provider.isSupported("RSA-OAEP-256", "encrypt"));
+        assert.isTrue(provider.isSupported("RSA-OAEP-256", "wrapKey"));
+      });
+
+      it("resolves entirely locally (no network) via CryptographyClient", async () => {
+        // Constructing the client from a plain JsonWebKey (no credential) creates ONLY a
+        // local provider -- there is no RemoteCryptographyProvider for this call to fall
+        // back to, so a successful result here proves the operation never needed the network.
+        const cryptoClient = new CryptographyClient(rsaKey);
+        const plaintext = stringToUint8Array("hello RSA-OAEP-256");
+
+        const encrypted = await cryptoClient.encrypt({
+          algorithm: "RSA-OAEP-256",
+          plaintext,
+        });
+        assert.equal(encrypted.algorithm, "RSA-OAEP-256");
+
+        const decrypted = privateDecrypt(
+          {
+            key: nodePrivateKey,
+            padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha256",
+          },
+          Buffer.from(encrypted.result),
+        );
+        assert.deepEqual(new Uint8Array(decrypted), plaintext);
+      });
+
+      it("encrypts locally using SHA-256 as the OAEP hash, round-tripping through Node's own decrypt", async () => {
+        const provider = new RsaCryptographyProvider(rsaKey);
+        const plaintext = stringToUint8Array("some plaintext to encrypt");
+
+        const { result: ciphertext } = await provider.encrypt({
+          algorithm: "RSA-OAEP-256",
+          plaintext,
+        });
+
+        const decrypted = privateDecrypt(
+          {
+            key: nodePrivateKey,
+            padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha256",
+          },
+          Buffer.from(ciphertext),
+        );
+        assert.deepEqual(new Uint8Array(decrypted), plaintext);
+
+        // Decrypting as though SHA-1 (RSA-OAEP's default hash) had been used must fail --
+        // proving encrypt really used SHA-256, and didn't silently fall back to Node's default.
+        assert.throws(() =>
+          privateDecrypt(
+            {
+              key: nodePrivateKey,
+              padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+              oaepHash: "sha1",
+            },
+            Buffer.from(ciphertext),
+          ),
+        );
+      });
+
+      it("wraps a key locally using SHA-256 as the OAEP hash, round-tripping through Node's own decrypt", async () => {
+        const provider = new RsaCryptographyProvider(rsaKey);
+        const keyToWrap = stringToUint8Array("a-data-encryption-key");
+
+        const { result: wrapped, algorithm } = await provider.wrapKey("RSA-OAEP-256", keyToWrap);
+        assert.equal(algorithm, "RSA-OAEP-256");
+
+        const unwrapped = privateDecrypt(
+          {
+            key: nodePrivateKey,
+            padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha256",
+          },
+          Buffer.from(wrapped),
+        );
+        assert.deepEqual(new Uint8Array(unwrapped), keyToWrap);
+      });
+
+      it("leaves plain RSA-OAEP (SHA-1) encrypt/wrapKey behavior unchanged", async () => {
+        const provider = new RsaCryptographyProvider(rsaKey);
+        const plaintext = stringToUint8Array("hello RSA-OAEP");
+
+        const { result: ciphertext } = await provider.encrypt({
+          algorithm: "RSA-OAEP",
+          plaintext,
+        });
+
+        const decrypted = privateDecrypt(
+          {
+            key: nodePrivateKey,
+            padding: cryptoConstants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha1",
+          },
+          Buffer.from(ciphertext),
+        );
+        assert.deepEqual(new Uint8Array(decrypted), plaintext);
+      });
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/keyvault-keys`

### Issues associated with this PR

Fixes a gap originally scoped in #4191 ("Investigation of crypto libraries"), which explicitly listed local RSA-OAEP-256 support as in-scope (with a working proof-of-concept sample) alongside RSA-OAEP and RSA1_5. It appears to have been dropped during the initial implementation in #4434 and has been missing on every release since, including current stable `4.10.2` and beta `4.11.0-beta.1`.

### Describe the problem that is addressed by this PR

`RsaCryptographyProvider` (the SDK's local, no-network crypto fallback used by `CryptographyClient`) supports `encrypt`/`wrapKey` locally for `RSA1_5` and `RSA-OAEP`, but its `applicableAlgorithms` list is missing `"RSA-OAEP-256"` (RSA-OAEP using SHA-256 as the OAEP/MGF1 hash instead of the legacy SHA-1 default), even though:

- Node's built-in `crypto.publicEncrypt` has fully supported this since Node 12.9 via the `oaepHash` option - no platform limitation.
- `RSA-OAEP-256` is a real, standard Key Vault algorithm identifier (`JsonWebKeyEncryptionAlgorithm`), just like `RSA1_5` and `RSA-OAEP`.
- There's no comment anywhere in the code suggesting this exclusion is intentional.

Because `"RSA-OAEP-256"` isn't in `applicableAlgorithms`, `CryptographyClient.getProvider()` (`this.providers.filter((p) => p.isSupported(algorithm, operation))`) excludes the local provider for this algorithm, so every `encrypt`/`wrapKey` call using `RSA-OAEP-256` is forced over the network to the Key Vault/Managed HSM service - even when the caller already has the full public key material locally (e.g. a `CryptographyClient` constructed directly from a `KeyVaultKey`/`JsonWebKey`). At any real volume this causes avoidable throttling (`VaultRequestTypeLimitReached` 429s) for anyone using `RSA-OAEP-256`, which is the modern, NIST-preferred choice over the legacy SHA-1-based `RSA-OAEP`.

### What is the new behavior

- `"RSA-OAEP-256"` is added to `RsaCryptographyProvider.applicableAlgorithms`, so `CryptographyClient` now includes the local provider as a candidate for this algorithm (avoiding the network round-trip whenever local key material is available).
- `encrypt()` and `wrapKey()` now pass `{ oaepHash: "sha256" }` to Node's `publicEncrypt` when the algorithm is `"RSA-OAEP-256"`. Plain `"RSA-OAEP"` is unchanged (Node's `oaepHash` default of `"sha1"` still applies), and `RSA1_5` is unaffected.
- `decrypt()`/`unwrapKey()` are untouched - both deliberately throw `LocalCryptographyUnsupportedError` for every algorithm today (local decrypt is a separate, intentionally-unimplemented capability of this provider), and that's out of scope for this fix.
- `RSA-OAEP-384`/`RSA-OAEP-512` are intentionally not added - they aren't real Key Vault algorithm identifiers.

### What is the new behavior tested by this PR

Added unit tests in `test/internal/crypto.spec.ts` (`RSA local cryptography tests > RSA-OAEP-256`) that:

- Assert `RsaCryptographyProvider.isSupported("RSA-OAEP-256", ...)` now returns `true` for `encrypt`/`wrapKey`.
- Construct a `CryptographyClient` from a plain `JsonWebKey` (which wires up only a local provider, no `RemoteCryptographyProvider`) and confirm `encrypt` with `RSA-OAEP-256` succeeds - proving the operation resolves entirely locally, with no network involved.
- Round-trip both `encrypt` and `wrapKey` output through Node's own `crypto.privateDecrypt` with `oaepHash: "sha256"` against a test RSA keypair fixture, confirming the plaintext matches (OAEP hash mismatches between encrypt/decrypt silently corrupt data rather than erroring, so this is the correctness proof that matters here).
- Include a negative check that decrypting the same ciphertext as though `sha1` had been used fails, proving the implementation really used `sha256` rather than silently falling back to Node's default.
- Confirm plain `RSA-OAEP` behavior (`sha1`) is unchanged.

All of the package's existing tests continue to pass (`npm run test:node`: 167 passed, 9 skipped - the skipped tests are live-only and require real Key Vault resources). `tsc -b --noEmit`, `npm run lint`, and `npm run check-format` are all clean (lint reports only pre-existing warnings unrelated to this change, 0 errors).

Also added a `CHANGELOG.md` entry under a new `4.11.0-beta.2 (Unreleased)` section.