### PR TITLE
[ai-projects] update regen skill to remove head v base commit check

### DIFF
--- a/sdk/ai/ai-projects/.github/skills/run-issue-regeneration/SKILL.md
+++ b/sdk/ai/ai-projects/.github/skills/run-issue-regeneration/SKILL.md
@@ -14,7 +14,7 @@ Before installing dependencies or editing files:
 1. Read exactly one unambiguous value labeled `TypeSpec commit` and exactly one unambiguous value labeled `Base branch` from the issue description. If either value is missing, duplicated, or ambiguous, stop without making changes and report the required labels.
 2. Require the TypeSpec commit to match `^[0-9a-f]{40}$` exactly.
 3. Require the entire base branch to case-sensitively match the conservative ASCII pattern `^[A-Za-z0-9][A-Za-z0-9._/-]*\z` and pass `git check-ref-format --branch`. Treat it only as a quoted command argument.
-4. Require a named working branch other than the base branch. Fetch `origin/<base-branch>`, then require the fetched branch tip to equal `HEAD` exactly. If the assignment started from the wrong branch, stop without making changes and report both commit IDs.
+4. Require a named working branch other than the base branch. Do not require `HEAD` to match the base branch tip; issue-assigned sessions run on a separate working branch that may already contain commits.
 
 Do not derive either input from the issue title. Do not infer, shorten, or silently correct either input.
 

--- a/sdk/ai/ai-projects/.github/skills/run-issue-regeneration/SKILL.md
+++ b/sdk/ai/ai-projects/.github/skills/run-issue-regeneration/SKILL.md
@@ -14,7 +14,7 @@ Before installing dependencies or editing files:
 1. Read exactly one unambiguous value labeled `TypeSpec commit` and exactly one unambiguous value labeled `Base branch` from the issue description. If either value is missing, duplicated, or ambiguous, stop without making changes and report the required labels.
 2. Require the TypeSpec commit to match `^[0-9a-f]{40}$` exactly.
 3. Require the entire base branch to case-sensitively match the conservative ASCII pattern `^[A-Za-z0-9][A-Za-z0-9._/-]*\z` and pass `git check-ref-format --branch`. Treat it only as a quoted command argument.
-4. Require a named working branch other than the base branch. Do not require `HEAD` to match the base branch tip; issue-assigned sessions run on a separate working branch that may already contain commits.
+4. Require a named working branch other than the base branch. Fetch `origin/<base-branch>` successfully before proceeding. Do not require `HEAD` to match the base branch tip; issue-assigned sessions run on a separate working branch that may already contain commits. Instead, require the working branch to be either (a) ahead of `origin/<base-branch>` or (b) able to merge or rebase cleanly onto `origin/<base-branch>`. If neither condition holds, stop without making changes and report the divergence details, including the merge base and ahead/behind state relative to `origin/<base-branch>`.
 
 Do not derive either input from the issue title. Do not infer, shorten, or silently correct either input.
 


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/ai-projects

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [ ] Added a changelog (if necessary)
