### PR TITLE
[Monitor-OpenTelemetry-Exporter] Add availability telemetry exporter support

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for exporting availability telemetry from OpenTelemetry log records with `microsoft.availability.*` attributes.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for exporting availability telemetry from OpenTelemetry log records with `microsoft.availability.*` attributes.
+- Added support for exporting availability telemetry from OpenTelemetry log records with `microsoft.availability.*` attributes. [#39734](https://github.com/Azure/azure-sdk-for-js/pull/39734)
 
 ### Breaking Changes
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -104,6 +104,41 @@ const loggerProvider = new LoggerProvider({
 logs.setGlobalLoggerProvider(loggerProvider);
 ```
 
+#### Availability results
+
+After registering the logger provider, emit an OpenTelemetry log record with the availability attributes below. The exporter converts the record to Application Insights availability telemetry.
+
+```ts snippet:ReadmeSampleAvailability
+import { logs } from "@opentelemetry/api-logs";
+
+const logger = logs.getLogger("availability");
+logger.emit({
+  body: "Homepage availability test completed.",
+  attributes: {
+    "microsoft.availability.id": "availability-test-run-123",
+    "microsoft.availability.name": "Homepage",
+    "microsoft.availability.duration": "00:00:00.250",
+    "microsoft.availability.success": true,
+    "microsoft.availability.runLocation": "westus2",
+    "microsoft.availability.message": "HTTP 200",
+    "microsoft.availability.testTimestamp": new Date().toISOString(),
+  },
+});
+```
+
+The following attributes are required:
+
+| Attribute | Description |
+| --- | --- |
+| `microsoft.availability.id` | Identifier for this test run. |
+| `microsoft.availability.name` | Name of the availability test. |
+| `microsoft.availability.duration` | Test duration, for example `00:00:00.250`. |
+| `microsoft.availability.success` | Whether the test succeeded. |
+
+`microsoft.availability.runLocation`, `microsoft.availability.message`, and `microsoft.availability.testTimestamp` are optional. The timestamp must be an ISO 8601 string and overrides the log record time when valid. If the message attribute is omitted, the log body is used as the availability message.
+
+If any required attribute is missing or empty, the exporter sends the record as regular message telemetry instead. Exception and custom event attributes take precedence over availability attributes.
+
 ### Sampling
 
 You can enable sampling to limit the amount of telemetry records you receive. In order to enable correct sampling in Application Insights, use the `ApplicationInsightsSampler` as shown below.

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/logSample.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/logSample.ts
@@ -44,6 +44,22 @@ export async function main(): Promise<void> {
     attributes: { key: "value" },
   });
 
+  // Add an availability result
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: "INFO",
+    body: "Homepage availability test completed.",
+    attributes: {
+      "microsoft.availability.id": "availability-test-run-123",
+      "microsoft.availability.name": "Homepage",
+      "microsoft.availability.duration": "00:00:00.250",
+      "microsoft.availability.success": true,
+      "microsoft.availability.runLocation": "westus2",
+      "microsoft.availability.message": "HTTP 200",
+      "microsoft.availability.testTimestamp": new Date().toISOString(),
+    },
+  });
+
   // flush and shutdown
   await loggerProvider.forceFlush();
   await loggerProvider.shutdown();

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/javascript/logSample.js
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/javascript/logSample.js
@@ -44,6 +44,22 @@ async function main() {
     attributes: { key: "value" },
   });
 
+  // Add an availability result
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: "INFO",
+    body: "Homepage availability test completed.",
+    attributes: {
+      "microsoft.availability.id": "availability-test-run-123",
+      "microsoft.availability.name": "Homepage",
+      "microsoft.availability.duration": "00:00:00.250",
+      "microsoft.availability.success": true,
+      "microsoft.availability.runLocation": "westus2",
+      "microsoft.availability.message": "HTTP 200",
+      "microsoft.availability.testTimestamp": new Date().toISOString(),
+    },
+  });
+
   // flush and shutdown
   await loggerProvider.forceFlush();
   await loggerProvider.shutdown();

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/typescript/src/logSample.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/typescript/src/logSample.ts
@@ -44,6 +44,22 @@ export async function main(): Promise<void> {
     attributes: { key: "value" },
   });
 
+  // Add an availability result
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: "INFO",
+    body: "Homepage availability test completed.",
+    attributes: {
+      "microsoft.availability.id": "availability-test-run-123",
+      "microsoft.availability.name": "Homepage",
+      "microsoft.availability.duration": "00:00:00.250",
+      "microsoft.availability.success": true,
+      "microsoft.availability.runLocation": "westus2",
+      "microsoft.availability.message": "HTTP 200",
+      "microsoft.availability.testTimestamp": new Date().toISOString(),
+    },
+  });
+
   // flush and shutdown
   await loggerProvider.forceFlush();
   await loggerProvider.shutdown();

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -40,6 +40,13 @@ export enum DependencyTypes {
 export const AzureMonitorSampleRate = "microsoft.sample_rate";
 export const ApplicationInsightsBaseType = "_MS.baseType";
 export const ApplicationInsightsCustomEventName = "microsoft.custom_event.name";
+export const ApplicationInsightsAvailabilityId = "microsoft.availability.id";
+export const ApplicationInsightsAvailabilityNameAttribute = "microsoft.availability.name";
+export const ApplicationInsightsAvailabilityDuration = "microsoft.availability.duration";
+export const ApplicationInsightsAvailabilitySuccess = "microsoft.availability.success";
+export const ApplicationInsightsAvailabilityRunLocation = "microsoft.availability.runLocation";
+export const ApplicationInsightsAvailabilityMessage = "microsoft.availability.message";
+export const ApplicationInsightsAvailabilityTestTimestamp = "microsoft.availability.testTimestamp";
 export const MicrosoftClientIp = "microsoft.client.ip";
 
 export const ApplicationInsightsMessageName = "Microsoft.ApplicationInsights.Message";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -30,8 +30,15 @@ import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "..
 import type { Attributes } from "@opentelemetry/api";
 import { diag } from "@opentelemetry/api";
 import {
+  ApplicationInsightsAvailabilityDuration,
+  ApplicationInsightsAvailabilityId,
   ApplicationInsightsAvailabilityBaseType,
+  ApplicationInsightsAvailabilityMessage,
   ApplicationInsightsAvailabilityName,
+  ApplicationInsightsAvailabilityNameAttribute,
+  ApplicationInsightsAvailabilityRunLocation,
+  ApplicationInsightsAvailabilitySuccess,
+  ApplicationInsightsAvailabilityTestTimestamp,
   ApplicationInsightsBaseType,
   ApplicationInsightsCustomEventName,
   ApplicationInsightsEventBaseType,
@@ -51,7 +58,7 @@ import {
  * @internal
  */
 export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | undefined {
-  const time = hrTimeToDate(log.hrTime);
+  let time = hrTimeToDate(log.hrTime);
   const sampleRate = 100;
   const instrumentationKey = ikey;
   const tags = createTagsFromLog(log);
@@ -65,6 +72,7 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
   const exceptionStacktrace = log.attributes[ATTR_EXCEPTION_STACKTRACE];
   const exceptionType = log.attributes[ATTR_EXCEPTION_TYPE];
   const isExceptionType: boolean = !!(exceptionType && exceptionStacktrace) || false;
+  const availabilityData = getAvailabilityData(log);
   const isMessageType: boolean =
     !log.attributes[ApplicationInsightsBaseType] &&
     !log.attributes[ApplicationInsightsCustomEventName] &&
@@ -96,6 +104,11 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
     };
     baseData = eventData;
     measurements = getLegacyApplicationInsightsMeasurements(log);
+  } else if (availabilityData) {
+    name = ApplicationInsightsAvailabilityName;
+    baseType = ApplicationInsightsAvailabilityBaseType;
+    baseData = availabilityData;
+    time = getAvailabilityTime(log) ?? time;
   } else if (isMessageType) {
     name = ApplicationInsightsMessageName;
     baseType = ApplicationInsightsMessageBaseType;
@@ -137,6 +150,51 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
       baseData: baseData,
     },
   };
+}
+
+function getAvailabilityData(log: ReadableLogRecord): AvailabilityData | undefined {
+  if (
+    log.attributes[ApplicationInsightsBaseType] ||
+    log.attributes[ApplicationInsightsAvailabilityNameAttribute] === undefined
+  ) {
+    return;
+  }
+
+  const id = getAttributeString(log, ApplicationInsightsAvailabilityId);
+  const name = getAttributeString(log, ApplicationInsightsAvailabilityNameAttribute);
+  const duration = getAttributeString(log, ApplicationInsightsAvailabilityDuration);
+  const success = getAttributeString(log, ApplicationInsightsAvailabilitySuccess);
+  if (!id || !name || !duration || !success) {
+    return;
+  }
+
+  return {
+    kind: "AvailabilityData",
+    version: DEFAULT_BREEZE_DATA_VERSION,
+    id,
+    name,
+    duration,
+    success: success.toLowerCase() === "true",
+    runLocation: getAttributeString(log, ApplicationInsightsAvailabilityRunLocation),
+    message:
+      getAttributeString(log, ApplicationInsightsAvailabilityMessage) ??
+      (log.body === undefined ? undefined : serializeAttribute(log.body)),
+  };
+}
+
+function getAvailabilityTime(log: ReadableLogRecord): Date | undefined {
+  const testTimestamp = log.attributes[ApplicationInsightsAvailabilityTestTimestamp];
+  if (typeof testTimestamp !== "string") {
+    return;
+  }
+
+  const time = new Date(testTimestamp);
+  return Number.isNaN(time.getTime()) ? undefined : time;
+}
+
+function getAttributeString(log: ReadableLogRecord, attributeName: string): string | undefined {
+  const value = log.attributes[attributeName];
+  return value === undefined ? undefined : String(value);
 }
 
 function createTagsFromLog(log: ReadableLogRecord): Tags {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -71,27 +71,21 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
 
   const exceptionStacktrace = log.attributes[ATTR_EXCEPTION_STACKTRACE];
   const exceptionType = log.attributes[ATTR_EXCEPTION_TYPE];
-  const exceptionMessage = log.attributes[ATTR_EXCEPTION_MESSAGE];
-  const isExceptionType =
-    exceptionType !== undefined ||
-    exceptionMessage !== undefined ||
-    exceptionStacktrace !== undefined;
+  const isExceptionType: boolean = !!(exceptionType && exceptionStacktrace) || false;
   const availabilityData = getAvailabilityData(log);
   const isMessageType: boolean =
     !log.attributes[ApplicationInsightsBaseType] &&
     !log.attributes[ApplicationInsightsCustomEventName] &&
-    !isExceptionType;
+    !exceptionType;
   if (isExceptionType) {
+    const exceptionMessage = log.attributes[ATTR_EXCEPTION_MESSAGE];
     name = ApplicationInsightsExceptionName;
     baseType = ApplicationInsightsExceptionBaseType;
     const exceptionDetails: TelemetryExceptionDetails = {
-      typeName: exceptionType === undefined ? "Exception" : String(exceptionType),
-      message:
-        exceptionMessage === undefined
-          ? serializeAttribute(log.body ?? "Exception")
-          : String(exceptionMessage),
-      hasFullStack: exceptionStacktrace !== undefined,
-      stack: exceptionStacktrace === undefined ? undefined : String(exceptionStacktrace),
+      typeName: String(exceptionType),
+      message: String(exceptionMessage),
+      hasFullStack: exceptionStacktrace ? true : false,
+      stack: String(exceptionStacktrace),
     };
     const exceptionData: TelemetryExceptionData = {
       kind: "ExceptionData",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -71,21 +71,27 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
 
   const exceptionStacktrace = log.attributes[ATTR_EXCEPTION_STACKTRACE];
   const exceptionType = log.attributes[ATTR_EXCEPTION_TYPE];
-  const isExceptionType: boolean = !!(exceptionType && exceptionStacktrace) || false;
+  const exceptionMessage = log.attributes[ATTR_EXCEPTION_MESSAGE];
+  const isExceptionType =
+    exceptionType !== undefined ||
+    exceptionMessage !== undefined ||
+    exceptionStacktrace !== undefined;
   const availabilityData = getAvailabilityData(log);
   const isMessageType: boolean =
     !log.attributes[ApplicationInsightsBaseType] &&
     !log.attributes[ApplicationInsightsCustomEventName] &&
-    !exceptionType;
+    !isExceptionType;
   if (isExceptionType) {
-    const exceptionMessage = log.attributes[ATTR_EXCEPTION_MESSAGE];
     name = ApplicationInsightsExceptionName;
     baseType = ApplicationInsightsExceptionBaseType;
     const exceptionDetails: TelemetryExceptionDetails = {
-      typeName: String(exceptionType),
-      message: String(exceptionMessage),
-      hasFullStack: exceptionStacktrace ? true : false,
-      stack: String(exceptionStacktrace),
+      typeName: exceptionType === undefined ? "Exception" : String(exceptionType),
+      message:
+        exceptionMessage === undefined
+          ? serializeAttribute(log.body ?? "Exception")
+          : String(exceptionMessage),
+      hasFullStack: exceptionStacktrace !== undefined,
+      stack: exceptionStacktrace === undefined ? undefined : String(exceptionStacktrace),
     };
     const exceptionData: TelemetryExceptionData = {
       kind: "ExceptionData",

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -912,60 +912,24 @@ describe("logUtils.ts", () => {
       assert.strictEqual((envelope?.data?.baseData as TelemetryEventData).name, "test-event");
     });
 
-    it.each([
-      {
-        marker: "type",
-        exceptionAttributes: { [SEMATTRS_EXCEPTION_TYPE]: "Error" },
-        expectedException: {
-          typeName: "Error",
-          message: "availability log",
-          hasFullStack: false,
-          stack: undefined,
-        },
-      },
-      {
-        marker: "message",
-        exceptionAttributes: { [SEMATTRS_EXCEPTION_MESSAGE]: "test exception" },
-        expectedException: {
-          typeName: "Exception",
-          message: "test exception",
-          hasFullStack: false,
-          stack: undefined,
-        },
-      },
-      {
-        marker: "stacktrace",
-        exceptionAttributes: { [SEMATTRS_EXCEPTION_STACKTRACE]: "test stack" },
-        expectedException: {
-          typeName: "Exception",
-          message: "availability log",
-          hasFullStack: true,
-          stack: "test stack",
-        },
-      },
-    ])(
-      "should give a partial exception $marker precedence over availability attributes",
-      ({ exceptionAttributes, expectedException }) => {
-        testLogRecord.attributes = {
-          "microsoft.availability.id": "test-id",
-          "microsoft.availability.name": "test-name",
-          "microsoft.availability.duration": "00:00:02",
-          "microsoft.availability.success": true,
-          ...exceptionAttributes,
-          [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
-        };
-        testLogRecord.body = "availability log";
+    it("should give exception telemetry precedence over availability attributes", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        [SEMATTRS_EXCEPTION_TYPE]: "Error",
+        [SEMATTRS_EXCEPTION_MESSAGE]: "test exception",
+        [SEMATTRS_EXCEPTION_STACKTRACE]: "test stack",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
 
-        const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
 
-        assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Exception");
-        assert.strictEqual(envelope?.data?.baseType, "ExceptionData");
-        assert.deepStrictEqual(
-          (envelope?.data?.baseData as TelemetryExceptionData).exceptions[0],
-          expectedException,
-        );
-      },
-    );
+      assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Exception");
+      assert.strictEqual(envelope?.data?.baseType, "ExceptionData");
+    });
   });
 
   it("should parse objects if passed as the message field of a legacy ApplicationInsights log", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -894,6 +894,24 @@ describe("logUtils.ts", () => {
       assert.strictEqual(envelope?.data?.baseType, "AvailabilityData");
     });
 
+    it("should give custom event telemetry precedence over availability attributes", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        "microsoft.custom_event.name": "test-event",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+      assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Event");
+      assert.strictEqual(envelope?.data?.baseType, "EventData");
+      assert.strictEqual((envelope?.data?.baseData as TelemetryEventData).name, "test-event");
+    });
+
     it.each([
       {
         marker: "type",

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -894,24 +894,60 @@ describe("logUtils.ts", () => {
       assert.strictEqual(envelope?.data?.baseType, "AvailabilityData");
     });
 
-    it("should give exception telemetry precedence over availability attributes", () => {
-      testLogRecord.attributes = {
-        "microsoft.availability.id": "test-id",
-        "microsoft.availability.name": "test-name",
-        "microsoft.availability.duration": "00:00:02",
-        "microsoft.availability.success": true,
-        [SEMATTRS_EXCEPTION_TYPE]: "Error",
-        [SEMATTRS_EXCEPTION_MESSAGE]: "test exception",
-        [SEMATTRS_EXCEPTION_STACKTRACE]: "test stack",
-        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
-      };
-      testLogRecord.body = "availability log";
+    it.each([
+      {
+        marker: "type",
+        exceptionAttributes: { [SEMATTRS_EXCEPTION_TYPE]: "Error" },
+        expectedException: {
+          typeName: "Error",
+          message: "availability log",
+          hasFullStack: false,
+          stack: undefined,
+        },
+      },
+      {
+        marker: "message",
+        exceptionAttributes: { [SEMATTRS_EXCEPTION_MESSAGE]: "test exception" },
+        expectedException: {
+          typeName: "Exception",
+          message: "test exception",
+          hasFullStack: false,
+          stack: undefined,
+        },
+      },
+      {
+        marker: "stacktrace",
+        exceptionAttributes: { [SEMATTRS_EXCEPTION_STACKTRACE]: "test stack" },
+        expectedException: {
+          typeName: "Exception",
+          message: "availability log",
+          hasFullStack: true,
+          stack: "test stack",
+        },
+      },
+    ])(
+      "should give a partial exception $marker precedence over availability attributes",
+      ({ exceptionAttributes, expectedException }) => {
+        testLogRecord.attributes = {
+          "microsoft.availability.id": "test-id",
+          "microsoft.availability.name": "test-name",
+          "microsoft.availability.duration": "00:00:02",
+          "microsoft.availability.success": true,
+          ...exceptionAttributes,
+          [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+        };
+        testLogRecord.body = "availability log";
 
-      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+        const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
 
-      assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Exception");
-      assert.strictEqual(envelope?.data?.baseType, "ExceptionData");
-    });
+        assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Exception");
+        assert.strictEqual(envelope?.data?.baseType, "ExceptionData");
+        assert.deepStrictEqual(
+          (envelope?.data?.baseData as TelemetryExceptionData).exceptions[0],
+          expectedException,
+        );
+      },
+    );
   });
 
   it("should parse objects if passed as the message field of a legacy ApplicationInsights log", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -760,6 +760,160 @@ describe("logUtils.ts", () => {
     });
   });
 
+  describe("#availability logs", () => {
+    it("should create an availability envelope from availability attributes", () => {
+      const testTimestamp = "2025-04-19T12:10:59.9930000+00:00";
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:05",
+        "microsoft.availability.success": true,
+        "microsoft.availability.runLocation": "test-location",
+        "microsoft.availability.message": "test-message",
+        "microsoft.availability.testTimestamp": testTimestamp,
+        "extra.attribute": "foo",
+        [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+      const expectedProperties = {
+        "extra.attribute": "foo",
+      };
+      const expectedBaseData: Partial<AvailabilityData> = {
+        id: "test-id",
+        name: "test-name",
+        duration: "00:00:05",
+        success: true,
+        runLocation: "test-location",
+        message: "test-message",
+        version: 2,
+        properties: expectedProperties,
+        measurements: {},
+      };
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+      assertEnvelope(
+        envelope,
+        "Microsoft.ApplicationInsights.Availability",
+        100,
+        "AvailabilityData",
+        expectedProperties,
+        emptyMeasurements,
+        expectedBaseData,
+        new Date(testTimestamp),
+        expectedServiceTagsBase,
+      );
+    });
+
+    it("should create an availability envelope with only required attributes", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": false,
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+      const expectedTime = hrTimeToDate(testLogRecord.hrTime);
+      const expectedBaseData: Partial<AvailabilityData> = {
+        id: "test-id",
+        name: "test-name",
+        duration: "00:00:02",
+        success: false,
+        runLocation: undefined,
+        message: "availability log",
+        version: 2,
+        properties: {},
+        measurements: {},
+      };
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+      assertEnvelope(
+        envelope,
+        "Microsoft.ApplicationInsights.Availability",
+        100,
+        "AvailabilityData",
+        {},
+        emptyMeasurements,
+        expectedBaseData,
+        expectedTime,
+        expectedServiceTagsBase,
+      );
+    });
+
+    it("should fall back to a message envelope for incomplete availability attributes", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        "extra.attribute": "foo",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+      testLogRecord.severityNumber = SeverityNumber.INFO;
+      const expectedTime = hrTimeToDate(testLogRecord.hrTime);
+      const expectedProperties = {
+        "extra.attribute": "foo",
+      };
+      const expectedBaseData: Partial<MessageData> = {
+        message: "availability log",
+        severityLevel: "Information",
+        version: 2,
+        properties: expectedProperties,
+        measurements: {},
+      };
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+      assertEnvelope(
+        envelope,
+        "Microsoft.ApplicationInsights.Message",
+        100,
+        "MessageData",
+        expectedProperties,
+        emptyMeasurements,
+        expectedBaseData,
+        expectedTime,
+        expectedServiceTagsBase,
+      );
+    });
+
+    it("should use the log time when the availability test timestamp is invalid", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        "microsoft.availability.testTimestamp": "invalid",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+      assert.deepStrictEqual(envelope?.time, hrTimeToDate(testLogRecord.hrTime));
+      assert.strictEqual(envelope?.data?.baseType, "AvailabilityData");
+    });
+
+    it("should give exception telemetry precedence over availability attributes", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        [SEMATTRS_EXCEPTION_TYPE]: "Error",
+        [SEMATTRS_EXCEPTION_MESSAGE]: "test exception",
+        [SEMATTRS_EXCEPTION_STACKTRACE]: "test stack",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "availability log";
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+      assert.strictEqual(envelope?.name, "Microsoft.ApplicationInsights.Exception");
+      assert.strictEqual(envelope?.data?.baseType, "ExceptionData");
+    });
+  });
+
   it("should parse objects if passed as the message field of a legacy ApplicationInsights log", () => {
     testLogRecord.attributes = {
       "_MS.baseType": "MessageData",

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/snippets.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/snippets.spec.ts
@@ -74,6 +74,23 @@ describe("snippets", () => {
     logs.setGlobalLoggerProvider(loggerProvider);
   });
 
+  it("ReadmeSampleAvailability", async () => {
+    const logger = logs.getLogger("availability");
+
+    logger.emit({
+      body: "Homepage availability test completed.",
+      attributes: {
+        "microsoft.availability.id": "availability-test-run-123",
+        "microsoft.availability.name": "Homepage",
+        "microsoft.availability.duration": "00:00:00.250",
+        "microsoft.availability.success": true,
+        "microsoft.availability.runLocation": "westus2",
+        "microsoft.availability.message": "HTTP 200",
+        "microsoft.availability.testTimestamp": new Date().toISOString(),
+      },
+    });
+  });
+
   it("ReadmeSampleSampling", async () => {
     // Sampler expects a sample rate of between 0 and 1 inclusive
     // A rate of 0.75 means approximately 75 % of your traces will be sent


### PR DESCRIPTION
## Description

Adds availability telemetry support to `@azure/monitor-opentelemetry-exporter` using the cross-language `microsoft.availability.*` OpenTelemetry log attributes.

- maps required and optional availability fields to `AvailabilityData`
- honors the optional test timestamp while preserving exception and custom-event precedence
- falls back to message telemetry when required availability attributes are incomplete
- documents customer usage and updates the maintained TypeScript and JavaScript log samples

## Testing

- package unit tests and typechecking
- lint, formatting, API extraction, and sample compilation
- live ingestion into a workspace-backed Application Insights resource, verified in `AppAvailabilityResults`