### PR TITLE
[core-lro] Add initial response state hook

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 3.5.0 (Unreleased)
+
+### Features Added
+
+- Added the `onInitialResponse` option to initialize custom poller state from the initial LRO response before `submitted()` resolves. [#39476](https://github.com/Azure/azure-sdk-for-js/issues/39476)
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.4.0 (2026-07-13)
 
 ### Other Changes

--- a/sdk/core/core-lro/docs/implementing-lros-with-createhttppoller.md
+++ b/sdk/core/core-lro/docs/implementing-lros-with-createhttppoller.md
@@ -25,6 +25,7 @@ Moreover, the last two pieces are options in the options bag which is defined as
 export interface CreateHttpPollerOptions<TResult, TState> {
   processResult?: (result: unknown, state: TState) => TResult;
   updateState?: (state: TState, response: LroResponse) => void;
+  onInitialResponse?: (state: TState, response: LroResponse) => void | Promise<void>;
   intervalInMs?: number;
   restoreFrom?: string;
   resourceLocationConfig?: LroResourceLocationConfig;
@@ -34,6 +35,8 @@ export interface CreateHttpPollerOptions<TResult, TState> {
 ```
 
 More specifically, those two pieces are the values of `processResult` and `updateState` respectively. `processResult` takes the last polling response and the state as input and returns a `TResult`, which will eventually be returned to the customer when they call `poller.pollUntilDone()`. `updateState` can mutate the state with specific information from every polling response such as updating metadata fields (e.g. many operations return a `lastUpdatedDateTime` field in their polling responses to tell the customer when last time their operation had an activity).
+
+`onInitialResponse` can initialize service-specific state from the initial response. The callback runs once after the state is created and before the initial response is processed, including when that response is already terminal. It is awaited before `submitted()` resolves and is not invoked when restoring a serialized poller. Changes to the core-owned operation status and configuration are discarded.
 
 These are the main four pieces of information needed to construct the poller but there are other options that can be used to adjust the poller behavior:
 - `intervalInMs`: controls the time interval between polling requests

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "description": "Isomorphic client library for supporting long-running operations in node.js and browser.",
   "exports": {

--- a/sdk/core/core-lro/review/core-lro-node.api.md
+++ b/sdk/core/core-lro/review/core-lro-node.api.md
@@ -16,6 +16,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
 export interface CreateHttpPollerOptions<TResult, TState> {
     baseUrl?: string;
     intervalInMs?: number;
+    onInitialResponse?: (state: TState, response: OperationResponse) => void | Promise<void>;
     processResult?: (result: unknown, state: TState) => Promise<TResult>;
     resolveOnUnsuccessful?: boolean;
     resourceLocationConfig?: ResourceLocationConfig;

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -113,6 +113,15 @@ export interface CreateHttpPollerOptions<TResult, TState> {
    */
   updateState?: (state: TState, response: OperationResponse) => void;
   /**
+   * A function to initialize service-specific state from the initial response.
+   *
+   * The callback is invoked once after the state is created and before the initial
+   * response is processed. It is awaited before `submitted()` resolves and is not
+   * invoked when restoring a serialized poller. Changes to the core-owned `status`
+   * and operation configuration are discarded.
+   */
+  onInitialResponse?: (state: TState, response: OperationResponse) => void | Promise<void>;
+  /**
    * A function to be called each time the operation location is updated by the
    * service.
    */

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -33,6 +33,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
     processResult,
     restoreFrom,
     updateState,
+    onInitialResponse,
     withOperationLocation,
     resolveOnUnsuccessful = false,
     baseUrl,
@@ -68,6 +69,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
       withOperationLocation,
       restoreFrom,
       updateState,
+      onInitialResponse,
       processResult: processResult
         ? ({ flatResponse }, state) => processResult(flatResponse, state)
         : ({ flatResponse }) => flatResponse as Promise<TResult>,

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -68,6 +68,15 @@ export interface CreatePollerOptions<TResponse, TResult, TState> {
    */
   updateState?: (state: TState, lastResponse: TResponse) => void;
   /**
+   * A function to initialize service-specific state from the initial response.
+   *
+   * The callback is invoked once after the state is created and before the initial
+   * response is processed. It is awaited before `submitted()` resolves and is not
+   * invoked when restoring a serialized poller. Changes to the core-owned `status`
+   * and operation configuration are discarded.
+   */
+  onInitialResponse?: (state: TState, response: TResponse) => void | Promise<void>;
+  /**
    * A function to be called each time the operation location is updated by the
    * service.
    */

--- a/sdk/core/core-lro/src/poller/operation.ts
+++ b/sdk/core/core-lro/src/poller/operation.ts
@@ -139,11 +139,18 @@ export async function initOperation<
     operationLocation?: string;
   }) => OperationStatus;
   processResult?: (result: TResponse, state: TState) => Promise<TResult>;
+  onInitialResponse?: (state: TState, response: TResponse) => void | Promise<void>;
   withOperationLocation?: (operationLocation: string, isUpdated: boolean) => void;
   setErrorAsResult: boolean;
 }): Promise<RestorableOperationState<TResult, TState>> {
-  const { init, processResult, getOperationStatus, withOperationLocation, setErrorAsResult } =
-    inputs;
+  const {
+    init,
+    processResult,
+    onInitialResponse,
+    getOperationStatus,
+    withOperationLocation,
+    setErrorAsResult,
+  } = inputs;
   const {
     operationLocation,
     resourceLocation,
@@ -162,6 +169,13 @@ export async function initOperation<
   };
   logger.verbose(`LRO: Operation description:`, config);
   const state = { status: "running", config } as any;
+  const protectedConfig = {
+    ...config,
+    metadata: config.metadata ? { ...config.metadata } : undefined,
+  };
+  await onInitialResponse?.(state, response);
+  state.status = "running";
+  state.config = protectedConfig;
   const status = getOperationStatus({ response, state, operationLocation });
   await processOperationStatus({
     state,

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -39,6 +39,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     const {
       processResult,
       updateState,
+      onInitialResponse,
       withOperationLocation: withOperationLocationCallback,
       intervalInMs = POLL_INTERVAL_IN_MS,
       restoreFrom,
@@ -62,6 +63,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
       statePromise = initOperation({
         init,
         processResult,
+        onInitialResponse,
         getOperationStatus: getStatusFromInitialResponse,
         withOperationLocation,
         setErrorAsResult: !resolveOnUnsuccessful,

--- a/sdk/core/core-lro/test/public/lro.spec.ts
+++ b/sdk/core/core-lro/test/public/lro.spec.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { ImplementationName, Result } from "../utils/utils.js";
+import type { ImplementationName, Result, State } from "../utils/utils.js";
 import { assertDivergentBehavior, assertError, createDoubleHeaders } from "../utils/utils.js";
 import { describe, it, assert, expect, vi } from "vitest";
 import { createRunLroWith, createTestPoller } from "../utils/router.js";
 import { createHttpPoller } from "../../src/index.js";
+import type { OperationState } from "../../src/index.js";
 import { makeRawResponse } from "../utils/utils.js";
 import { delay } from "@azure/core-util";
 import { matrix } from "@azure-tools/test-utils-vitest";
@@ -3361,6 +3362,161 @@ matrix(
 );
 
 describe("createHttpPoller", () => {
+  describe("onInitialResponse callback", () => {
+    it("initializes custom state before submitted resolves without a polling URL", async () => {
+      type JobState = State & { jobId?: string };
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: { id: "job-123" },
+          rawResponse: makeRawResponse({
+            statusCode: 202,
+            request: { method: "POST", url: "https://example.com/jobs" },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+
+      const poller = createHttpPoller<Result, JobState>(lro, {
+        onInitialResponse: async (state, response) => {
+          await delay(1);
+          state.jobId = (response.flatResponse as { id: string }).id;
+        },
+      });
+
+      await poller.submitted();
+
+      assert.equal(poller.operationState?.jobId, "job-123");
+    });
+
+    it("preserves the status determined from the initial response", async () => {
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: {},
+          rawResponse: makeRawResponse({
+            statusCode: 202,
+            headers: { "operation-location": "https://example.com/jobs/job-123" },
+            request: { method: "POST", url: "https://example.com/jobs" },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+
+      const poller = createHttpPoller<Result, State>(lro, {
+        onInitialResponse: (state) => {
+          state.status = "succeeded";
+        },
+      });
+
+      await poller.submitted();
+
+      assert.equal(poller.operationState?.status, "running");
+    });
+
+    it("preserves the operation configuration", async () => {
+      type StateWithConfig = State & {
+        config: { operationLocation?: string };
+      };
+      const operationLocation = "https://example.com/jobs/job-123";
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: {},
+          rawResponse: makeRawResponse({
+            statusCode: 202,
+            headers: { "operation-location": operationLocation },
+            request: { method: "POST", url: "https://example.com/jobs" },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+
+      const poller = createHttpPoller<Result, StateWithConfig>(lro, {
+        onInitialResponse: (state) => {
+          state.config.operationLocation = "https://example.com/incorrect";
+        },
+      });
+
+      await poller.submitted();
+
+      assert.equal(poller.operationState?.config.operationLocation, operationLocation);
+    });
+
+    it("initializes state before processing an initially terminal response", async () => {
+      type AnalysisState = OperationState<string> & { operationId?: string };
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: { id: "operation-123" },
+          rawResponse: makeRawResponse({
+            statusCode: 200,
+            request: { method: "PUT", url: "https://example.com/analyze" },
+            body: { properties: { provisioningState: "Succeeded" } },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+
+      const poller = createHttpPoller<string, AnalysisState>(lro, {
+        onInitialResponse: (state, response) => {
+          state.operationId = (response.flatResponse as { id: string }).id;
+        },
+        processResult: async (_response, state) => state.operationId ?? "missing",
+      });
+
+      assert.equal(await poller.pollUntilDone(), "operation-123");
+    });
+
+    it("retains initialized state without invoking the callback when restored", async () => {
+      type JobState = State & { jobId?: string };
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: { id: "job-123" },
+          rawResponse: makeRawResponse({
+            statusCode: 202,
+            headers: { "operation-location": "https://example.com/jobs/job-123" },
+            request: { method: "POST", url: "https://example.com/jobs" },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+      const poller = createHttpPoller<Result, JobState>(lro, {
+        onInitialResponse: (state, response) => {
+          state.jobId = (response.flatResponse as { id: string }).id;
+        },
+      });
+      const restoreFrom = await poller.serialize();
+
+      const restoredPoller = createHttpPoller<Result, JobState>(lro, {
+        restoreFrom,
+        onInitialResponse: () => {
+          throw new Error("onInitialResponse should not run when restoring state");
+        },
+      });
+      await restoredPoller.submitted();
+
+      assert.equal(restoredPoller.operationState?.jobId, "job-123");
+    });
+
+    it("rejects submission when initialization fails", async () => {
+      const lro = {
+        sendInitialRequest: async () => ({
+          flatResponse: {},
+          rawResponse: makeRawResponse({
+            statusCode: 202,
+            headers: { "operation-location": "https://example.com/jobs/job-123" },
+            request: { method: "POST", url: "https://example.com/jobs" },
+          }),
+        }),
+        sendPollRequest: vi.fn(),
+      };
+      const poller = createHttpPoller<Result, State>(lro, {
+        onInitialResponse: async () => {
+          throw new Error("Unable to initialize operation state");
+        },
+      });
+
+      await expect(poller.submitted()).rejects.toThrow("Unable to initialize operation state");
+    });
+  });
+
   describe("withOperationLocation callback", () => {
     it("calls withOperationLocation on initial and updated locations", async () => {
       const locations: string[] = [];


### PR DESCRIPTION
`createHttpPoller` currently has no supported way to initialize service-specific poller state from the initial LRO response. `updateState` only sees polling responses, so operations that need an identifier before the first poll have to wrap or patch the poller.

This PR adds an opt-in `onInitialResponse` callback. It runs after the shared state object is created and before the initial status/result is processed, so it also works when the initial response is already terminal or has no polling URL. The callback can be async and is awaited before `submitted()` resolves.

I considered reusing `updateState`, but its existing contract is specifically tied to polling responses and some consumers rely on that response shape. Keeping this separate avoids changing existing behavior. The hook is skipped when restoring serialized state, and changes to the core-owned status/configuration are discarded.

I am intentionally keeping this PR scoped to `@azure/core-lro`. Plumbing the option through `@azure-tools/typespec-ts` and removing the downstream package workarounds can follow separately.

Contributes to #39476
