### PR TITLE
[service-bus] Assert on errors captured by processError in receiveAndDelete tests

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiveAndDeleteMode.spec.ts
@@ -118,11 +118,6 @@ describe("receive and delete", () => {
   });
 
   describe("Streaming Receiver in ReceiveAndDelete mode", function (): void {
-    // NOTE: this is never reassigned, so the `=== undefined` assertion below is
-    // trivially true. Wiring processError to capture the error is tracked in
-    // https://github.com/Azure/azure-sdk-for-js/issues/39462.
-    const errorFromErrorHandler: Error | undefined = undefined;
-
     afterEach(async () => {
       await afterEachTest();
     });
@@ -163,11 +158,7 @@ describe("receive and delete", () => {
         "MessageId is different than expected",
       );
 
-      should.equal(
-        errorFromErrorHandler,
-        undefined,
-        errorFromErrorHandler && errorFromErrorHandler.message,
-      );
+      should.equal(errors.length, 0, `Unexpected errors from error handler: ${errors.join(", ")}`);
 
       await testPeekMsgsLength(receiver, 0);
     }

--- a/sdk/servicebus/service-bus/test/internal/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/receiveAndDeleteMode.spec.ts
@@ -143,7 +143,14 @@ describe("receive and delete", () => {
         { autoCompleteMessages: autoCompleteFlag },
       );
 
-      const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
+      // Stop waiting as soon as either a message or an error arrives, and check
+      // `errors` first so a handler error is reported instead of being masked by
+      // the generic "could not receive" timeout.
+      const msgsCheck = await checkWithTimeout(
+        () => receivedMsgs.length === 1 || errors.length > 0,
+      );
+
+      should.equal(errors.length, 0, `Unexpected errors from error handler: ${errors.join(", ")}`);
       should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
       should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
@@ -157,8 +164,6 @@ describe("receive and delete", () => {
         testMessages.messageId,
         "MessageId is different than expected",
       );
-
-      should.equal(errors.length, 0, `Unexpected errors from error handler: ${errors.join(", ")}`);
 
       await testPeekMsgsLength(receiver, 0);
     }


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/service-bus` (test-only change)

### Issues associated with this PR

Fixes #39462

### Describe the problem that is addressed by this PR

Follow-up to the `no-unassigned-vars` cleanup in #39460 (part of #39423).

In `sdk/servicebus/service-bus/test/internal/receiveAndDeleteMode.spec.ts`, the `Streaming Receiver in ReceiveAndDelete mode` suite declared:

```ts
const errorFromErrorHandler: Error | undefined = undefined;
```

and `sendReceiveMsg` asserted:

```ts
should.equal(
  errorFromErrorHandler,
  undefined,
  errorFromErrorHandler && errorFromErrorHandler.message,
);
```

`errorFromErrorHandler` was never assigned anywhere, so `errorFromErrorHandler === undefined` was trivially always true. The assertion did not actually guard against errors surfaced by the receiver's error handler — which is what it was clearly intended to do.

Meanwhile, the `processError` callback in the same helper already captures errors into a local `errors` array:

```ts
async processError(args: ProcessErrorArgs): Promise<void> {
  errors.push(args.error.message);
},
```

...which nothing ever asserted on.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Two options were considered:

1. **Assert on the existing `errors` array** (chosen). `processError` already populates it, it is scoped per `sendReceiveMsg` invocation, and it carries the error messages needed for a useful failure message. This is the smallest change that makes the assertion meaningful.
2. Wire `processError` to assign to the outer `errorFromErrorHandler` variable. Rejected: it reintroduces suite-scoped mutable state shared across `it` blocks (a stale-value hazard between tests), and duplicates what the local `errors` array already does correctly.

The resulting assertion is:

```ts
should.equal(errors.length, 0, `Unexpected errors from error handler: ${errors.join(", ")}`);
```

The now-unused `errorFromErrorHandler` declaration and its accompanying `NOTE` comment (which pointed at #39462) are removed.

### Are there test cases added in this PR? _(If not, why?)_

No new test cases. This PR repairs an existing assertion that was silently passing; the change is confined to test code and adds no product behavior to cover. The affected tests (`test/internal/receiveAndDeleteMode.spec.ts`) are live-only — they are excluded from `vitest.unit.config.ts` and require a real Service Bus namespace — so they run in the live pipeline rather than locally.

Verification performed locally:
- `prettier --check` passes on the modified file.
- `tsc --noEmit -p tsconfig.test.node.json` produces an identical error set before and after the change (the two pre-existing diagnostics in this file simply shift by 5 lines because 5 lines were deleted), confirming no new type errors are introduced.

### Provide a list of related PRs _(if any)_

- #39460 — the lint cleanup that introduced the interim `const` and flagged this follow-up
- #39423 — the umbrella ESLint v10 rules issue

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary) — not necessary: test-only change with no user-facing behavior change.
