### PR TITLE
[engsys] Declare @azure/logger devDependency where snippets require it

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,7 +746,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
@@ -1374,7 +1374,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
@@ -1438,7 +1438,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
@@ -1584,7 +1584,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
@@ -2192,7 +2192,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
@@ -4192,7 +4192,7 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: workspace:^
         version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -1370,6 +1373,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -1431,6 +1437,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -1574,6 +1583,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -2179,6 +2191,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -4176,6 +4191,9 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1

--- a/sdk/agrifood/arm-agrifood/package.json
+++ b/sdk/agrifood/arm-agrifood/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/agrifood/arm-agrifood/package.json
+++ b/sdk/agrifood/arm-agrifood/package.json
@@ -34,6 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -34,6 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/apicenter/arm-apicenter/package.json
+++ b/sdk/apicenter/arm-apicenter/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/apicenter/arm-apicenter/package.json
+++ b/sdk/apicenter/arm-apicenter/package.json
@@ -34,6 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
@@ -34,6 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
@@ -34,6 +34,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/changes/arm-changes/package.json
+++ b/sdk/changes/arm-changes/package.json
@@ -32,6 +32,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
+    "@azure/logger": "^1.1.4",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/changes/arm-changes/package.json
+++ b/sdk/changes/arm-changes/package.json
@@ -32,7 +32,7 @@
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/logger": "^1.1.4",
+    "@azure/logger": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/arm-agrifood`
- `@azure/arm-analysisservices`
- `@azure/arm-apicenter`
- `@azure/arm-appcomplianceautomation`
- `@azure/arm-appservice-profile-2020-09-01-hybrid`
- `@azure/arm-changes`

### Issues associated with this PR

Fixes #38627

### Describe the problem that is addressed by this PR

`dev-tool run update-snippets` generates `test/snippets.spec.ts` from each package's README. The standard logging snippet imports `setLogLevel` from `@azure/logger`:

```ts
import { setLogLevel } from "@azure/logger";
```

Six packages emit that import without declaring `@azure/logger` anywhere in their `package.json`, so snippet type checking cannot resolve it:

```
test/snippets.spec.ts(5,29): error TS2307: Cannot find module '@azure/logger' or its corresponding type declarations.
```

Reproduced locally against `sdk/apicenter/arm-apicenter` with `tsc --noEmit -p config/tsconfig.snippets.json` before the change; `@azure/logger` was absent from the package's `node_modules`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Two options were considered:

1. **Declare the missing devDependency in the six affected packages** (chosen). This is what the other 409 packages already do and requires no tooling change.
2. Teach `dev-tool run update-snippets` to add the dependency automatically when it emits an import. Rejected for this PR: that is a generator design change affecting every package, and it would still need this one-time repair of the existing six. Worth considering separately as an enforcement mechanism (a lint rule or a generator check) if the team wants to prevent recurrence — happy to open a follow-up issue if that is desired.

**Why `devDependency` at `^1.1.4`** — this matches the existing convention exactly, rather than being an arbitrary pick. Surveying all 415 `arm-*` packages whose generated snippets import `@azure/logger`:

| `src/` uses `@azure/logger` | declared as | count |
| --- | --- | --- |
| yes | `dependency` | 218 |
| no | `devDependency` (`^1.1.4`, unanimous) | 83 |
| no | **missing** | **6 ← this PR** |

None of the six reference `@azure/logger` from `src/` — it appears only in the generated snippet — so `devDependency` is the correct bucket, and `^1.1.4` is what all 83 comparable packages use.

### Are there test cases added in this PR? _(If not, why?)_

No new test cases. This is a dependency-manifest fix; the thing it repairs *is* the existing snippet type-check step, and no product code changes.

Verification performed locally:

- **Before:** `tsc --noEmit -p config/tsconfig.snippets.json` in `arm-apicenter` → `Cannot find module '@azure/logger'`; no `node_modules/@azure/logger`.
- **After:** `node_modules/@azure/logger -> ../../../../core/logger` resolves.
- `pnpm install --frozen-lockfile` reports **"Lockfile is up to date"**, confirming `pnpm-lock.yaml` is consistent with the six manifests.
- **Control:** `@azure/arm-astro` — already compliant on `main` and untouched by this PR — produces the *identical* residual `TS2307` for `@azure/logger` in an unbuilt workspace, because workspace packages expose types from `dist/` and `@azure/logger` was not built locally. After this change the six packages are in exactly the same state as the 92 known-good ones; full resolution follows from a built workspace, which CI provides.

### Provide a list of related PRs _(if any)_

None.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary) — not necessary: no shipped code or public API changes; the added dependency is dev-only and affects the snippet type-check step.
