### PR TITLE
Redirect Linux browser temp files off root disk

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -315,6 +315,12 @@ jobs:
 
       # ===== END LIVE TEST RUNS =====
 
+      - pwsh: |
+          Write-Host "Filesystem usage after browser tests:"
+          df -h / /mnt
+        displayName: "Report disk usage after browser tests (Linux)"
+        condition: and(always(),eq(variables['Agent.OS'], 'Linux'),eq(variables['TestType'], 'browser'))
+
       - ${{ if ne(parameters.ServiceDirectory, '') }}:
         - ${{ each directory in coalesce(parameters.TestResourceDirectories, split(parameters.ServiceDirectory, '|')) }}:
           - template: /eng/common/TestResources/remove-test-resources.yml

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -5,35 +5,39 @@
 # nesting it causes UseNode and npmAuthenticate to run several times per job.
 steps:
   # Linux CI agents have limited space on the root disk ('/'), where many Node
-  # tools cache under the home directory. Redirect the largest caches to
-  # Agent.TempDirectory, which lives on a roomier disk, by configuring each
-  # tool through its own supported environment variable. HOME is left untouched
-  # so credentials and unrelated tool state are unaffected. The pnpm store stays
-  # on the same filesystem as the workspace node_modules so pnpm can keep
-  # hardlinking instead of copying. The df output makes the disk layout visible
-  # in the log so the redirection can be confirmed to actually free root space.
+  # tools cache under the home directory, while Playwright creates browser
+  # profiles under the system temporary directory. Redirect both to
+  # Agent.TempDirectory, which lives on a roomier disk, through their supported
+  # environment variables. HOME is left untouched so credentials and unrelated
+  # tool state are unaffected. The pnpm store stays on the same filesystem as
+  # the workspace node_modules so pnpm can keep hardlinking instead of copying.
+  # The df output makes the disk layout visible so a pipeline run can confirm
+  # that the redirection is keeping work off the root disk.
   #
   # NOTE: Tools invoked inside `turbo run` (e.g. `playwright install` during
   # test:browser) only see env vars that turbo is configured to pass through.
-  # PLAYWRIGHT_BROWSERS_PATH is added to the test:browser task's passThroughEnv
-  # in the root turbo.json so the browser download honors this redirect.
+  # PLAYWRIGHT_BROWSERS_PATH and TMPDIR are added to the test:browser task's
+  # passThroughEnv in the root turbo.json so browser downloads and temporary
+  # profiles honor these redirects.
   - pwsh: |
       $cacheRoot = Join-Path $env:AGENT_TEMPDIRECTORY 'cache'
       $npmCache = Join-Path $cacheRoot 'npm'
       $pnpmStore = Join-Path $cacheRoot 'pnpm/store'
       $playwrightBrowsers = Join-Path $cacheRoot 'ms-playwright'
+      $tempDirectory = Join-Path $env:AGENT_TEMPDIRECTORY 'tmp'
 
-      foreach ($dir in @($npmCache, $pnpmStore, $playwrightBrowsers)) {
+      foreach ($dir in @($npmCache, $pnpmStore, $playwrightBrowsers, $tempDirectory)) {
         New-Item -Path $dir -ItemType Directory -Force | Out-Null
       }
 
-      Write-Host "Redirecting Linux tool caches under $cacheRoot"
+      Write-Host "Redirecting Linux tool caches and temporary files under $env:AGENT_TEMPDIRECTORY"
       Write-Host "##vso[task.setvariable variable=npm_config_cache]$npmCache"
       Write-Host "##vso[task.setvariable variable=pnpm_config_store_dir]$pnpmStore"
       Write-Host "##vso[task.setvariable variable=PLAYWRIGHT_BROWSERS_PATH]$playwrightBrowsers"
+      Write-Host "##vso[task.setvariable variable=TMPDIR]$tempDirectory"
 
-      Write-Host "Filesystem usage for HOME ($env:HOME) and Agent.TempDirectory ($env:AGENT_TEMPDIRECTORY):"
-      df -h $env:HOME $env:AGENT_TEMPDIRECTORY
+      Write-Host "Filesystem usage before pipeline work:"
+      df -h / /mnt
     displayName: "Redirect tool caches off root disk (Linux)"
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -56,7 +56,7 @@ steps:
       Write-Host "Filesystem usage after browser tests:"
       df -h / /mnt
     displayName: "Report disk usage after browser tests (Linux)"
-    condition: and(succeededOrFailed(),eq(variables['Agent.OS'], 'Linux'),eq(variables['TestType'], 'browser'))
+    condition: and(always(),eq(variables['Agent.OS'], 'Linux'),eq(variables['TestType'], 'browser'))
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -52,6 +52,12 @@ steps:
     displayName: "Test libraries browser NodeJS $(NodeTestVersion)"
     condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
+  - pwsh: |
+      Write-Host "Filesystem usage after browser tests:"
+      df -h / /mnt
+    displayName: "Report disk usage after browser tests (Linux)"
+    condition: and(succeededOrFailed(),eq(variables['Agent.OS'], 'Linux'),eq(variables['TestType'], 'browser'))
+
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
         copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)

--- a/turbo.json
+++ b/turbo.json
@@ -55,7 +55,12 @@
     },
     "test:browser": {
       "dependsOn": ["build"],
-      "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage", "PLAYWRIGHT_BROWSERS_PATH"]
+      "passThroughEnv": [
+        "PUBLISHCODECOVERAGE",
+        "PublishCodeCoverage",
+        "PLAYWRIGHT_BROWSERS_PATH",
+        "TMPDIR"
+      ]
     },
     "test:node": {
       "dependsOn": ["build"],


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): This PR redirects Linux browser-test temporary files to the runner's larger temporary volume to prevent root disk exhaustion.

## Evidence

Build [6738392](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6738392&view=logs&j=6bfc3478-7a6a-507a-e04a-59490f09434a&t=a26e82bf-ad1b-5d38-ce06-6cbd2817d1b7) showed four Ubuntu 24.04 workers on image `20260816.277.1` starting with `/dev/root` at 89% usage (8.2 GB free), while `/mnt` had 133 GB free. The browser-test worker reached 99.97% root usage and hung until timeout.

## Hypothesis

The pipeline already redirects npm, pnpm, and Playwright browser downloads under `$(Agent.TempDirectory)`, but Chromium temporary profiles use Node's `os.tmpdir()`. Without `TMPDIR`, those profiles remain on the constrained root filesystem. Turbo's strict environment handling also requires the variable to be explicitly passed to `test:browser` commands.

## Changes

- Create `$(Agent.TempDirectory)/tmp` in the Linux cache redirect prelude and publish it as the job-scoped `TMPDIR` variable.
- Pass `TMPDIR` through Turbo for `test:browser`; build tasks remain unchanged because the dry-run task graph confirms browser-profile work occurs in the browser-test task, not its build dependencies.
- Log bounded `df -h / /mnt` snapshots before pipeline work and after browser tests, including failed browser-test runs.
- Leave `HOME`, `TEMP`, `TMP`, and `XDG_CACHE_HOME` unchanged to keep the fix scoped to the observed Linux temporary-profile behavior.

## Validation

- Prettier configuration check passed for both YAML templates and `turbo.json`.
- `eng/tools/check-pipeline-templates.mjs` passed.
- A Turbo dry run confirmed `TMPDIR` is passed to `test:browser` and not to build dependencies.

## Real-run metrics

Compare the before/after `df` snapshots for `/` and `/mnt`: root usage should retain material headroom instead of approaching 100%, while browser-profile growth should appear on `/mnt`. Also compare browser-test completion time and confirm the previous timeout/hang no longer occurs.