### PR TITLE
Disable SBOM

### DIFF
--- a/eng/common/pipelines/templates/jobs/npm-publish.yml
+++ b/eng/common/pipelines/templates/jobs/npm-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
   templateContext:
     type: releaseJob
-    isProduction: ${{ eq(parameters.Registry, 'https://registry.npmjs.org/') }}
+    isProduction: false
     inputs:
     - input: pipelineArtifact
       artifactName: ${{ parameters.ArtifactName }}

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -170,6 +170,7 @@ steps:
     parameters:
       ArtifactPath: "$(Build.ArtifactStagingDirectory)"
       ArtifactName: "packages"
+      SbomEnabled: false
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -170,7 +170,6 @@ steps:
     parameters:
       ArtifactPath: "$(Build.ArtifactStagingDirectory)"
       ArtifactName: "packages"
-      SbomEnabled: false
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:


### PR DESCRIPTION
This pull request makes a minor adjustment to the npm publish pipeline configuration. The change ensures that the `isProduction` flag in the `npm-publish.yml` template context is always set to `false`, regardless of the registry being used.

- Pipeline configuration:
  * In `eng/common/pipelines/templates/jobs/npm-publish.yml`, the `isProduction` parameter is now hardcoded to `false` instead of being dynamically set based on the registry URL.