### PR TITLE
[commvaultcontentstore] Set planned release date for @azure/arm-commvaultcontentstore 1.0.0-beta.1

### DIFF
--- a/sdk/commvaultcontentstore/arm-commvaultcontentstore/CHANGELOG.md
+++ b/sdk/commvaultcontentstore/arm-commvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
     
-## 1.0.0-beta.1 (2026-08-18)
+## 1.0.0-beta.1 (2026-08-20)
 
 ### Features Added
 

--- a/sdk/commvaultcontentstore/arm-commvaultcontentstore/CHANGELOG.md
+++ b/sdk/commvaultcontentstore/arm-commvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
     
-## 1.0.0-beta.1 (2026-06-24)
+## 1.0.0-beta.1 (2026-08-18)
 
 ### Features Added
 


### PR DESCRIPTION
Updates CHANGELOG.md with a planned release date (2026-08-18) so the release pipeline readiness check passes for release plan 2101.
## Release Plan Details
- Release Plan: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=2101
- Work Item Link: https://dev.azure.com/azure-sdk/fe81d705-3c06-41e5-bf7c-5ebea18efe89/_workitems/edit/32864
- Spec Pull Request: https://github.com/Azure/azure-rest-api-specs/pull/43838
- Spec API version: 2025-01-01-preview