### PR TITLE
Post release automated changes for servicebus releases

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 7.10.0-beta.6 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 7.10.0-beta.5 (2026-08-21)
 
 ### Features Added

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "7.10.0-beta.5",
+  "version": "7.10.0-beta.6",
   "license": "MIT",
   "description": "Azure Service Bus SDK for JavaScript",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/README.md",

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "7.10.0-beta.5",
+  version: "7.10.0-beta.6",
 };
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/service-bus`

### Issues associated with this PR

- Follow-up to release pipeline [6733349](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6733349).

### Describe the problem that is addressed by this PR

The external post-release automation did not open its expected version-increment PR after `@azure/service-bus` 7.10.0-beta.5 was published. This PR applies the equivalent generated changes: it advances the package and user-agent constant to 7.10.0-beta.6 and adds the next unreleased changelog section.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The alternatives were to continue waiting for the missing external automation or apply its documented `dev-tool package increment-version` operation manually. The manual operation was chosen after no automation branch or PR appeared for more than 48 hours.

### Are there test cases added in this PR? _(If not, why?)_

No tests were added because this is a metadata-only post-release version increment. The package version guard, formatting, dependency build, lint, and local Node/browser checks pass.

### Provide a list of related PRs _(if any)_

- Prior equivalent automation PR: [#37562](https://github.com/Azure/azure-sdk-for-js/pull/37562)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

`npx dev-tool package increment-version`

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog (if necessary)
