### PR TITLE
[Monitor OpenTelemetry] Respect OTEL_BSP environment variables

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed incorrect performance-counter sampling by giving standard and normalized process CPU counters independent state and initializing the first request and exception rate intervals with the current time. [#39520](https://github.com/Azure/azure-sdk-for-js/pull/39520)
 - Fixed a failed IMDS request being recorded as a dependency when running on App Service, Functions, and Container Apps. The Azure VM resource detector now runs only when no other detector has identified the platform. [#39510](https://github.com/Azure/azure-sdk-for-js/issues/39510)
+- The built-in `BatchSpanProcessor` now respects the standard OpenTelemetry `OTEL_BSP_*` environment variables. [#39607](https://github.com/Azure/azure-sdk-for-js/issues/39607)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -40,6 +40,7 @@ useAzureMonitor(options);
 ```
 
 - Connection String can be set via `APPLICATIONINSIGHTS_CONNECTION_STRING`.
+- Batch span processing can be configured with the standard OpenTelemetry environment variables `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`, `OTEL_BSP_SCHEDULE_DELAY`, and `OTEL_BSP_EXPORT_TIMEOUT`.
 - Sampler can be set via the OpenTelemetry env vars `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` (takes precedence over the `samplingRatio` option). Supported sampler values: `microsoft.rate_limited`, `microsoft.fixed_percentage`, `always_on`, `always_off`, `trace_id_ratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_trace_id_ratio`. For `microsoft.rate_limited`, the arg is spans per second; for `trace_id_ratio`/parentbased, the arg is a probability in [0,1]. When the arg is omitted, defaults apply (rate limit disabled; probability defaults to 1). See the upstream OpenTelemetry environment variable spec for full context: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
 - To use the **fixed percentage sampler** (instead of the default rate-limited sampler), you can either:
   - Set the environment variable `OTEL_TRACES_SAMPLER=microsoft.fixed_percentage` with an optional `OTEL_TRACES_SAMPLER_ARG` for the sampling probability (e.g., `0.5` for 50%).

--- a/sdk/monitor/monitor-opentelemetry/src/traces/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/handler.ts
@@ -8,7 +8,7 @@ import {
   AzureMonitorTraceExporter,
   RateLimitedSampler,
 } from "@azure/monitor-opentelemetry-exporter";
-import type { BufferConfig, Sampler } from "@opentelemetry/sdk-trace-base";
+import type { Sampler } from "@opentelemetry/sdk-trace-base";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type {
   HttpInstrumentationConfig,
@@ -65,13 +65,7 @@ export class TraceHandler {
       this._sampler = new ApplicationInsightsSampler(this._config.samplingRatio);
     }
     this._azureExporter = new AzureMonitorTraceExporter(this._config.azureMonitorExporterOptions);
-    const bufferConfig: BufferConfig = {
-      maxExportBatchSize: 512,
-      scheduledDelayMillis: 5000,
-      exportTimeoutMillis: 30000,
-      maxQueueSize: 2048,
-    };
-    this._batchSpanProcessor = new BatchSpanProcessor(this._azureExporter, bufferConfig);
+    this._batchSpanProcessor = new BatchSpanProcessor(this._azureExporter);
     this._azureSpanProcessor = new AzureMonitorSpanProcessor(this._metricHandler);
     this._azureFunctionsHook = new AzureFunctionsHook();
     this._initializeInstrumentations();

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -202,6 +202,10 @@ describe("Library/TraceHandler", () => {
       handler = new TraceHandler(_config, metricHandler);
       const processor = handler.getBatchSpanProcessor();
 
+      assert.strictEqual(process.env.OTEL_BSP_MAX_QUEUE_SIZE, "4096");
+      assert.strictEqual(process.env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE, "1024");
+      assert.strictEqual(process.env.OTEL_BSP_SCHEDULE_DELAY, "2500");
+      assert.strictEqual(process.env.OTEL_BSP_EXPORT_TIMEOUT, "15000");
       assert.propertyVal(processor, "_maxQueueSize", 4096);
       assert.propertyVal(processor, "_maxExportBatchSize", 1024);
       assert.propertyVal(processor, "_scheduledDelayMillis", 2500);

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -110,6 +110,7 @@ describe("Library/TraceHandler", () => {
       await handler.shutdown();
     }
     metrics.disable();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -187,6 +188,24 @@ describe("Library/TraceHandler", () => {
 
       expect(handler.getSampler()).toBeInstanceOf(ApplicationInsightsSampler);
       expect(handler.getSampler().toString()).toBe("ApplicationInsightsSampler{0.2}");
+    });
+  });
+
+  describe("BatchSpanProcessor configuration", () => {
+    it("uses OpenTelemetry environment variables", () => {
+      vi.stubEnv("OTEL_BSP_MAX_QUEUE_SIZE", "4096");
+      vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1024");
+      vi.stubEnv("OTEL_BSP_SCHEDULE_DELAY", "2500");
+      vi.stubEnv("OTEL_BSP_EXPORT_TIMEOUT", "15000");
+
+      metricHandler = new MetricHandler(_config);
+      handler = new TraceHandler(_config, metricHandler);
+      const processor = handler.getBatchSpanProcessor();
+
+      assert.propertyVal(processor, "_maxQueueSize", 4096);
+      assert.propertyVal(processor, "_maxExportBatchSize", 1024);
+      assert.propertyVal(processor, "_scheduledDelayMillis", 2500);
+      assert.propertyVal(processor, "_exportTimeoutMillis", 15000);
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/monitor-opentelemetry`

### Issues associated with this PR

Fixes #39607

### Describe the problem that is addressed by this PR

`TraceHandler` explicitly supplied every `BatchSpanProcessor` buffer default, preventing `@opentelemetry/sdk-trace-base` from applying the standard `OTEL_BSP_*` environment-variable fallbacks. This change lets the OpenTelemetry processor supply its unchanged defaults while honoring `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`, `OTEL_BSP_SCHEDULE_DELAY`, and `OTEL_BSP_EXPORT_TIMEOUT` when configured.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

A new Azure Monitor options surface could expose the same four settings. Delegating to the existing OpenTelemetry environment-variable behavior avoids a redundant public API and follows the upstream SDK configuration specification.

### Are there test cases added in this PR? _(If not, why?)_

Yes. A focused unit test verifies all four environment variables configure the built-in processor. The change was also exercised with a standalone Node.js app against a temporary Application Insights resource; the app observed all four runtime values and all five emitted spans were ingested. The temporary Azure resources were deleted afterward.

### Provide a list of related PRs _(if any)_

None.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog