### PR TITLE
[Service Bus] Clarify and sample session listing

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -504,6 +504,14 @@ for await (const sessionId of serviceBusClient.listMessageSessions("my-session-q
 for await (const sessionId of serviceBusClient.listMessageSessions("my-topic", "my-subscription")) {
   console.log("Session ID:", sessionId);
 }
+
+// List only sessions whose stored session state was set or updated in the last seven days
+const sessionStateUpdatedAfter = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+for await (const sessionId of serviceBusClient.listMessageSessions("my-session-queue", {
+  sessionStateUpdatedAfter,
+})) {
+  console.log("Recently updated session ID:", sessionId);
+}
 ```
 
 ### Manage resources of a service bus namespace

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -39,9 +39,9 @@ import { ensureValidIdentifier } from "./util/utils.js";
  * (10000-01-01T00:00:00Z) due to double-to-long rounding in TotalMilliseconds,
  * and its decoder clamps values beyond DateTime.MaxValue.Ticks back to
  * DateTime.MaxValue. The service checks `lastUpdatedTime != DateTime.MaxValue`
- * (exact equality) to switch into default listing mode, which returns sessions
- * with active messages or stored session state. This value matches Track 1
- * Java's SessionBrowser.MAXDATE = new Date(253402300800000L).
+ * to switch into updated-since mode; exact equality selects default listing,
+ * which returns sessions with active messages or stored session state. This
+ * value matches Track 1 Java's SessionBrowser.MAXDATE = new Date(253402300800000L).
  *
  * @internal
  */

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -39,12 +39,13 @@ import { ensureValidIdentifier } from "./util/utils.js";
  * (10000-01-01T00:00:00Z) due to double-to-long rounding in TotalMilliseconds,
  * and its decoder clamps values beyond DateTime.MaxValue.Ticks back to
  * DateTime.MaxValue. The service checks `lastUpdatedTime != DateTime.MaxValue`
- * (exact equality) to switch into "active messages" mode. This value matches
- * Track 1 Java's SessionBrowser.MAXDATE = new Date(253402300800000L).
+ * (exact equality) to switch into default listing mode, which returns sessions
+ * with active messages or stored session state. This value matches Track 1
+ * Java's SessionBrowser.MAXDATE = new Date(253402300800000L).
  *
  * @internal
  */
-export const ACTIVE_SESSIONS_SENTINEL_MS = 253402300800000;
+export const DEFAULT_LISTING_SENTINEL_MS = 253402300800000;
 
 /**
  * A client that can create Sender instances for sending messages to queues and
@@ -540,10 +541,11 @@ export class ServiceBusClient {
     const pageSize = 100;
 
     // The service checks for DateTime.MaxValue (C# 9999-12-31T23:59:59.9999999) to switch
-    // between "active messages" mode and "updated since" mode. On the AMQP wire, timestamps
-    // have millisecond precision, so DateTime.MaxValue becomes this value in ms from epoch.
+    // between default listing mode (active messages or stored session state) and updated-since
+    // mode. On the AMQP wire, timestamps have millisecond precision, so DateTime.MaxValue becomes
+    // this value in ms from epoch.
     const lastUpdatedTime =
-      options?.sessionStateUpdatedAfter ?? new Date(ACTIVE_SESSIONS_SENTINEL_MS);
+      options?.sessionStateUpdatedAfter ?? new Date(DEFAULT_LISTING_SENTINEL_MS);
 
     const pagedResult: PagedResult<string[], { maxPageSize?: number }, number> = {
       firstPageLink: 0,

--- a/sdk/servicebus/service-bus/test/internal/unit/listMessageSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/listMessageSessions.spec.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ACTIVE_SESSIONS_SENTINEL_MS, ServiceBusClient } from "../../../src/serviceBusClient.js";
+import { DEFAULT_LISTING_SENTINEL_MS, ServiceBusClient } from "../../../src/serviceBusClient.js";
 import { translateServiceBusError } from "../../../src/serviceBusError.js";
 import { describe, it } from "vitest";
 import { expect } from "../../public/utils/chai.js";
 
 /**
- * Unit tests for the active-messages sentinel value used by listMessageSessions.
+ * Unit tests for the default-listing sentinel value used by listMessageSessions.
  *
  * The service checks `lastUpdatedTime != DateTime.MaxValue` (exact equality) to switch
- * between "active messages" mode and "updated since" mode. The .NET AMQP library
+ * between default listing mode and updated-since mode. Default listing mode returns
+ * sessions with active messages or stored session state. The .NET AMQP library
  * (TimeStampEncoding.cs) encodes DateTime.MaxValue as 253402300800000 ms
  * (10000-01-01T00:00:00Z) due to double-to-long rounding in TotalMilliseconds.
  * Sending 253402300799999 (1 ms less) fails this check and the service returns
- * empty results instead of sessions with active messages.
+ * empty results instead of sessions with active messages or stored session state.
  */
 describe("listMessageSessions sentinel", function (): void {
   it("sentinel matches .NET AMQP encoding of DateTime.MaxValue (253402300800000 ms)", () => {
@@ -22,14 +23,14 @@ describe("listMessageSessions sentinel", function (): void {
     // so no api.md diff guards it, and the wire-value assertions elsewhere compare
     // against the constant itself. It must be 253402300800000, not 253402300799999
     // (the last ms of year 9999): sending the lower value fails the service's
-    // DateTime.MaxValue equality check and takes the active-messages code path.
-    expect(ACTIVE_SESSIONS_SENTINEL_MS).to.equal(253402300800000);
+    // DateTime.MaxValue equality check and takes the updated-since code path.
+    expect(DEFAULT_LISTING_SENTINEL_MS).to.equal(253402300800000);
   });
 
   it("sentinel represents 10000-01-01T00:00:00.000Z", () => {
     // Pins the expanded-year ISO form (normative per ECMA-262), independent of
     // the numeric assertion above.
-    const d = new Date(ACTIVE_SESSIONS_SENTINEL_MS);
+    const d = new Date(DEFAULT_LISTING_SENTINEL_MS);
     expect(d.toISOString()).to.equal("+010000-01-01T00:00:00.000Z");
   });
 });
@@ -63,7 +64,7 @@ describe("listMessageSessions request", function (): void {
     return { client, calls };
   }
 
-  it("puts the active-messages sentinel Date on the wire by default", async () => {
+  it("puts the default-listing sentinel Date on the wire by default", async () => {
     const { client, calls } = stubbedClient([["s1"]]);
     const ids: string[] = [];
     for await (const id of client.listMessageSessions("myqueue")) {
@@ -72,7 +73,7 @@ describe("listMessageSessions request", function (): void {
     expect(ids).to.eql(["s1"]);
     expect(calls).to.have.lengthOf(1);
     expect(calls[0].lastUpdatedTime).to.be.instanceOf(Date);
-    expect(calls[0].lastUpdatedTime!.getTime()).to.equal(ACTIVE_SESSIONS_SENTINEL_MS);
+    expect(calls[0].lastUpdatedTime!.getTime()).to.equal(DEFAULT_LISTING_SENTINEL_MS);
     expect(calls[0].skip).to.equal(0);
     expect(calls[0].top).to.equal(100);
     await client.close();

--- a/sdk/servicebus/service-bus/test/public/listMessageSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/listMessageSessions.spec.ts
@@ -30,7 +30,7 @@ describe("listMessageSessions", () => {
     await serviceBusClient.close();
   });
 
-  it("returns sessions with active messages", async () => {
+  it("includes sessions with active messages in default listing mode", async () => {
     // Send messages to distinct sessions
     const sessionIds = ["list-session-1", "list-session-2", "list-session-3"];
     for (const sessionId of sessionIds) {

--- a/sdk/servicebus/service-bus/test/snippets.spec.ts
+++ b/sdk/servicebus/service-bus/test/snippets.spec.ts
@@ -161,6 +161,14 @@ describe("snippets", () => {
     )) {
       console.log("Session ID:", sessionId);
     }
+    // @ts-preserve-whitespace
+    // List only sessions whose stored session state was set or updated in the last seven days
+    const sessionStateUpdatedAfter = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    for await (const sessionId of serviceBusClient.listMessageSessions("my-session-queue", {
+      sessionStateUpdatedAfter,
+    })) {
+      console.log("Recently updated session ID:", sessionId);
+    }
   });
 
   it("ReadmeSampleSendMessage_Session", async () => {


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/service-bus`

### Issues associated with this PR

Related implementation: Azure/azure-sdk-for-js#38323

### Describe the problem that is addressed by this PR

The list-message-sessions documentation used incomplete "active messages" terminology and did not demonstrate the `sessionStateUpdatedAfter` mode.

This PR clarifies that default listing returns sessions with active messages or stored session state, renames the internal sentinel terminology to "default listing," and adds a README/snippet example that filters for state updated in the last seven days.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The samples omit the cutoff for the complete default set and pass a real timestamp for filtered results. They do not expose the internal far-future sentinel.

### Are there test cases added in this PR? _(If not, why?)_

Existing focused list-session tests were updated for the corrected terminology. The package builds and type-checks successfully, Prettier passes, and README snippets were regenerated from `test/snippets.spec.ts`.

### Provide a list of related PRs _(if any)_

Azure/azure-sdk-for-js#38323

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

Not applicable.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR need any fixes in the SDK Generator? No
- [x] Added a changelog (if necessary) - not necessary; no shipped behavior changes
