### PR TITLE
Implement OneSettings manager polling

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,7 @@
   resolution. [#39279](https://github.com/Azure/azure-sdk-for-js/pull/39279)
 - Added an internal OneSettings HTTP request utility (`makeOneSettingsRequest`) that fetches dynamic configuration and parses the response, ETag, and refresh interval. Requests honor the standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY`). This is groundwork with no user-facing behavior yet. [#39492](https://github.com/Azure/azure-sdk-for-js/pull/39492)
 - Added internal OneSettings feature evaluation (`evaluateFeature`) and a write-once SDK profile (`ConfigurationProfile`) that resolve typed setting values from defaults and override rules, including JSON-encoded configurations and list-valued conditions. This is groundwork with no user-facing behavior yet. [#39617](https://github.com/Azure/azure-sdk-for-js/pull/39617)
+- Implemented the internal OneSettings manager polling state machine, including ETag-based change detection, configuration caching, callback notification, and bounded retry backoff. Background scheduling and feature wiring remain disabled, so this has no user-facing behavior yet. [#39636](https://github.com/Azure/azure-sdk-for-js/pull/39636)
 
 ## 1.0.0-beta.44 (2026-07-29)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -88,6 +88,8 @@ export class ConfigurationManager {
   public registerCallback(callback: ConfigurationChangeCallback): void {
     this.callbacks.push(callback);
     if (Object.keys(this.state.settings).length > 0) {
+      // A callback may register after the last configuration change, so replay the cache now rather
+      // than leaving the consumer stale until another change occurs (which may never happen).
       this.invokeCallback(callback, this.state.settings);
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -2,7 +2,30 @@
 // Licensed under the MIT License.
 
 import { diag } from "@opentelemetry/api";
-import { ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS } from "../Declarations/Constants.js";
+import {
+  ONE_SETTINGS_BACKOFF_BASE_MS,
+  ONE_SETTINGS_CHANGE_URL,
+  ONE_SETTINGS_CONFIG_URL,
+  ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+  ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+  ONE_SETTINGS_NODEJS_TARGETING,
+  ONE_SETTINGS_RETRYABLE_STATUS_CODES,
+} from "../Declarations/Constants.js";
+import type { OneSettingsResponse } from "./utils.js";
+import { makeOneSettingsRequest } from "./utils.js";
+
+interface ConfigurationState {
+  etag?: string;
+  refreshIntervalMs: number;
+  settings: Readonly<Record<string, unknown>>;
+}
+
+function createInitialState(): ConfigurationState {
+  return {
+    refreshIntervalMs: ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+    settings: {},
+  };
+}
 
 /**
  * Callback invoked with the latest settings whenever OneSettings reports a configuration change.
@@ -19,15 +42,16 @@ export type ConfigurationChangeCallback = (
 /**
  * Singleton that owns the OneSettings control-plane state and change-detection logic.
  *
- * It holds the list of registered change callbacks and, once change detection is implemented,
- * the last ETag and cached settings. Use {@link ConfigurationManager.getInstance} rather than
- * constructing this directly.
+ * It holds the list of registered change callbacks, the last ETag, and cached settings. Use
+ * {@link ConfigurationManager.getInstance} rather than constructing this directly.
  * @internal
  */
 export class ConfigurationManager {
   private static instance: ConfigurationManager | undefined;
   private callbacks: ConfigurationChangeCallback[] = [];
   private initialized = false;
+  private state = createInitialState();
+  private backoffAttempts = 0;
 
   /**
    * Use {@link ConfigurationManager.getInstance} to obtain the singleton instance.
@@ -59,9 +83,13 @@ export class ConfigurationManager {
 
   /**
    * Register a callback to be invoked whenever OneSettings reports a configuration change.
+   * If settings are already cached, they are replayed immediately to the new callback.
    */
   public registerCallback(callback: ConfigurationChangeCallback): void {
     this.callbacks.push(callback);
+    if (Object.keys(this.state.settings).length > 0) {
+      this.invokeCallback(callback, this.state.settings);
+    }
   }
 
   /**
@@ -70,14 +98,7 @@ export class ConfigurationManager {
    */
   protected notifyCallbacks(settings: Readonly<Record<string, unknown>>): void {
     for (const callback of [...this.callbacks]) {
-      try {
-        // `try/catch` handles synchronous throws; `.catch` handles rejections from async callbacks.
-        Promise.resolve(callback(settings)).catch((error) => {
-          diag.debug("OneSettings configuration callback failed:", error);
-        });
-      } catch (error) {
-        diag.debug("OneSettings configuration callback failed:", error);
-      }
+      this.invokeCallback(callback, settings);
     }
   }
 
@@ -86,9 +107,108 @@ export class ConfigurationManager {
    * notify callbacks on change, and return the next refresh interval in milliseconds.
    */
   public async getConfigurationAndRefreshInterval(): Promise<number> {
-    // TODO(onesettings): implement change detection against the CHANGE (e2) endpoint, fetch the
-    // CONFIG (e1) payload on a new ETag, update the cached ETag/settings/refresh interval, call
-    // `notifyCallbacks`, and apply exponential backoff on transient errors.
-    return ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS;
+    const headers: Record<string, string> = {
+      "x-ms-onesetinterval": String(Math.floor(this.state.refreshIntervalMs / (60 * 1000))),
+    };
+    if (this.state.etag) {
+      headers["If-None-Match"] = this.state.etag;
+    }
+
+    const changeResponse = await makeOneSettingsRequest(
+      ONE_SETTINGS_CHANGE_URL,
+      ONE_SETTINGS_NODEJS_TARGETING,
+      headers,
+    );
+
+    if (this.isTransientError(changeResponse)) {
+      this.backoffAttempts += 1;
+      const backoffIntervalMs = Math.min(
+        ONE_SETTINGS_BACKOFF_BASE_MS * 2 ** (this.backoffAttempts - 1),
+        ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+      );
+      diag.debug(
+        `OneSettings change detection failed transiently; retrying in ${backoffIntervalMs}ms`,
+      );
+      return backoffIntervalMs;
+    }
+
+    this.backoffAttempts = 0;
+
+    if (changeResponse.statusCode === 304) {
+      this.state = {
+        ...this.state,
+        etag: changeResponse.etag ?? this.state.etag,
+        refreshIntervalMs: changeResponse.refreshIntervalMs,
+      };
+      return this.state.refreshIntervalMs;
+    }
+
+    if (changeResponse.statusCode !== 200) {
+      diag.debug(
+        `OneSettings change detection returned non-retryable status ${changeResponse.statusCode}`,
+      );
+      return ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS;
+    }
+
+    const configResponse = await makeOneSettingsRequest(
+      ONE_SETTINGS_CONFIG_URL,
+      ONE_SETTINGS_NODEJS_TARGETING,
+    );
+    if (configResponse.statusCode !== 200 || Object.keys(configResponse.settings).length === 0) {
+      diag.debug(
+        `OneSettings configuration fetch did not return settings (status ${configResponse.statusCode})`,
+      );
+      this.state = {
+        ...this.state,
+        refreshIntervalMs: changeResponse.refreshIntervalMs,
+      };
+      return this.state.refreshIntervalMs;
+    }
+
+    const settings = Object.freeze({ ...configResponse.settings });
+    this.state = {
+      etag: changeResponse.etag ?? this.state.etag,
+      refreshIntervalMs: changeResponse.refreshIntervalMs,
+      settings,
+    };
+    this.notifyCallbacks(settings);
+    return this.state.refreshIntervalMs;
+  }
+
+  /**
+   * Return a snapshot of the currently cached settings.
+   */
+  public getSettings(): Readonly<Record<string, unknown>> {
+    return { ...this.state.settings };
+  }
+
+  /**
+   * Reset cached state and callbacks. Intended for test isolation until worker shutdown is added.
+   */
+  public reset(): void {
+    this.callbacks = [];
+    this.initialized = false;
+    this.state = createInitialState();
+    this.backoffAttempts = 0;
+  }
+
+  private isTransientError(response: OneSettingsResponse): boolean {
+    return (
+      response.hasException || ONE_SETTINGS_RETRYABLE_STATUS_CODES.includes(response.statusCode)
+    );
+  }
+
+  private invokeCallback(
+    callback: ConfigurationChangeCallback,
+    settings: Readonly<Record<string, unknown>>,
+  ): void {
+    try {
+      // `try/catch` handles synchronous throws; `.catch` handles rejections from async callbacks.
+      Promise.resolve(callback(settings)).catch((error) => {
+        diag.debug("OneSettings configuration callback failed:", error);
+      });
+    } catch (error) {
+      diag.debug("OneSettings configuration callback failed:", error);
+    }
   }
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
+import { ConfigurationManager } from "../../src/_configuration/configurationManager.js";
+import type { OneSettingsResponse } from "../../src/_configuration/utils.js";
+import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
+import {
+  ONE_SETTINGS_CHANGE_URL,
+  ONE_SETTINGS_CONFIG_URL,
+  ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+  ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+  ONE_SETTINGS_NODEJS_TARGETING,
+} from "../../src/Declarations/Constants.js";
+
+vi.mock("../../src/_configuration/utils.js", () => ({
+  makeOneSettingsRequest: vi.fn(),
+}));
+
+function response(overrides: Partial<OneSettingsResponse> = {}): OneSettingsResponse {
+  return {
+    refreshIntervalMs: ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+    settings: {},
+    statusCode: 200,
+    hasException: false,
+    ...overrides,
+  };
+}
+
+describe("ConfigurationManager", () => {
+  const manager = ConfigurationManager.getInstance();
+  const request = vi.mocked(makeOneSettingsRequest);
+
+  beforeEach(() => {
+    manager.reset();
+    request.mockReset();
+  });
+
+  afterEach(() => {
+    manager.reset();
+  });
+
+  it("fetches and caches configuration when change detection reports an update", async () => {
+    const callback = vi.fn();
+    manager.registerCallback(callback);
+    request
+      .mockResolvedValueOnce(
+        response({
+          etag: '"etag-1"',
+          refreshIntervalMs: 30 * 60 * 1000,
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          settings: { FEATURE_SDK_STATS: '{"default":"enabled"}' },
+        }),
+      );
+
+    const interval = await manager.getConfigurationAndRefreshInterval();
+
+    assert.strictEqual(interval, 30 * 60 * 1000);
+    assert.deepStrictEqual(manager.getSettings(), {
+      FEATURE_SDK_STATS: '{"default":"enabled"}',
+    });
+    assert.deepStrictEqual(request.mock.calls, [
+      [ONE_SETTINGS_CHANGE_URL, ONE_SETTINGS_NODEJS_TARGETING, { "x-ms-onesetinterval": "60" }],
+      [ONE_SETTINGS_CONFIG_URL, ONE_SETTINGS_NODEJS_TARGETING],
+    ]);
+    assert.deepStrictEqual(callback.mock.calls, [[{ FEATURE_SDK_STATS: '{"default":"enabled"}' }]]);
+  });
+
+  it("keeps cached settings and skips the config endpoint on 304", async () => {
+    request
+      .mockResolvedValueOnce(
+        response({
+          etag: '"etag-1"',
+          settings: {},
+        }),
+      )
+      .mockResolvedValueOnce(response({ settings: { setting: "cached" } }))
+      .mockResolvedValueOnce(
+        response({
+          statusCode: 304,
+          etag: '"etag-1"',
+          refreshIntervalMs: 15 * 60 * 1000,
+        }),
+      );
+
+    await manager.getConfigurationAndRefreshInterval();
+    request.mockClear();
+
+    const interval = await manager.getConfigurationAndRefreshInterval();
+
+    assert.strictEqual(interval, 15 * 60 * 1000);
+    assert.deepStrictEqual(manager.getSettings(), { setting: "cached" });
+    assert.deepStrictEqual(request.mock.calls, [
+      [
+        ONE_SETTINGS_CHANGE_URL,
+        ONE_SETTINGS_NODEJS_TARGETING,
+        {
+          "If-None-Match": '"etag-1"',
+          "x-ms-onesetinterval": "60",
+        },
+      ],
+    ]);
+  });
+
+  it("does not advance the ETag or notify callbacks when config fetching fails", async () => {
+    const callback = vi.fn();
+    manager.registerCallback(callback);
+    request
+      .mockResolvedValueOnce(response({ etag: '"unapplied-etag"', refreshIntervalMs: 120000 }))
+      .mockResolvedValueOnce(response({ statusCode: 500 }))
+      .mockResolvedValueOnce(response({ statusCode: 304 }));
+
+    assert.strictEqual(await manager.getConfigurationAndRefreshInterval(), 120000);
+    request.mockClear();
+
+    await manager.getConfigurationAndRefreshInterval();
+
+    assert.deepStrictEqual(request.mock.calls[0], [
+      ONE_SETTINGS_CHANGE_URL,
+      ONE_SETTINGS_NODEJS_TARGETING,
+      { "x-ms-onesetinterval": "2" },
+    ]);
+    assert.deepStrictEqual(manager.getSettings(), {});
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it("applies capped exponential backoff for consecutive transient errors", async () => {
+    request
+      .mockResolvedValue(response({ statusCode: 503 }))
+      .mockResolvedValueOnce(response({ hasException: true, statusCode: 0 }));
+
+    const intervals = [];
+    for (let attempt = 0; attempt < 7; attempt++) {
+      intervals.push(await manager.getConfigurationAndRefreshInterval());
+    }
+
+    assert.deepStrictEqual(intervals, [
+      1 * 60 * 60 * 1000,
+      2 * 60 * 60 * 1000,
+      4 * 60 * 60 * 1000,
+      8 * 60 * 60 * 1000,
+      16 * 60 * 60 * 1000,
+      ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+      ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+    ]);
+  });
+
+  it("resets transient backoff after a non-transient response", async () => {
+    request
+      .mockResolvedValueOnce(response({ statusCode: 503 }))
+      .mockResolvedValueOnce(response({ statusCode: 304 }))
+      .mockResolvedValueOnce(response({ statusCode: 503 }));
+
+    assert.strictEqual(
+      await manager.getConfigurationAndRefreshInterval(),
+      ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+    );
+    assert.strictEqual(
+      await manager.getConfigurationAndRefreshInterval(),
+      ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+    );
+    assert.strictEqual(
+      await manager.getConfigurationAndRefreshInterval(),
+      ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
+    );
+  });
+
+  it("slow-polls after a non-retryable change-detection error", async () => {
+    request.mockResolvedValueOnce(response({ statusCode: 404 }));
+
+    assert.strictEqual(
+      await manager.getConfigurationAndRefreshInterval(),
+      ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS,
+    );
+    assert.strictEqual(request.mock.calls.length, 1);
+  });
+
+  it("replays cached settings to callbacks registered after an update", async () => {
+    request
+      .mockResolvedValueOnce(response({ etag: '"etag-1"' }))
+      .mockResolvedValueOnce(response({ settings: { setting: "cached" } }));
+    await manager.getConfigurationAndRefreshInterval();
+    const callback = vi.fn();
+
+    manager.registerCallback(callback);
+
+    assert.deepStrictEqual(callback.mock.calls, [[{ setting: "cached" }]]);
+  });
+
+  it("isolates callback failures while notifying an update", async () => {
+    const successfulCallback = vi.fn();
+    manager.registerCallback(() => {
+      throw new Error("callback failed");
+    });
+    manager.registerCallback(successfulCallback);
+    request
+      .mockResolvedValueOnce(response({ etag: '"etag-1"' }))
+      .mockResolvedValueOnce(response({ settings: { setting: "updated" } }));
+
+    await manager.getConfigurationAndRefreshInterval();
+
+    assert.deepStrictEqual(successfulCallback.mock.calls, [[{ setting: "updated" }]]);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry-exporter`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The exporter has OneSettings request and feature-evaluation utilities, but `ConfigurationManager` does not yet perform change detection or maintain configuration state.

This PR implements one polling operation in the manager. It sends cached ETag and refresh metadata to e2, fetches e1 only on change, caches successful updates, preserves state when e1 fails, applies capped transient backoff, slow-polls non-retryable errors, and notifies or replays callbacks from cached settings.

Background timer scheduling, lifecycle shutdown, and exporter/SDK Stats wiring are intentionally deferred to follow-up PRs so this state machine can be reviewed and validated independently.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The polling loop and state transitions could be implemented together. This PR separates them: the manager exposes one deterministic async poll operation, while a later worker will own jitter, timers, and shutdown. This mirrors the Python SDK architecture and keeps network/state behavior easy to unit test without fake timers.

### Are there test cases added in this PR? _(If not, why?)_

Yes. Focused tests cover successful e2/e1 updates, 304 handling, failed e1 fetches, ETag retention, transient backoff and reset, non-retryable responses, callback replay, and callback failure isolation.

### Provide a list of related PRs _(if any)_

- Typed OneSettings feature evaluation: https://github.com/Azure/azure-sdk-for-js/pull/39617
- Python reference implementation: https://github.com/Azure/azure-sdk-for-python/pull/47949

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog (if necessary).