### PR TITLE
[core] surface the cause error code when a fetch request fails

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - `NodeHttpClient` request timeouts now remain active while buffered response bodies are being read. [Issue #39519](https://github.com/Azure/azure-sdk-for-js/issues/39519)
+- `FetchHttpClient` now surfaces the system error code (such as `ECONNRESET` or `ETIMEDOUT`) carried by the `cause` of a failed `fetch()` call on the resulting `RestError`, so that `systemErrorRetryPolicy` retries transient network failures instead of rethrowing them immediately. [Issue #39703](https://github.com/Azure/azure-sdk-for-js/issues/39703)
 
 ### Other Changes
 

--- a/sdk/core/ts-http-runtime/src/fetchHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/fetchHttpClient.ts
@@ -13,6 +13,7 @@ import { RestError } from "./restError.js";
 import { createHttpHeaders } from "./httpHeaders.js";
 import { isNodeReadableStream, isWebReadableStream } from "./util/typeGuards.js";
 import { arrayBufferViewToArrayBuffer } from "./util/arrayBuffer.js";
+import { isObject } from "./util/object.js";
 
 // The Fetch spec requires `duplex: "half"` when body is a ReadableStream,
 // but TypeScript's lib.dom.d.ts hasn't added it to RequestInit yet.
@@ -202,10 +203,21 @@ function getError(e: RestError, request: PipelineRequest): RestError {
     return e;
   } else {
     return new RestError(`Error sending request: ${e.message}`, {
-      code: e?.code ?? RestError.REQUEST_SEND_ERROR,
+      code: e?.code ?? getCauseCode(e) ?? RestError.REQUEST_SEND_ERROR,
       request,
     });
   }
+}
+
+/**
+ * Native fetch implementations such as undici in Node.js report network failures as a TypeError
+ * whose system error code (for example ECONNRESET, ETIMEDOUT or ENOTFOUND) is carried by the
+ * error's `cause` rather than by the error itself. Surfacing that code on the RestError lets
+ * retry policies classify the failure as a transient system error.
+ */
+function getCauseCode(e: Error): string | undefined {
+  const cause: unknown = e?.cause;
+  return isObject(cause) && typeof cause.code === "string" ? cause.code : undefined;
 }
 
 /**

--- a/sdk/core/ts-http-runtime/test/internal/browser/fetchHttpClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/browser/fetchHttpClient.spec.ts
@@ -1,9 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, assert, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, assert, expect, vi, beforeEach, afterEach } from "vitest";
 import { createFetchHttpClient } from "../../../src/fetchHttpClient.js";
-import { createPipelineRequest, createHttpHeaders, AbortError } from "../../../src/index.js";
+import {
+  createPipelineRequest,
+  createHttpHeaders,
+  AbortError,
+  RestError,
+  isRestError,
+} from "../../../src/index.js";
+import { systemErrorRetryPolicy } from "../../../src/policies/internal.js";
 import { png } from "./mocks/encodedPng.js";
 import { delay } from "../../../src/util/helpers.js";
 import { arrayBufferViewToArrayBuffer } from "../../../src/util/arrayBuffer.js";
@@ -512,6 +519,50 @@ describe("FetchHttpClient", function () {
     });
     const response = await client.sendRequest(request);
     assert.strictEqual(response.status, 200);
+  });
+
+  it("should surface the system error code carried by the cause of a failed fetch", async function () {
+    // Native fetch implementations such as undici throw a TypeError whose errno lives on the cause
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    vi.mocked(fetch).mockRejectedValue(new TypeError("fetch failed", { cause }));
+
+    const client = createFetchHttpClient();
+    const request = createPipelineRequest({ url: "https://localhost/reset" });
+    try {
+      await client.sendRequest(request);
+      assert.fail("Expected await to throw");
+    } catch (e: any) {
+      assert.isTrue(isRestError(e));
+      assert.strictEqual(e.code, "ECONNRESET");
+    }
+  });
+
+  it("should fall back to REQUEST_SEND_ERROR when neither the error nor its cause has a code", async function () {
+    vi.mocked(fetch).mockRejectedValue(new TypeError("fetch failed"));
+
+    const client = createFetchHttpClient();
+    const request = createPipelineRequest({ url: "https://localhost/reset" });
+    try {
+      await client.sendRequest(request);
+      assert.fail("Expected await to throw");
+    } catch (e: any) {
+      assert.isTrue(isRestError(e));
+      assert.strictEqual(e.code, RestError.REQUEST_SEND_ERROR);
+    }
+  });
+
+  it("should let systemErrorRetryPolicy retry a fetch failure caused by a system error", async function () {
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError("fetch failed", { cause }))
+      .mockResolvedValueOnce(createResponse(200));
+
+    const client = createFetchHttpClient();
+    const policy = systemErrorRetryPolicy({ retryDelayInMs: 1, maxRetryDelayInMs: 1 });
+    const request = createPipelineRequest({ url: "https://localhost/reset" });
+    const response = await policy.sendRequest(request, (req) => client.sendRequest(req));
+    assert.strictEqual(response.status, 200);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
[core] surface the cause error code when a fetch request fails

### Packages impacted by this PR

`@typespec/ts-http-runtime` (`sdk/core/ts-http-runtime`)

### Issues associated with this PR

Fixes #39703

### Describe the problem that is addressed by this PR

`getError()` in `src/fetchHttpClient.ts` wraps a rejected `fetch()` call into a `RestError` using `e?.code ?? RestError.REQUEST_SEND_ERROR`. Native fetch implementations such as undici in Node.js report TCP and TLS level failures as `TypeError("fetch failed", { cause })`: the error's own `code` is `undefined` and the real system error code (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND` and so on) lives on `error.cause.code`. As a result every such failure was wrapped with the generic `REQUEST_SEND_ERROR` code.

`isSystemError()` in `src/retryStrategies/exponentialRetryStrategy.ts` only matches the real system error codes, so `systemErrorRetryPolicy` never retried these failures and rethrew them on the first attempt. Reproduced on `main` with a mocked `fetch` that rejects with a `TypeError` carrying `cause.code = "ECONNRESET"`:

```
code: REQUEST_SEND_ERROR
isSystemError: false
policy rethrew code: REQUEST_SEND_ERROR after fetch calls: 1
```

With this change the same scenario yields `code: ECONNRESET`, `isSystemError: true`, and the policy retries (four fetch calls against an always failing mock, which is the default of three retries plus the initial attempt).

Scope note: the Node.js entry points of this package use `NodeHttpClient`, which already reads the code straight off the `http` error, so on Node.js `FetchHttpClient` is only involved when it is created explicitly through `createFetchHttpClient()` or when a bundler resolves the `browser` export condition. The browser build uses `FetchHttpClient` by default. The change applies to any consumer of `FetchHttpClient` whose fetch implementation attaches a `cause` with a `code`, which is what undici does.

Coverage note: undici forwards the Node system error as the `cause` for socket and DNS level failures (`ECONNRESET`, `ECONNREFUSED`, `ENOTFOUND` and so on), but some failures carry undici's own codes instead, for example `UND_ERR_SOCKET` when the socket is closed mid request or `UND_ERR_CONNECT_TIMEOUT` for a connect timeout. Those codes are now surfaced on the `RestError` too, which makes them visible for diagnostics, but `isSystemError()` still only matches its six Node codes, so they are not retried by this change. Whether `isSystemError()` should also recognize undici codes is left as a separate decision.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

1. Read the code from the cause at the wrapping site (chosen). The wrapper now uses `e?.code ?? getCauseCode(e) ?? RestError.REQUEST_SEND_ERROR`, where `getCauseCode(e: Error)` narrows `e.cause` with the existing `isObject` helper and returns `cause.code` when it is a string. This keeps the precedence of the error's own code, leaves `RestError` and the retry strategies untouched, and mirrors what `nodeHttpClient.ts` already does with `err.code ?? RestError.REQUEST_SEND_ERROR`. A helper is used instead of the one liner `e?.cause?.code` because `Error.cause` is typed `unknown` under the repository's ES2023 lib setting. The helper takes `Error` rather than `RestError` so that it satisfies the repository's `@azure/azure-sdk/ts-use-interface-parameters` rule without a suppression comment.
2. Teach `isSystemError()` to look at `err.cause`. Rejected: by the time the retry strategy sees the error it is a `RestError` created by the client, and the original cause has already been dropped, so the information has to be captured where the wrapping happens.

The error message is intentionally left as `Error sending request: fetch failed`. Nothing else in `fetchHttpClient.ts` composes messages from a cause, and `RestErrorOptions` has no `cause` field today, so appending the cause message or forwarding the cause would be a separate change that can be discussed as a follow up.

### Are there test cases added in this PR? _(If not, why?)_

Yes, three cases in `test/internal/browser/fetchHttpClient.spec.ts`, using the file's existing `vi.stubGlobal("fetch", vi.fn())` setup:

- the `RestError` code is `ECONNRESET` when `fetch` rejects with a `TypeError` whose `cause.code` is `ECONNRESET`
- the code still falls back to `REQUEST_SEND_ERROR` when neither the error nor its cause carries a code
- `systemErrorRetryPolicy` retries such a failure and succeeds on the second `fetch` call

The first and third cases fail on `main` without the source change (`expected 'REQUEST_SEND_ERROR' to equal 'ECONNRESET'`, and the policy rethrowing instead of retrying) and pass with it; the second documents unchanged behavior. With the change, the spec file passes 31 of 31 cases and the package's Node test suite passes 418 of 418 tests across 45 files. `prettier --check` on the changed files and `tsc --noEmit` with both `config/tsconfig.test.browser.json` and `config/tsconfig.test.node.json` are clean, and the repository's `ts-use-interface-parameters` rule reports nothing for the changed source and test files. A changelog entry was added under the Unreleased Bugs Fixed section.

### Provide a list of related PRs _(if any)_

None.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

Not applicable.

### Checklists
- [ ] Added impacted package name to the issue description (the issue's Environment section already names `@typespec/ts-http-runtime`; the description was not edited)
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary)
