### PR TITLE
[cosmos] test: raise container.spec.ts suite timeout above the SDK requestTimeout

### DIFF
--- a/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
@@ -26,7 +26,10 @@ import { GeospatialType } from "../../../src/index.js";
 import { describe, it, assert, beforeEach, beforeAll } from "vitest";
 import { skipTestForSignOff } from "../common/_testConfig.js";
 
-describe("Containers", { timeout: 10000 }, () => {
+// Must exceed the SDK's default requestTimeout (60s, ConnectionPolicy.ts): a tighter
+// budget kills the test mid-await with no diagnostics when the emulator stalls on a
+// single control-plane request. See https://github.com/Azure/azure-sdk-for-js/issues/39659.
+describe("Containers", { timeout: 120000 }, () => {
   beforeEach(async () => {
     await removeAllDatabases();
   });


### PR DESCRIPTION
Fixes #39659.

One-line test-only change. `container.spec.ts` capped its suite at 10s while the repo default is 20 minutes and the SDK's own `requestTimeout` is 60s. Its indexing-policy test runs 8 sequential control-plane ops in that budget; when the emulator stalls on one request there is no SDK-side signal before 60s (writes are not retried on connection errors; the 503 path throws immediately), so vitest kills the test at 10s with no diagnostics.

This is the dominant recurring failure of `Public windows_22x_coverage` — it was the only failure in two of the three runs on #39627 (killed at 10068ms and 10065ms against ~1.6–2.4s passes; full evidence in #39659). Raising the budget to 2× `requestTimeout` lets a genuinely hung request surface as the SDK's own `TimeoutError` with diagnostics instead of a silent kill.

No source changes; no other tests affected. Happy to switch to plain removal of the override (inheriting the repo-default `testTimeout: 1200000`) if maintainers prefer.
