### PR TITLE
[ai-projects] Add post-release Foundry docs skill

### DIFF
--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/SKILL.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: sync-foundry-docs-after-release
+description: "Sync Microsoft Foundry JavaScript/TypeScript documentation after an @azure/ai-projects release. Use when a stable package version has shipped and azure-ai-docs-pr needs its SDK version guidance, inline JavaScript snippets, TypeScript snippets, includes, or external sample references audited against the released API. Verifies the release tag and npm publication, derives API changes from the release diff, updates only affected Foundry docs, and validates snippets before handoff. Do not use for unreleased builds or Foundry classic 1.x docs."
+argument-hint: "[docs repo path] [released version]"
+---
+
+# Sync Foundry docs after an ai-projects release
+
+Audit Microsoft Foundry docs against a released `@azure/ai-projects` package,
+sync explicit 2.x version guidance, and update affected JS/TS examples from SDK
+source. This workflow edits `azure-ai-docs-pr`, not SDK source or samples.
+
+## When to use
+
+- A stable `@azure/ai-projects` version has been published.
+- Foundry articles still name an older 2.x JavaScript library version.
+- A release added, removed, renamed, or reshaped APIs used by Foundry JS/TS
+  examples.
+- A post-release docs PR is needed in `azure-ai-docs-pr`.
+
+Do not use this skill to document an unreleased package, update other language
+tabs opportunistically, or migrate Foundry classic content from SDK 1.x.
+
+## Inputs
+
+| Name       | Default                                                                | Description                                       |
+| ---------- | ---------------------------------------------------------------------- | ------------------------------------------------- |
+| `sdkRepo`  | Current `azure-sdk-for-js` root                                        | Repository containing `sdk/ai/ai-projects`.       |
+| `docsRepo` | Explicit argument, `AZURE_AI_DOCS_PR`, then `~/repos/azure-ai-docs-pr` | Clean canonical checkout or verified GitHub fork. |
+| `version`  | npm `latest` dist-tag                                                  | Stable published version to document.             |
+
+Use [references/foundry-docs-surface.md](./references/foundry-docs-surface.md)
+as the maintained starting map. Always run a fresh search because docs move and
+new articles can acquire package references between releases.
+
+## Safety rails
+
+- Stop if either repository has unrelated changes. Never stash, discard, or
+  overwrite another contributor's work.
+- Stop if the target version, npm publication, release tag, tagged package
+  metadata, and tagged dated changelog entry do not all identify the same
+  stable version. The current branch can already contain the next unreleased
+  version; in that case, use only the released tag snapshot as SDK evidence.
+- Work from a dedicated docs branch based on the latest canonical
+  `MicrosoftDocs/azure-ai-docs-pr` `main`. Remote names are not fixed.
+- Read the docs repository's `.github/AGENTS.md`,
+  `.github/copilot-instructions.md`, and applicable nested instructions before
+  editing.
+- Do not edit `articles/foundry-classic/**` or its `1.0.1` references for a 2.x
+  release.
+- Do not bulk-replace version numbers. API versions, model versions, Java/.NET
+  package versions, Node versions, and REST dates are different domains.
+- Do not edit SDK files under `generated/` or published `samples/`. For JS
+  evidence, use `src/`, `review/ai-projects-node.api.md`, `README.md`,
+  `test/snippets.spec.ts`, and `samples-dev/`.
+- Do not invent examples. Every changed call, option, model, and return shape
+  must be supported by the released API report and an SDK source/sample anchor.
+- Treat the docs snippet harness's `--dry-run` as syntax validation only. Prove
+  SDK API compatibility separately against the exact released package.
+- Do not run live docs snippets or create Azure resources without explicit user
+  approval. Static and compile-only validation comes first.
+- Do not stage, commit, push work, or open a docs PR unless the user requests
+  it. The only preauthorized remote mutation is a non-force synchronization of
+  a verified fork's `main` from canonical `main` during checkout preparation.
+
+## Procedure
+
+Run SDK commands from the `azure-sdk-for-js` root and docs commands from the
+`azure-ai-docs-pr` root.
+
+### 1. Resolve and inspect the docs checkout
+
+Resolve `docsRepo` in this order:
+
+1. The path supplied by the user.
+2. `$env:AZURE_AI_DOCS_PR`.
+3. `Join-Path $HOME 'repos/azure-ai-docs-pr'`.
+
+Follow the inspection phase in
+[docs checkout and fork sync](./references/docs-checkout.md). Accept either:
+
+- A canonical checkout, where any remote points to
+  `MicrosoftDocs/azure-ai-docs-pr`.
+- A checkout whose `origin` is verified through GitHub metadata as a fork of
+  `MicrosoftDocs/azure-ai-docs-pr`.
+
+Record the canonical remote and optional fork remote by repository identity,
+not by assuming names such as `origin`, `upstream`, or `fork`. Also record the
+current branch, upstream, and both repository statuses:
+
+```powershell
+git -C $docsRepo remote
+git -C $docsRepo branch --show-current
+git -C $docsRepo status --short
+git -C $sdkRepo status --short
+```
+
+Before editing, read:
+
+- `.github/AGENTS.md`
+- `.github/copilot-instructions.md`
+- Applicable files under `.github/instructions/`
+- `.github/skills/test-code-snippets/SKILL.md`
+- `.github/skills/learn-tabs/references/validation-checks.md`
+
+Preserve monikers, tab order, Markdown includes, `<!-- preserve -->` sections,
+and any generated-content boundaries those instructions identify.
+
+Do not switch or create a branch yet. Prove the release and build its API change
+ledger first, without changing either working tree.
+
+### 2. Prove that the SDK version is released
+
+Follow [release verification](./references/release-verification.md). Require a
+stable npm `latest` version, matching exact npm publication, local release tag,
+tagged package version, and one dated tagged changelog entry. A package version
+or Git tag alone is not proof of publication.
+
+If the current SDK branch has moved to the next version, continue from the
+released tag snapshot. Never substitute newer unreleased APIs into this docs
+change.
+
+### 3. Build the release change ledger
+
+Follow [release diff and evidence](./references/release-diff.md) to resolve the
+immediate stable predecessor and compare tagged package metadata, API report,
+source, README, snippets, and samples. Record any Node engine change.
+
+Create a short ledger before touching docs:
+
+- Added public operations, models, options, enum/union values, and properties.
+- Removed or renamed public symbols and their replacements.
+- Signature, requiredness, return-shape, paging, polling, and behavior changes.
+- New or updated SDK samples that demonstrate each customer-facing change.
+- Release changes that do not affect documentation snippets.
+
+Use this authority order when sources disagree. Read each source from
+`$releaseTag`, not from the current branch:
+
+1. Released `review/ai-projects-node.api.md` and exported `src/` declarations.
+2. Released `test/snippets.spec.ts`, `samples-dev/`, and README snippets.
+3. The dated changelog entry for intent and customer impact.
+
+### 4. Synchronize the fork and create the docs branch
+
+After release proof and ledger creation succeed, follow the preparation phase in
+[docs checkout and fork sync](./references/docs-checkout.md).
+
+If a verified fork exists, initiate `gh repo sync` for its `main` from
+`MicrosoftDocs/azure-ai-docs-pr` `main`, without `--force`, then fetch and
+require the fork and canonical remote-tracking refs to match. This covers both
+common layouts: `origin=canonical, fork=fork` and
+`origin=fork, upstream=canonical`.
+
+Create `docs/ai-projects-<version>` explicitly from canonical `main`, never
+from the currently checked-out feature branch. If the branch already exists,
+do not reset or recreate it; require it to contain the latest canonical `main`
+and no unrelated changes.
+
+### 5. Inventory affected Foundry documentation
+
+Search the current docs tree instead of relying only on the reference map:
+
+````powershell
+git -C $docsRepo grep -n -E `
+  '@azure/ai-projects|Azure AI Projects client library' -- `
+  articles/foundry articles/foundry-classic
+git -C $docsRepo grep -n -E '\b[0-9]+\.[0-9]+\.[0-9]+( or later)?\b' -- `
+  articles/foundry
+git -C $docsRepo grep -n -E '```(javascript|typescript|js|ts)|:::code' -- `
+  articles/foundry
+````
+
+For every removed, renamed, or materially changed API in the ledger, search its
+old and new symbol names under `articles/foundry/**`. Include shared Markdown
+includes and the source of every `:::code` directive.
+
+Before editing a shared include, find every caller by searching for its file
+name across both `articles/foundry/**` and `articles/foundry-classic/**`. If a
+classic article consumes it, do not put 2.x-only prose or code in that include;
+update the active caller or split the include according to docs-repo patterns.
+
+Classify each match before editing:
+
+| Match                                                                                | Action                                                                      |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Exact active 2.x SDK version in prose or a version matrix                            | Update to the released version.                                             |
+| Minimum-version statement tied to a feature                                          | Update only when that feature first appears in this release.                |
+| Unpinned `npm install @azure/ai-projects`                                            | Keep unpinned; verify it installs the current stable package.               |
+| "latest" or "current version" guidance                                               | Keep unless it is technically false; do not replace reflexively with a pin. |
+| Foundry classic `1.0.1` guidance                                                     | Leave unchanged.                                                            |
+| REST `api-version`, model version, Node version, or another language package version | Leave unchanged unless independently required by the release.               |
+
+### 6. Synchronize version guidance
+
+Update explicit active 2.x references from the prior SDK version to the released
+version. Keep installation commands unpinned unless the article deliberately
+teaches side-by-side version selection. In particular:
+
+- Update current-version matrices and sentences such as
+  `Use Node.js 22 or later with @azure/ai-projects <version>`.
+- Update `<version> or later` only when it describes the general current SDK or
+  a feature introduced by the release.
+- Do not change the Node requirement unless `package.json.engines.node` changed.
+- Update `ms.date` to the edit date in every modified published article/include.
+- Add `ai-usage: ai-assisted` to modified files under `articles/**` when it is
+  absent and AI meaningfully contributed, as required by docs-repo guidance.
+
+### 7. Update JavaScript and TypeScript snippets
+
+Audit every JS/TS snippet that uses an API in the release ledger. Cover:
+
+- Inline `javascript`, `typescript`, `js`, and `ts` fenced blocks.
+- JavaScript/TypeScript tabs inside Microsoft Learn tab groups or zone pivots.
+- Shared `[!INCLUDE]` files; edit the include source rather than every caller.
+- `:::code` directives; resolve and update the owning external sample instead
+  of copying it into the article.
+
+For each affected example:
+
+1. Start from the nearest released SDK sample or snippet source.
+2. Match released method names, argument order, options-bag properties, model
+   discriminators, async/paging/poller usage, and return shape.
+3. Keep `DefaultAzureCredential`, environment variables, placeholders, and
+   cleanup behavior consistent with docs-repo rules.
+4. Update nearby prose and expected output when the observable behavior changed.
+5. Preserve the surrounding language tabs exactly. Do not rewrite Python,
+   .NET, Java, or REST examples merely to mirror JavaScript.
+
+If an external `:::code` source checkout is missing or the new API cannot be
+compiled or behavior-tested, stop that snippet update and report the owning
+repository/path as a follow-up. Do not publish an unverified approximation.
+
+### 8. Validate the docs change
+
+First rerun searches for the prior version and every removed API symbol. Review
+each remaining hit and explain why it is intentionally retained.
+
+From `azure-ai-docs-pr`, validate the snippet environment and each changed
+article or include:
+
+```powershell
+python .github/skills/test-code-snippets/scripts/test_snippets.py --check-env
+python .github/skills/test-code-snippets/scripts/test_snippets.py `
+  --doc <changed-article-or-include.md> --dry-run
+```
+
+`--dry-run` does not prove SDK API compatibility. Follow
+[snippet validation](./references/snippet-validation.md). For each complete
+changed JS/TS block, copy it unchanged to a scratch file outside both
+repositories and run the exact-version checker:
+
+```powershell
+$snippetTester = Join-Path $packageDir `
+  '.github/skills/sync-foundry-docs-after-release/scripts/test-released-snippet.ps1'
+& $snippetTester -SnippetPath <scratch-snippet.ts> -Version $version
+```
+
+Then run the docs repository's tab-count, tab-ID-order, and stray-tab-anchor
+checks from `.github/skills/learn-tabs/references/validation-checks.md` against
+the changed files. Inspect VS Code Markdown diagnostics for broken links and
+metadata errors.
+
+Do not run the generic harness in non-dry mode across a mixed-language article
+without understanding its scope. `--live --confirm` requires explicit user
+approval because it can call Azure and create billable resources.
+
+Finally verify:
+
+- Every modified file belongs to the intended Foundry JS docs surface.
+- No `articles/foundry-classic/**` file changed.
+- No protected section or unrelated language tab changed.
+- No shared include introduced 2.x-only content into a classic caller.
+- Every explicit current 2.x reference equals the released version.
+- Every changed API call exists in the released API report.
+- `git diff --check` passes in `azure-ai-docs-pr`.
+
+## Handoff
+
+Leave a focused working-tree diff in `azure-ai-docs-pr` and report:
+
+- Released and previous SDK versions/tags.
+- Version-reference files updated and intentionally retained matches.
+- JS/TS snippets updated, with their SDK source anchors.
+- External snippet follow-ups or validation gaps.
+- Exact validation commands and outcomes.
+
+If the user asks to publish, create a dedicated docs commit and preview pull
+request in `MicrosoftDocs/azure-ai-docs-pr` following that repository's branch,
+AI-disclosure, and Open Publishing requirements. For a fork checkout, push the
+work branch to the verified fork remote and target canonical `main`. Never
+force-push.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/docs-checkout.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/docs-checkout.md
@@ -1,0 +1,75 @@
+# Docs checkout and fork sync
+
+Remote names are roles, not assumptions. Accept either the canonical repository
+or a verified GitHub fork of `MicrosoftDocs/azure-ai-docs-pr`.
+
+## Inspect the checkout
+
+Require clean SDK and docs trees. Read each remote URL without printing
+credentials. Accept GitHub HTTPS, SCP-style SSH, or `ssh://` URLs only when they
+end in `<owner>/azure-ai-docs-pr(.git)`. Derive each `owner/repo` slug.
+
+The canonical remote is the remote whose slug is exactly
+`MicrosoftDocs/azure-ai-docs-pr`. Verify every fork candidate with:
+
+```powershell
+gh api "repos/$forkSlug" --jq `
+  '{full_name, fork, parent: .parent.full_name, default_branch}'
+```
+
+Require `fork: true`, parent `MicrosoftDocs/azure-ai-docs-pr`, and default
+branch `main`. Also require canonical default branch `main`. If `origin` is not
+canonical, it must pass this fork check. Stop on ambiguous multiple forks.
+
+Record `$canonicalRemote`, optional `$forkRemote`, and `$forkSlug`. Common valid
+layouts are:
+
+- `origin` = canonical and `fork` = verified fork.
+- `origin` = verified fork and `upstream` = canonical.
+
+If `origin` is a verified fork and no canonical remote exists, defer setup until
+the preparation phase. If a remote named `upstream` already points elsewhere,
+stop instead of replacing it.
+
+## Prepare after release verification
+
+If needed, add the canonical remote, then fetch canonical `main`:
+
+```powershell
+git -C $docsRepo remote add upstream `
+  https://github.com/MicrosoftDocs/azure-ai-docs-pr.git
+$canonicalRemote = 'upstream'
+git -C $docsRepo fetch $canonicalRemote main
+```
+
+Run `remote add` only when no canonical remote exists. If a verified fork is
+configured, synchronize its remote `main` on GitHub:
+
+```powershell
+gh repo sync $forkSlug `
+  --source MicrosoftDocs/azure-ai-docs-pr `
+  --branch main
+```
+
+Never add `--force`. If fast-forward synchronization fails because the fork
+diverged, stop for human resolution. After success:
+
+```powershell
+git -C $docsRepo fetch $canonicalRemote main
+git -C $docsRepo fetch $forkRemote main
+$canonicalSha = git -C $docsRepo rev-parse `
+  "refs/remotes/$canonicalRemote/main"
+$forkSha = git -C $docsRepo rev-parse "refs/remotes/$forkRemote/main"
+if ($canonicalSha -ne $forkSha) { throw 'Fork main did not synchronize.' }
+```
+
+Create the work branch from canonical `main`:
+
+```powershell
+git -C $docsRepo switch --create "docs/ai-projects-$version" `
+  "refs/remotes/$canonicalRemote/main"
+```
+
+For an existing work branch, require canonical `main` to be its ancestor and
+inspect `git diff --name-only "$canonicalRemote/main...HEAD"`; stop on unrelated
+work.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/foundry-docs-surface.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/foundry-docs-surface.md
@@ -1,0 +1,61 @@
+# Foundry JavaScript docs surface
+
+Starting map only. Search `azure-ai-docs-pr` on every run because ownership and
+includes move.
+
+## Active 2.x version references
+
+- `articles/foundry/how-to/develop/sdk-overview.md`
+- `articles/foundry/agents/concepts/runtime-components.md`
+- `articles/foundry/agents/how-to/memory-usage.md`
+- `articles/foundry/agents/how-to/migrate.md`
+- `articles/foundry/agents/how-to/tools/work-iq.md`
+
+- `articles/foundry/includes/quickstart-v2-install.md`
+- `articles/foundry/includes/how-to-develop-sdk-overview-2.md`
+
+The second include is consumed by both active docs and
+`articles/foundry-classic/how-to/develop/sdk-overview.md`. Do not add 2.x-only
+content to it. Search all include callers before editing either include.
+
+## Classic boundary
+
+Classic docs intentionally retain SDK `1.0.1`; a 2.x release does not update
+them.
+
+## Common unpinned install sites
+
+- `articles/foundry/agents/how-to/use-routines.md`
+- `articles/foundry/agents/how-to/tools/ai-search.md`
+- `articles/foundry/agents/how-to/tools/azure-functions.md`
+- `articles/foundry/agents/how-to/tools/image-generation.md`
+- `articles/foundry/agents/how-to/tools/sharepoint.md`
+- `articles/foundry/agents/how-to/tools/toolbox.md`
+
+Keep these installs unpinned. Preserve accurate "latest" wording in
+`file-search.md`, `function-calling.md`, and `web-overview.md`.
+
+## Snippet forms
+
+1. Inline fenced blocks in an article.
+2. JavaScript/TypeScript tabs in a Microsoft Learn tab group.
+3. Shared Markdown files referenced with `[!INCLUDE]`.
+4. External files referenced with `:::code source="..."`.
+
+Edit include sources, after checking all callers. Resolve `:::code` to its
+owning repository; the current root is `~/foundry-samples-main/...`. If source
+is unavailable, report a follow-up instead of copying code into the article.
+
+## High-yield snippet areas
+
+- `articles/foundry/agents/concepts/runtime-components.md`
+- `articles/foundry/agents/how-to/memory-usage.md`
+- `articles/foundry/agents/how-to/migrate.md`
+- `articles/foundry/agents/how-to/structured-inputs.md`
+- `articles/foundry/agents/how-to/use-routines.md`
+- `articles/foundry/agents/how-to/tools/`
+- `articles/foundry/how-to/develop/sdk-overview.md`
+
+Search changed API symbols across all `articles/foundry/**`, not only this list.
+Do not confuse npm versions with REST/API, model, toolbox URL, Node, metadata,
+or other-language versions.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-diff.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-diff.md
@@ -1,0 +1,36 @@
+# Release diff and evidence
+
+Resolve stable tags in semantic-version order after fetching tags:
+
+```powershell
+$stableTags = @(git tag --list '@azure/ai-projects_*' --sort=-v:refname |
+  Where-Object { $_ -match '^@azure/ai-projects_\d+\.\d+\.\d+$' })
+$targetIndex = [Array]::IndexOf($stableTags, $releaseTag)
+```
+
+For npm `latest`, require `$targetIndex -eq 0`. The immediate predecessor is
+`$stableTags[$targetIndex + 1]`; stop if either index is unavailable. Compare:
+
+```powershell
+git diff "$previousTag..$releaseTag" -- `
+  sdk/ai/ai-projects/package.json `
+  sdk/ai/ai-projects/CHANGELOG.md `
+  sdk/ai/ai-projects/review/ai-projects-node.api.md `
+  sdk/ai/ai-projects/README.md `
+  sdk/ai/ai-projects/src `
+  sdk/ai/ai-projects/test/snippets.spec.ts `
+  sdk/ai/ai-projects/samples-dev
+```
+
+Compare tagged `package.json.engines.node` values separately. Build a ledger of
+added/removed/renamed APIs; signatures and requiredness; options, unions, and
+return shapes; paging/polling behavior; and new authoritative samples.
+
+Evidence priority, always read from `$releaseTag`:
+
+1. API report and exported `src/` declarations.
+2. `test/snippets.spec.ts`, `samples-dev/`, and README snippets.
+3. Dated changelog entry for intent.
+
+Mark release changes that require no docs update. Never use newer current-branch
+source as evidence for the released API.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-verification.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-verification.md
@@ -1,0 +1,38 @@
+# Release verification
+
+Run from `azure-sdk-for-js`. Fetch tags, then resolve npm `latest`:
+
+```powershell
+git fetch origin --tags --prune
+$latest = npm view '@azure/ai-projects@latest' version 2>&1
+```
+
+If npm exits nonzero or reports inability to reach npm/its registry (`EAI_AGAIN`,
+`ENETUNREACH`, `ECONNRESET`, or `ETIMEDOUT`), retry only through:
+
+```powershell
+npm view '@azure/ai-projects@latest' version `
+  --registry=https://packagefeedproxy.microsoft.io/npm/
+```
+
+Use the resolved version unless the user explicitly requests a historical
+backfill. Otherwise stop when a supplied version differs from npm `latest`.
+Require stable semver, then set:
+
+```powershell
+$releaseTag = "@azure/ai-projects_$version"
+git rev-parse "refs/tags/$releaseTag"
+git show "${releaseTag}:sdk/ai/ai-projects/package.json"
+git show "${releaseTag}:sdk/ai/ai-projects/CHANGELOG.md"
+npm view "@azure/ai-projects@$version" version
+```
+
+Apply the same proxy fallback to the exact npm lookup. Require:
+
+- Exact npm result, tagged `package.json` version, and target version match.
+- Tagged changelog has exactly one `## <version> (YYYY-MM-DD)` entry and no
+  `(Unreleased)` entry for that version.
+- The current branch may differ only because development moved on; all evidence
+  for this workflow must then come from `$releaseTag`.
+
+Package metadata or a Git tag without npm publication is not a release.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-verification.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/release-verification.md
@@ -11,15 +11,16 @@ If npm exits nonzero or reports inability to reach npm/its registry (`EAI_AGAIN`
 `ENETUNREACH`, `ECONNRESET`, or `ETIMEDOUT`), retry only through:
 
 ```powershell
-npm view '@azure/ai-projects@latest' version `
+$latest = npm view '@azure/ai-projects@latest' version `
   --registry=https://packagefeedproxy.microsoft.io/npm/
 ```
 
-Use the resolved version unless the user explicitly requests a historical
-backfill. Otherwise stop when a supplied version differs from npm `latest`.
-Require stable semver, then set:
+If no version was supplied, set `$version = $latest`. For a historical
+backfill, keep the explicitly supplied version; otherwise stop when a supplied
+version differs from npm `latest`. Require stable semver, then set:
 
 ```powershell
+if (-not $version) { $version = $latest }
 $releaseTag = "@azure/ai-projects_$version"
 git rev-parse "refs/tags/$releaseTag"
 git show "${releaseTag}:sdk/ai/ai-projects/package.json"

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/snippet-validation.md
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/references/snippet-validation.md
@@ -1,0 +1,29 @@
+# JavaScript and TypeScript snippet validation
+
+The docs harness `--dry-run` checks syntax but does not install the target SDK.
+Use it first, then prove API compatibility against the exact release.
+
+For each complete changed JS/TS block:
+
+1. Copy the block unchanged to a scratch `.js` or `.ts` file outside both
+   repositories.
+2. Run
+   [`test-released-snippet.ps1`](../scripts/test-released-snippet.ps1) with the
+   scratch path and released version.
+3. Record the result and delete the scratch source.
+
+The checker requires Node 22+, pins `@azure/ai-projects` exactly, installs in an
+isolated temporary project through
+`https://packagefeedproxy.microsoft.io/npm/`, compiles with TypeScript, and
+removes the project unless `-KeepTemp` is set.
+
+For a partial block, create a minimal scratch harness that supplies only omitted
+declarations while retaining published statements unchanged. Keep that harness
+with the validation report. For snippets with relative files or a larger sample
+project, run the owning project's compile check with the SDK pinned exactly.
+Stop and report a gap when the source or dependencies are unavailable.
+
+Do not treat compilation as behavioral proof. Run live snippets only with
+explicit approval; Azure calls can create resources or charges. The generic
+docs harness has no language filter, so avoid non-dry runs on mixed-language
+articles unless every block is intentionally in scope.

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/scripts/test-released-snippet.ps1
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/scripts/test-released-snippet.ps1
@@ -1,0 +1,104 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateScript({ Test-Path $_ -PathType Leaf })]
+  [string] $SnippetPath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^\d+\.\d+\.\d+$')]
+  [string] $Version,
+
+  [switch] $KeepTemp
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sourcePath = (Resolve-Path $SnippetPath).Path
+$extension = [System.IO.Path]::GetExtension($sourcePath).ToLowerInvariant()
+$supportedExtensions = @('.js', '.mjs', '.cjs', '.ts', '.mts', '.cts')
+if ($extension -notin $supportedExtensions) {
+  throw "Unsupported snippet extension '$extension'."
+}
+
+$nodeCommand = Get-Command node -ErrorAction Stop
+$npmCommand = Get-Command npm -ErrorAction Stop
+$nodeVersion = (& $nodeCommand.Source --version).TrimStart('v')
+$nodeMajor = [int] ($nodeVersion -split '\.')[0]
+if ($nodeMajor -lt 22) {
+  throw "Node.js 22 or later is required; found $nodeVersion."
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+  'ai-projects-doc-snippet-' + [guid]::NewGuid().ToString('N')
+)
+$snippetName = "snippet$extension"
+$pushedLocation = $false
+
+try {
+  New-Item -ItemType Directory -Path $tempRoot | Out-Null
+  Copy-Item -LiteralPath $sourcePath -Destination (Join-Path $tempRoot $snippetName)
+
+  $packageJson = [ordered]@{
+    name = 'ai-projects-doc-snippet-check'
+    private = $true
+    version = '0.0.0'
+    type = 'module'
+    dependencies = [ordered]@{
+      '@azure/ai-projects' = $Version
+      '@azure/identity' = 'latest'
+      dotenv = 'latest'
+      openai = 'latest'
+    }
+    devDependencies = [ordered]@{
+      '@types/node' = 'latest'
+      typescript = 'latest'
+    }
+  }
+  $packageJson | ConvertTo-Json -Depth 5 |
+    Set-Content -Path (Join-Path $tempRoot 'package.json') -Encoding utf8
+
+  $tsconfig = [ordered]@{
+    compilerOptions = [ordered]@{
+      target = 'ES2022'
+      module = 'NodeNext'
+      moduleResolution = 'NodeNext'
+      strict = $true
+      noEmit = $true
+      skipLibCheck = $true
+      allowJs = $true
+      checkJs = $true
+      types = @('node')
+    }
+    include = @($snippetName)
+  }
+  $tsconfig | ConvertTo-Json -Depth 5 |
+    Set-Content -Path (Join-Path $tempRoot 'tsconfig.json') -Encoding utf8
+
+  Push-Location $tempRoot
+  $pushedLocation = $true
+
+  & $npmCommand.Source install --ignore-scripts --no-audit --no-fund `
+    --package-lock=false `
+    --registry=https://packagefeedproxy.microsoft.io/npm/
+  if ($LASTEXITCODE -ne 0) {
+    throw "Dependency installation failed with exit code $LASTEXITCODE."
+  }
+
+  & $nodeCommand.Source node_modules/typescript/bin/tsc `
+    --project tsconfig.json --pretty false
+  if ($LASTEXITCODE -ne 0) {
+    throw "Snippet compilation failed with exit code $LASTEXITCODE."
+  }
+
+  Write-Host "Snippet compiles with @azure/ai-projects@$Version."
+} finally {
+  if ($pushedLocation) {
+    Pop-Location
+  }
+  if ($KeepTemp) {
+    Write-Host "Temporary project retained at $tempRoot"
+  } elseif (Test-Path $tempRoot) {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+  }
+}

--- a/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/scripts/test-released-snippet.ps1
+++ b/sdk/ai/ai-projects/.github/skills/sync-foundry-docs-after-release/scripts/test-released-snippet.ps1
@@ -29,6 +29,21 @@ if ($nodeMajor -lt 22) {
   throw "Node.js 22 or later is required; found $nodeVersion."
 }
 
+$packageDependenciesJson = & $npmCommand.Source view `
+  "@azure/ai-projects@$Version" dependencies --json `
+  --registry=https://packagefeedproxy.microsoft.io/npm/
+if ($LASTEXITCODE -ne 0) {
+  throw "Package metadata lookup failed with exit code $LASTEXITCODE."
+}
+$packageDependencies = (
+  $packageDependenciesJson -join [Environment]::NewLine
+) | ConvertFrom-Json -AsHashtable
+foreach ($dependencyName in @('@azure/identity', 'openai')) {
+  if (-not $packageDependencies.ContainsKey($dependencyName)) {
+    throw "@azure/ai-projects@$Version does not declare a $dependencyName dependency."
+  }
+}
+
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
   'ai-projects-doc-snippet-' + [guid]::NewGuid().ToString('N')
 )
@@ -46,9 +61,9 @@ try {
     type = 'module'
     dependencies = [ordered]@{
       '@azure/ai-projects' = $Version
-      '@azure/identity' = 'latest'
+      '@azure/identity' = $packageDependencies['@azure/identity']
       dotenv = 'latest'
-      openai = 'latest'
+      openai = $packageDependencies['openai']
     }
     devDependencies = [ordered]@{
       '@types/node' = 'latest'


### PR DESCRIPTION
## Summary

- add a package-owned workflow for synchronizing Microsoft Foundry JavaScript documentation after an `@azure/ai-projects` release
- verify npm publication and tagged API changes before updating version guidance or JS/TS snippets
- support canonical and verified-fork `azure-ai-docs-pr` checkouts, including non-force fork `main` synchronization
- add an isolated checker that compiles docs snippets against the exact released package through the Microsoft npm proxy

## Validation

- Prettier check passed for `SKILL.md` and all references
- frontmatter, relative links, reference ownership, and token budgets passed
- PowerShell syntax validation passed
- `agentProgrammaticToolCalling.ts` compiled against exact `@azure/ai-projects@2.5.0`
- `git diff --check` passed