### PR TITLE
fix(core-client-rest): normalize legacy custom headers

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Added support for normalizing package-local `customHeaders` aliases. [#39593](https://github.com/Azure/azure-sdk-for-js/issues/39593)
+
 ### Other Changes
 
 ## 2.8.0 (2026-07-13)

--- a/sdk/core/core-client-rest/src/operationOptionHelpers.ts
+++ b/sdk/core/core-client-rest/src/operationOptionHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions, RequestParameters } from "./common.js";
+import type { OperationOptions, OperationRequestOptions, RequestParameters } from "./common.js";
 
 import {
   operationOptionsToRequestParameters as tspOperationOptionsToRequestParameters,
@@ -14,11 +14,32 @@ import {
  * @returns the result of the conversion in RequestParameters of RLC layer
  */
 export function operationOptionsToRequestParameters(options: OperationOptions): RequestParameters {
+  const compatibilityOptions = options as OperationOptions & {
+    requestOptions?: OperationRequestOptions & {
+      customHeaders?: Record<string, string>;
+    };
+  };
   const tspRequestParameters = tspOperationOptionsToRequestParameters(
     options as TspOperationOptions,
   ) as RequestParameters;
   return {
     ...tspRequestParameters,
+    headers: mergeHeaders(
+      compatibilityOptions.requestOptions?.customHeaders,
+      tspRequestParameters.headers,
+    ),
     tracingOptions: options.tracingOptions,
   };
+}
+
+function mergeHeaders(
+  ...headerSets: Array<RequestParameters["headers"]>
+): NonNullable<RequestParameters["headers"]> {
+  const headers = new Map<string, string | number | boolean>();
+  for (const headerSet of headerSets) {
+    for (const [name, value] of Object.entries(headerSet ?? {})) {
+      headers.set(name.toLowerCase(), value);
+    }
+  }
+  return Object.fromEntries(headers);
 }

--- a/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, assert } from "vitest";
 import { operationOptionsToRequestParameters } from "../../src/operationOptionHelpers.js";
+import type { OperationOptions, OperationRequestOptions } from "../../src/common.js";
 
 describe("operationOptionsToRequestParameters", () => {
   it("promotes requestOptions fields to root-level request parameters", () => {
@@ -24,6 +25,33 @@ describe("operationOptionsToRequestParameters", () => {
     assert.equal(result.onUploadProgress, onUpload);
     assert.equal(result.onDownloadProgress, onDownload);
     assert.deepEqual(result.headers, { "x-custom": "value" });
+  });
+
+  it("maps package-local customHeaders to headers and prefers canonical headers", () => {
+    const options: Omit<OperationOptions, "requestOptions"> & {
+      requestOptions: OperationRequestOptions & {
+        customHeaders: Record<string, string>;
+      };
+    } = {
+      requestOptions: {
+        customHeaders: {
+          "x-legacy": "legacy",
+          "X-Shared": "legacy",
+        },
+        headers: {
+          "X-Current": "current",
+          "x-shared": "current",
+        },
+      },
+    };
+
+    const result = operationOptionsToRequestParameters(options);
+
+    assert.deepEqual(result.headers, {
+      "x-legacy": "legacy",
+      "x-current": "current",
+      "x-shared": "current",
+    });
   });
 
   it("passes through abortSignal and onResponse", () => {


### PR DESCRIPTION
## Impact

- Package: `@azure-rest/core-client`
- Issue: #39593

## Summary

- Structurally recognize package-local legacy `requestOptions.customHeaders` without adding it to the public `@azure-rest/core-client` API.
- Merge legacy and canonical header names case-insensitively, with canonical `requestOptions.headers` taking precedence.
- Provide the core foundation needed by emitter-regenerated clients that still carry the package-local legacy alias.

## Tests

- `pnpm -C sdk/core/core-client-rest format`
- `pnpm -C sdk/core/core-client-rest check-format`
- `pnpm -C sdk/core/core-client-rest lint`
- `pnpm turbo build --filter=@azure-rest/core-client... --token 1`
- `pnpm -C sdk/core/core-client-rest exec vitest run test/internal/operationOptionHelpers.spec.ts --config vitest.config.ts`
- `pnpm -C sdk/core/core-client-rest extract-api` (no public API report changes)
- `node eng/tools/ci-runner/index.js check-package-version core -packages "azure-rest-core-client"`