### PR TITLE
[Service Bus] Prepare @azure/service-bus 7.10.0-beta.5 release

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.10.0-beta.5 (Unreleased)
+## 7.10.0-beta.5 (2026-08-21)
 
 ### Features Added
 
@@ -8,15 +8,11 @@
 - Added `sqlFilterCount` and `correlationFilterCount` to `TopicRuntimeProperties`, exposing the total number of SQL filters and correlation filters across all of a topic's subscriptions. ([#39500](https://github.com/Azure/azure-sdk-for-js/pull/39500))
 - The ATOM administration client now sends `api-version=2024-05` (previously `2021-05`), which is required for the topic filter counts above. ([#39500](https://github.com/Azure/azure-sdk-for-js/pull/39500))
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Read `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB.
 - Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping remaining-time computations to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
 - Fixed CBS token renewal stopping permanently after a single failed renewal. A transient credential error (for example a failed AAD `getToken` during a workload-identity rotation) no longer leaves the link's token un-renewed; renewal now retries with a capped exponential backoff until it succeeds or the link closes. [#38467](https://github.com/Azure/azure-sdk-for-js/issues/38467)
-
-### Other Changes
 
 ## 7.10.0-beta.4 (2026-03-10)
 


### PR DESCRIPTION
## Summary

Prepares `@azure/service-bus` `7.10.0-beta.5` for the planned
August 21, 2026 release.

## Changes

- `sdk/servicebus/service-bus/CHANGELOG.md`

No additional package changes.

## Cross-SDK release set

| SDK | Package | Version | PR |
|-----|---------|---------|----|
| .NET | `Azure.Messaging.ServiceBus` | `7.21.0-beta.1` | [#62282](https://github.com/Azure/azure-sdk-for-net/pull/62282) |
| Java | `azure-messaging-servicebus` | `7.18.0-beta.3` | [#50198](https://github.com/Azure/azure-sdk-for-java/pull/50198) |
| JavaScript | `@azure/service-bus` | `7.10.0-beta.5` | [#39672](https://github.com/Azure/azure-sdk-for-js/pull/39672) |
| Go | `sdk/messaging/azservicebus` | `1.11.0-beta.1` | [#27420](https://github.com/Azure/azure-sdk-for-go/pull/27420) |
| Python | `azure-servicebus` | `7.15.0b2` | [#48649](https://github.com/Azure/azure-sdk-for-python/pull/48649) |

## Validation

- `./eng/common/scripts/Prepare-Release.ps1 -PackageName '@azure/service-bus' -ServiceDirectory servicebus -ReleaseDate '08/21/2026'`
- `git diff --check`
- Metadata-only change; no product tests required.

## Release controls

- Release tracking: [22034 - JavaScript - Service Bus - 7.10](https://dev.azure.com/azure-sdk/Release/_workitems/edit/22034/)
- Release pipeline: Not queued by this PR.
