### PR TITLE
Add package customization lifecycle

### DIFF
--- a/common/tools/dev-tool/src/commands/customization/init.ts
+++ b/common/tools/dev-tool/src/commands/customization/init.ts
@@ -68,11 +68,10 @@ async function ensureCustomizeScript(packagePath: string): Promise<void> {
     return;
   }
 
+  // Append only the new entry to avoid reordering existing scripts; the repo's
+  // package.json formatting (prettier-plugin-packagejson) sorts the field on commit.
   scripts.customize = DEFAULT_CUSTOMIZE_SCRIPT;
-  // Match prettier-plugin-packagejson, which sorts the scripts field alphabetically.
-  packageJson.scripts = Object.fromEntries(
-    Object.entries(scripts).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
-  );
+  packageJson.scripts = scripts;
 
   const content = await format(JSON.stringify(packageJson, null, 2), "json-stringify");
   await fs.writeFile(packageJsonPath, content);

--- a/common/tools/dev-tool/src/commands/customization/init.ts
+++ b/common/tools/dev-tool/src/commands/customization/init.ts
@@ -63,7 +63,7 @@ async function ensureCustomizeScript(packagePath: string): Promise<void> {
   }
 
   const scripts = packageJson.scripts ?? {};
-  if (scripts.customize) {
+  if ("customize" in scripts) {
     log(`Existing 'customize' script left unchanged: ${scripts.customize}`);
     return;
   }

--- a/common/tools/dev-tool/src/commands/customization/init.ts
+++ b/common/tools/dev-tool/src/commands/customization/init.ts
@@ -4,10 +4,17 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import { resolveProject } from "../../util/resolveProject.ts";
+import { format } from "../../util/prettier.ts";
 import { createPrinter } from "../../util/printer.ts";
 import { leafCommand, makeCommandInfo } from "../../framework/command.ts";
 
 const log = createPrinter("customization-init");
+
+// Default `customize` script for a package that uses the generated/ + src/ merge flow.
+// Automation runs `npm run --if-present customize`, so this keeps the package in sync
+// with the customization lifecycle without any additional wiring.
+const DEFAULT_CUSTOMIZE_SCRIPT =
+  "dev-tool customization apply -s ./generated -t ./src && npm run format";
 
 export const commandInfo = makeCommandInfo(
   "init",
@@ -30,13 +37,44 @@ export default leafCommand(commandInfo, async () => {
   try {
     await fs.access(generatedDirectory);
     log("generated/ folder already exists. Customization is already set up.");
-    return true;
   } catch {
-    // generated/ doesn't exist, proceed with copying
+    await fs.cp(srcDirectory, generatedDirectory, { recursive: true });
+    log("✅ Copied src/ to generated/. You can now customize files in src/.");
   }
 
-  await fs.cp(srcDirectory, generatedDirectory, { recursive: true });
-  log("✅ Copied src/ to generated/. You can now customize files in src/.");
+  await ensureCustomizeScript(info.path);
 
   return true;
 });
+
+/**
+ * Adds a default `customize` script to the package when one is not already present so
+ * the package participates in the customization lifecycle. An existing `customize`
+ * script is left untouched to preserve any package-specific flags or steps.
+ */
+async function ensureCustomizeScript(packagePath: string): Promise<void> {
+  const packageJsonPath = path.join(packagePath, "package.json");
+  let packageJson: { scripts?: Record<string, string>; [key: string]: unknown };
+  try {
+    packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: "utf-8" }));
+  } catch {
+    log("⚠️  Could not read package.json; skipping customize script setup.");
+    return;
+  }
+
+  const scripts = packageJson.scripts ?? {};
+  if (scripts.customize) {
+    log(`Existing 'customize' script left unchanged: ${scripts.customize}`);
+    return;
+  }
+
+  scripts.customize = DEFAULT_CUSTOMIZE_SCRIPT;
+  // Match prettier-plugin-packagejson, which sorts the scripts field alphabetically.
+  packageJson.scripts = Object.fromEntries(
+    Object.entries(scripts).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+
+  const content = await format(JSON.stringify(packageJson, null, 2), "json-stringify");
+  await fs.writeFile(packageJsonPath, content);
+  log(`✅ Added 'customize' script: ${DEFAULT_CUSTOMIZE_SCRIPT}`);
+}

--- a/documentation/modular-customization.md
+++ b/documentation/modular-customization.md
@@ -14,7 +14,7 @@ If your package has not been set up for customization yet, run the following com
 npx dev-tool customization init
 ```
 
-This copies the contents of `src/` into `generated/`, establishing the baseline for the customization workflow. If `generated/` already exists, the package is already set up and the command makes no changes.
+This copies the contents of `src/` into `generated/`, establishing the baseline for the customization workflow. It also adds a default `customize` script to the package's `package.json` when one is not already present. If `generated/` already exists, the package is already set up and the command makes no changes to it.
 
 ## Folder Structure
 
@@ -64,4 +64,4 @@ This command will:
 
 If the merge was successful, review the merged changes and run the package's normal formatting, build, and test checks before committing. If merge conflicts are present, this means that the changes in the generated code conflicted with your customizations. Resolve the conflicts as you would do for any other merge, taking parts from the new generated code and parts from the customized code as makes sense to you. After resolving the conflicts, the `src/` folder should be the result of applying your customizations to the new version of the generated code.
 
-When an SDK is generated through the SDK generation pipeline, the pipeline automatically runs `dev-tool customization apply` after the emitter updates the root-level `generated/` directory and before the package is built. You only need to run the command yourself when regenerating locally.
+When an SDK is generated through the SDK generation pipeline, the pipeline automatically runs the package's `customize` script (via `npm run --if-present customize`) after the emitter updates the root-level `generated/` directory and before the package is built. Packages without a `customize` script are skipped. You only need to run the command yourself when regenerating locally.

--- a/eng/tools/js-sdk-release-tools/docs/automation-pipeline.md
+++ b/eng/tools/js-sdk-release-tools/docs/automation-pipeline.md
@@ -98,7 +98,7 @@ CLI Entry (autoGenerateInPipeline.ts)
   │       ├── tsp-client init code generation
   │       ├── buildPackage:
   │       │   ├── pnpm install
-  │       │   ├── customize (root `generated/`)
+  │       │   ├── customize (if `customize` script present)
   │       │   ├── lint fix (Release/Local)
   │       │   ├── turbo build
   │       │   ├── extract ApiView info
@@ -123,7 +123,7 @@ CLI Entry (autoGenerateInPipeline.ts)
 | Format code          | `formatSdk()`                                | ✅ Required                          | `npm run format`                                          |
 | Update snippets      | `updateSnippets()`                           | ✅ Required                          | `dev-tool run update-snippets`                            |
 | Lint fix             | `lintFix()`                                  | ⚠️ Optional (`Release`/`Local` only) | `npm run lint:fix`                                        |
-| Apply custom code    | `customizeCodes()`                           | ⚠️ Optional (root `generated/`)      | `dev-tool customization apply -s ./generated -t ./src`    |
+| Customize package    | `customizeCodes()`                           | ⚠️ If present                        | `npm run --if-present customize`                          |
 | Clean up package dir | `cleanUpPackageDirectory()`                  | ✅ Required                          | Cleanup strategy based on SDK type + `RunMode`            |
 | Specify API version  | `specifyApiVersionToGenerateSDKByTypeSpec()` | ⚠️ Optional                          | Modify `api-version` field in `tspconfig.yaml`            |
 
@@ -279,20 +279,20 @@ There are two generation paths based on the source: **TypeSpec project** or **Sw
 
 #### Common Post-generation Steps (both paths)
 
-| Step                                      | Required    | Operation                                   | Command / Details                                                                                                      | Code Link                       |
-| ----------------------------------------- | ----------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **4. Generate/Modify CI YAML**            | ✅ Required | `modifyOrGenerateCiYml()`                   | Create or update `ci.yml`                                                                                              | [generateRLCInPipeline.ts#L180] |
-| **5. Modify Test/Sample Config**          | ✅ Required | `changeConfigOfTestAndSample()`             | Skip test/sample compilation                                                                                           | [generateRLCInPipeline.ts#L186] |
-| **6. Install Dependencies**               | ✅ Required | pnpm                                        | `pnpm install`                                                                                                         | [generateRLCInPipeline.ts#L204] |
-| **7. Apply Custom Code**                  | ⚠️ Optional | `customizeCodes()` — root `generated/` only | `dev-tool customization apply -s ./generated -t ./src`                                                                 | [generateRLCInPipeline.ts#L215] |
-| **8. Lint Fix**                           | ⚠️ Optional | `lintFix()` — `Release` / `Local` mode only | `npm run lint:fix`                                                                                                     | [generateRLCInPipeline.ts#L218] |
-| **9. Build**                              | ✅ Required | Compile package                             | `pnpm build --filter {packageName}...` (`Release`/`Local`) or `pnpm run --filter {packageName}... build` (other modes) | [generateRLCInPipeline.ts#L208] |
-| **10. Pack**                              | ✅ Required | Generate `.tgz`                             | `pnpm run --filter {packageName}... pack`                                                                              | [generateRLCInPipeline.ts#L210] |
-| **11. Format Code**                       | ✅ Required | `formatSdk()`                               | `npm run format`                                                                                                       | [generateRLCInPipeline.ts#L239] |
-| **12. Update Snippets**                   | ✅ Required | `updateSnippets()`                          | `dev-tool run update-snippets`                                                                                         | [generateRLCInPipeline.ts#L240] |
-| **13. Generate Changelog & Bump Version** | ✅ Required | `generateChangelogAndBumpVersion()`         | Same as HLC                                                                                                            | [generateRLCInPipeline.ts#L249] |
-| **14. Add ApiView Info**                  | ✅ Required | `addApiViewInfo()`                          | Find `*.api.json` files                                                                                                | [generateRLCInPipeline.ts#L260] |
-| **15. Restore Config**                    | ✅ Required | `changeConfigOfTestAndSample(Revert)`       | Restore original `tsconfig.json`                                                                                       | [generateRLCInPipeline.ts#L279] |
+| Step                                      | Required      | Operation                                   | Command / Details                                                                                                      | Code Link                       |
+| ----------------------------------------- | ------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **4. Generate/Modify CI YAML**            | ✅ Required   | `modifyOrGenerateCiYml()`                   | Create or update `ci.yml`                                                                                              | [generateRLCInPipeline.ts#L180] |
+| **5. Modify Test/Sample Config**          | ✅ Required   | `changeConfigOfTestAndSample()`             | Skip test/sample compilation                                                                                           | [generateRLCInPipeline.ts#L186] |
+| **6. Install Dependencies**               | ✅ Required   | pnpm                                        | `pnpm install`                                                                                                         | [generateRLCInPipeline.ts#L204] |
+| **7. Customize Package**                  | ⚠️ If present | `customizeCodes()`                          | `npm run --if-present customize` (runs the package `customize` script when present, no-op otherwise)                   | [generateRLCInPipeline.ts#L215] |
+| **8. Lint Fix**                           | ⚠️ Optional   | `lintFix()` — `Release` / `Local` mode only | `npm run lint:fix`                                                                                                     | [generateRLCInPipeline.ts#L218] |
+| **9. Build**                              | ✅ Required   | Compile package                             | `pnpm build --filter {packageName}...` (`Release`/`Local`) or `pnpm run --filter {packageName}... build` (other modes) | [generateRLCInPipeline.ts#L208] |
+| **10. Pack**                              | ✅ Required   | Generate `.tgz`                             | `pnpm run --filter {packageName}... pack`                                                                              | [generateRLCInPipeline.ts#L210] |
+| **11. Format Code**                       | ✅ Required   | `formatSdk()`                               | `npm run format`                                                                                                       | [generateRLCInPipeline.ts#L239] |
+| **12. Update Snippets**                   | ✅ Required   | `updateSnippets()`                          | `dev-tool run update-snippets`                                                                                         | [generateRLCInPipeline.ts#L240] |
+| **13. Generate Changelog & Bump Version** | ✅ Required   | `generateChangelogAndBumpVersion()`         | Same as HLC                                                                                                            | [generateRLCInPipeline.ts#L249] |
+| **14. Add ApiView Info**                  | ✅ Required   | `addApiViewInfo()`                          | Find `*.api.json` files                                                                                                | [generateRLCInPipeline.ts#L260] |
+| **15. Restore Config**                    | ✅ Required   | `changeConfigOfTestAndSample(Revert)`       | Restore original `tsconfig.json`                                                                                       | [generateRLCInPipeline.ts#L279] |
 
 ---
 
@@ -318,16 +318,16 @@ There are two generation paths based on the source: **TypeSpec project** or **Sw
 
 #### `buildPackage()` Sub-steps Detail
 
-| Sub-step             | Required    | Command / Operation                                                                               | Code Link           |
-| -------------------- | ----------- | ------------------------------------------------------------------------------------------------- | ------------------- |
-| pnpm install         | ✅ Required | `pnpm install`                                                                                    | [rushUtils.ts#L127] |
-| Apply custom code    | ⚠️ Optional | `dev-tool customization apply -s ./generated -t ./src` — packages with root-level `generated/`    | [rushUtils.ts#L139] |
-| Lint fix             | ⚠️ Optional | `npm run lint:fix` — only in `Release` / `Local` mode                                             | [rushUtils.ts#L142] |
-| turbo build          | ✅ Required | `pnpm turbo build --filter {packageName}... --token 1` (build errors are warnings for Data Plane) | [rushUtils.ts#L150] |
-| Extract ApiView info | ✅ Required | Find `temp/**/*-node.api.json` or `temp/**/*.api.json`                                            | [rushUtils.ts#L157] |
-| Test package         | ⚠️ Optional | `pnpm run test:node` — `TEST_MODE=record`; failure does not block                                 | [rushUtils.ts#L169] |
-| Format               | ✅ Required | `npm run format`                                                                                  | [rushUtils.ts#L170] |
-| Update snippets      | ✅ Required | `dev-tool run update-snippets`                                                                    | [rushUtils.ts#L171] |
+| Sub-step             | Required      | Command / Operation                                                                                  | Code Link           |
+| -------------------- | ------------- | ---------------------------------------------------------------------------------------------------- | ------------------- |
+| pnpm install         | ✅ Required   | `pnpm install`                                                                                       | [rushUtils.ts#L127] |
+| Customize package    | ⚠️ If present | `npm run --if-present customize` — runs the package `customize` script when present, no-op otherwise | [rushUtils.ts#L139] |
+| Lint fix             | ⚠️ Optional   | `npm run lint:fix` — only in `Release` / `Local` mode                                                | [rushUtils.ts#L142] |
+| turbo build          | ✅ Required   | `pnpm turbo build --filter {packageName}... --token 1` (build errors are warnings for Data Plane)    | [rushUtils.ts#L150] |
+| Extract ApiView info | ✅ Required   | Find `temp/**/*-node.api.json` or `temp/**/*.api.json`                                               | [rushUtils.ts#L157] |
+| Test package         | ⚠️ Optional   | `pnpm run test:node` — `TEST_MODE=record`; failure does not block                                    | [rushUtils.ts#L169] |
+| Format               | ✅ Required   | `npm run format`                                                                                     | [rushUtils.ts#L170] |
+| Update snippets      | ✅ Required   | `dev-tool run update-snippets`                                                                       | [rushUtils.ts#L171] |
 
 ---
 

--- a/eng/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/eng/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -91,25 +91,13 @@ export async function lintFix(packageDirectory: string) {
 }
 
 export async function customizeCodes(packageDirectory: string): Promise<void> {
-  const generatedDirectory = path.join(packageDirectory, "generated");
-  if (!fs.existsSync(generatedDirectory)) {
-    logger.info(`Skip customization because '${generatedDirectory}' does not exist.`);
-    return;
-  }
-
-  logger.info(`Start to customize codes in '${packageDirectory}'.`);
   const cwd = packageDirectory;
   const options = { ...runCommandOptions, cwd };
 
   try {
-    await runCommand(
-      "npm",
-      ["exec", "--", "dev-tool", "customization", "apply", "-s", "./generated", "-t", "./src"],
-      options,
-      true,
-      600,
-    );
-    logger.info(`Customize codes successfully.`);
+    // `--if-present` runs the package's `customize` script when it exists and is a
+    // no-op otherwise, so packages without customization are silently skipped.
+    await runCommand("npm", ["run", "--if-present", "customize"], options, true, 600);
   } catch (error) {
     logger.warn(`Failed to customize codes due to: ${(error as Error)?.stack ?? error}`);
   }

--- a/eng/tools/js-sdk-release-tools/src/test/common/devToolUtils.test.ts
+++ b/eng/tools/js-sdk-release-tools/src/test/common/devToolUtils.test.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
-import path from "path";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runCommand: vi.fn(),
@@ -27,41 +25,25 @@ describe("customizeCodes", () => {
     mocks.loggerWarn.mockReset();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  test("applies customizations when a root-level generated folder exists", async () => {
-    const packageDirectory = path.join(__dirname, "testCases", "customized-package");
-    const existsSync = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  test("runs the package customize script from the package directory", async () => {
+    const packageDirectory = "/sdk/example";
     const { customizeCodes } = await import("../../common/devToolUtils.js");
 
     await expect(customizeCodes(packageDirectory)).resolves.toBeUndefined();
-    expect(existsSync).toHaveBeenCalledWith(path.join(packageDirectory, "generated"));
+
+    // `--if-present` makes this a no-op for packages without a `customize` script,
+    // so the caller does not need to know whether a package opts into customization.
     expect(mocks.runCommand).toHaveBeenCalledWith(
       "npm",
-      ["exec", "--", "dev-tool", "customization", "apply", "-s", "./generated", "-t", "./src"],
+      ["run", "--if-present", "customize"],
       { shell: true, cwd: packageDirectory },
       true,
       600,
     );
   });
 
-  test("skips src/generated packages without a root-level generated folder", async () => {
-    const packageDirectory = path.join(__dirname, "testCases", "src-generated-package");
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const { customizeCodes } = await import("../../common/devToolUtils.js");
-
-    await expect(customizeCodes(packageDirectory)).resolves.toBeUndefined();
-    expect(mocks.runCommand).not.toHaveBeenCalled();
-    expect(mocks.loggerInfo).toHaveBeenCalledWith(
-      `Skip customization because '${path.join(packageDirectory, "generated")}' does not exist.`,
-    );
-  });
-
   test("logs failures without blocking generation", async () => {
-    const packageDirectory = path.join(__dirname, "testCases", "conflicting-package");
-    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const packageDirectory = "/sdk/example";
     const error = new Error("merge conflict");
     mocks.runCommand.mockRejectedValue(error);
     const { customizeCodes } = await import("../../common/devToolUtils.js");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17925,8 +17925,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/keyvault-keys':
-        specifier: ^4.9.0
-        version: 4.10.2
+        specifier: workspace:^
+        version: link:../keyvault-keys
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1

--- a/sdk/ai/ai-projects/CHANGELOG.md
+++ b/sdk/ai/ai-projects/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.5.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.5.0 (2026-08-20)
 
 ### Features Added

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-projects",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Azure AI Projects client library.",
   "engines": {
     "node": ">=22.0.0"
@@ -96,7 +96,7 @@
     "extract-api": "rimraf review && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"samples-dev/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "generate": "rimraf ./src/generated && mkdirp ./src/generated && npm run copy:yaml && npm run tsp:update && rimraf ./src/generated/test && rimraf ./src/generated/tsp-location.yaml",
-    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply",
+    "generate:client": "tsp-client update -d && npm run customize",
     "generate-samples": "dev-tool samples publish -f",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
@@ -106,7 +106,8 @@
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "post-emitter": "node scripts/post-emitter.mjs",
     "tsp:update": "tsp-client update -o ./src/generated",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && dev-tool customization apply"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/ai/ai-projects/src/constants.ts
+++ b/sdk/ai/ai-projects/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the `@azure/ai-projects` package.
  */
-export const SDK_VERSION = `2.5.0`;
+export const SDK_VERSION = `2.5.1`;
 
 /**
  * The package name of the `@azure/ai-projects` package.

--- a/sdk/batch/batch-rest/package.json
+++ b/sdk/batch/batch-rest/package.json
@@ -100,7 +100,8 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -96,7 +96,8 @@
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/communication/communication-job-router-rest/package.json
+++ b/sdk/communication/communication-job-router-rest/package.json
@@ -49,7 +49,8 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.1 (2026-07-13)
 
 ### Features Added

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/confidential-ledger",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
   "engines": {
     "node": ">=22.0.0"
@@ -114,6 +114,7 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   }
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerClient.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerClient.ts
@@ -22,7 +22,7 @@ export default function createClient(
   { apiVersion = "2026-02-23", ...options }: ConfidentialLedgerClientOptions = {},
 ): ConfidentialLedgerClient {
   const endpointUrl = options.endpoint ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.2`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerCustomized.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerCustomized.ts
@@ -199,7 +199,7 @@ export default function ConfidentialLedger(
 
   const apiVersion = options.apiVersion ?? "2026-02-23";
   const endpointUrl = options.endpoint ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.2`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.4 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0-beta.3 (2026-08-13)
 
 ### Features Added

--- a/sdk/contentunderstanding/ai-content-understanding/package.json
+++ b/sdk/contentunderstanding/ai-content-understanding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-content-understanding",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.4",
   "description": "Azure Content Understanding Rest Client",
   "engines": {
     "node": ">=22.0.0"
@@ -101,7 +101,8 @@
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/discovery/ai-discovery/CHANGELOG.md
+++ b/sdk/discovery/ai-discovery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-08-04)
 
 ### Features Added

--- a/sdk/discovery/ai-discovery/package.json
+++ b/sdk/discovery/ai-discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-discovery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Azure AI Discovery client library for JavaScript, providing WorkspaceClient and BookshelfClient.",
   "engines": {
     "node": ">=22.0.0"
@@ -231,7 +231,8 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "//sampleConfiguration": {
     "productName": "Microsoft Discovery",

--- a/sdk/discovery/ai-discovery/src/bookshelf/api/bookshelfContext.ts
+++ b/sdk/discovery/ai-discovery/src/bookshelf/api/bookshelfContext.ts
@@ -17,7 +17,7 @@ export function createBookshelf(
 ): BookshelfContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-discovery/1.0.0`;
+  const userAgentInfo = `azsdk-js-ai-discovery/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;

--- a/sdk/discovery/ai-discovery/src/workspace/api/workspaceContext.ts
+++ b/sdk/discovery/ai-discovery/src/workspace/api/workspaceContext.ts
@@ -17,7 +17,7 @@ export function createWorkspace(
 ): WorkspaceContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-discovery/1.0.0`;
+  const userAgentInfo = `azsdk-js-ai-discovery/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;

--- a/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-06-25)
 
 ### Features Added

--- a/sdk/eventgrid/eventgrid-systemevents/package.json
+++ b/sdk/eventgrid/eventgrid-systemevents/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "node",
     "azure",
@@ -44,11 +44,12 @@
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
-    "regenerate": "tsp-client update -d --emitter-options=\"generate-metadata=false;generate-test=false\" && dev-tool customization apply && node scripts/generateMapping.mjs && npm run format",
+    "regenerate": "tsp-client update -d --emitter-options=\"generate-metadata=false;generate-test=false\" && npm run customize",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser --no-test-proxy",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest --no-test-proxy",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply && node scripts/generateMapping.mjs && npm run format"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 4.7.3-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 4.7.3-beta.1 (2026-07-07)
 
 ### Features Added

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.7.3-beta.1",
+  "version": "4.7.3-beta.2",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/keyvault/keyvault-admin/README.md",
@@ -54,7 +54,8 @@
     "test:browser": "echo Skipped",
     "test:node": "dev-tool run test:vitest",
     "test:node:live": "cross-env TEST_MODE=live dev-tool run test:vitest --no-test-proxy",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -100,7 +100,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/keyvault-keys": "^4.9.0",
+    "@azure/keyvault-keys": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.7.3-beta.1";
+export const SDK_VERSION: string = "4.7.3-beta.2";
 
 /**
  * The latest supported Key Vault service API version.

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -122,7 +122,8 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "imports": {
     "#platform/*": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -50,7 +50,8 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "sideEffects": false,
   "//metadata": {

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -133,7 +133,8 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "imports": {
     "#platform/*": {

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -66,7 +66,8 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -30,7 +30,8 @@
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "test:node:live": "dev-tool run test:vitest -- -c vitest.int.config.ts",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "files": [
     "dist/",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -22,7 +22,8 @@
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "test:node:live": "dev-tool run test:vitest -- -c vitest.int.config.ts",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "files": [
     "dist/",

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
@@ -93,7 +93,8 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "npm run build:test && dev-tool run test:vitest --browser",
     "unit-test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "//sampleConfiguration": {
     "productName": "Azure Online Experimentation REST",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -20,7 +20,8 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "files": [
     "dist/",

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 13.1.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 13.1.0-beta.2 (2026-08-31)
 
 ### Features Added

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "13.1.0-beta.2",
+  "version": "13.1.0-beta.3",
   "description": "Azure client library to use AI Search for node.js and browser.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",
@@ -14,7 +14,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,mts}\" \"generated/**/*.{ts,mts}\" \"test/**/*.{ts,mts}\" \"samples-dev/**/*.{ts,mts}\" \"*.{js,mjs,json}\"",
-    "generate:client": "tsp-client update -d --emitter-options=\"api-version=2026-08-01-preview;ignore-nullable-on-optional=true;wrap-non-model-return=false\" && npm run format && npx dev-tool customization apply --skip index.ts",
+    "generate:client": "tsp-client update -d --emitter-options=\"api-version=2026-08-01-preview;ignore-nullable-on-optional=true;wrap-non-model-return=false\" && npm run customize",
     "generate:embeddings": "ts-node scripts/generateSampleEmbeddings.ts",
     "lint": "eslint package.json src test samples-dev",
     "lint:fix": "eslint package.json src test samples-dev --fix --fix-type [problem,suggestion]",
@@ -22,7 +22,8 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest --test-proxy-debug",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && npx dev-tool customization apply --skip index.ts"
   },
   "files": [
     "dist/",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -91,7 +91,7 @@
     "execute:samples": "echo skipped",
     "extract-api": "rimraf review && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"generated/**/*.{ts,cts,mts}\" \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update && npm run format && dev-tool customization apply",
+    "generate:client": "tsp-client update && npm run customize",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
@@ -99,7 +99,8 @@
     "test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && dev-tool customization apply"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/transcription/ai-speech-transcription/package.json
+++ b/sdk/transcription/ai-speech-transcription/package.json
@@ -82,13 +82,14 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "execute:samples": "echo skipped",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update && npm run format && dev-tool customization apply-v2",
+    "generate:client": "tsp-client update && npm run customize",
     "test:browser": "echo skipped",
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && dev-tool customization apply"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/translation/ai-translation-document/CHANGELOG.md
+++ b/sdk/translation/ai-translation-document/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-08-01)
 
 This release migrates the package to the `@azure/ai-translation-document` name and a new client design. It replaces the previous `@azure-rest/ai-translation-document` REST-level client (RLC) package.

--- a/sdk/translation/ai-translation-document/package.json
+++ b/sdk/translation/ai-translation-document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-translation-document",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SDK for Microsoft Translation Document service",
   "engines": {
     "node": ">=22.0.0"
@@ -228,6 +228,7 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   }
 }

--- a/sdk/translation/ai-translation-document/src/documentTranslation/api/documentTranslationContext.ts
+++ b/sdk/translation/ai-translation-document/src/documentTranslation/api/documentTranslationContext.ts
@@ -28,7 +28,7 @@ export function createDocumentTranslation(
 ): DocumentTranslationContext {
   const endpointUrl = options.endpoint ?? `${endpointParam}/translator`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-translation-document/1.0.0`;
+  const userAgentInfo = `azsdk-js-ai-translation-document/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;

--- a/sdk/translation/ai-translation-document/src/singleDocumentTranslation/api/singleDocumentTranslationContext.ts
+++ b/sdk/translation/ai-translation-document/src/singleDocumentTranslation/api/singleDocumentTranslationContext.ts
@@ -28,7 +28,7 @@ export function createSingleDocumentTranslation(
 ): SingleDocumentTranslationContext {
   const endpointUrl = options.endpoint ?? `${endpointParam}/translator`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-translation-document/1.0.0`;
+  const userAgentInfo = `azsdk-js-ai-translation-document/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;

--- a/sdk/translation/ai-translation-text-rest/package.json
+++ b/sdk/translation/ai-translation-text-rest/package.json
@@ -66,7 +66,8 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/voicelive/ai-voicelive/CHANGELOG.md
+++ b/sdk/voicelive/ai-voicelive/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2026-08-03)
 
 General Availability release aligning `@azure/ai-voicelive` with the stable Voice Live API version `2026-07-15`. The changes below are cumulative relative to the previous stable release, `1.0.0`.

--- a/sdk/voicelive/ai-voicelive/package.json
+++ b/sdk/voicelive/ai-voicelive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-voicelive",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A generated SDK for VoiceLiveClient.",
   "engines": {
     "node": ">=22.0.0"
@@ -85,7 +85,7 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "execute:samples": "echo skipped",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply",
+    "generate:client": "tsp-client update -d && npm run customize",
     "test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:browser:debug": "dev-tool run build-test && vitest --config vitest.browser.debug.config.ts --browser",
     "test:browser:grep": "dev-tool run build-test && vitest --config vitest.browser.debug.config.ts --browser --run -t",
@@ -105,7 +105,8 @@
     "test:integration:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/integration-test.ps1",
     "update-snippets": "dev-tool run update-snippets",
     "dev": "./fast-dev.sh",
-    "watch": "dev-tool run build-package --watch"
+    "watch": "dev-tool run build-package --watch",
+    "customize": "npm run format && dev-tool customization apply"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/voicelive/ai-voicelive/package.json
+++ b/sdk/voicelive/ai-voicelive/package.json
@@ -38,7 +38,12 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/voicelive/ai-voicelive/README.md",
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "//metadata": {
-    "constantPaths": []
+    "constantPaths": [
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
   },
   "dependencies": {
     "@azure-rest/core-client": "^2.3.1",

--- a/sdk/voicelive/ai-voicelive/src/constants.ts
+++ b/sdk/voicelive/ai-voicelive/src/constants.ts
@@ -7,7 +7,7 @@
  *
  * @internal
  */
-export const SDK_VERSION = "1.1.0";
+export const SDK_VERSION = "1.1.1";
 
 /**
  * The default API version used by the Voice Live service when the user does

--- a/sdk/web-pubsub/web-pubsub-chat/package.json
+++ b/sdk/web-pubsub/web-pubsub-chat/package.json
@@ -120,12 +120,13 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" \"samples-dev/*.ts\"",
     "execute:samples": "dev-tool samples run samples-dev",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" \"samples-dev/*.ts\"",
-    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply --skip index.ts",
+    "generate:client": "tsp-client update -d && npm run customize",
     "test:browser": "echo skipped",
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && dev-tool customization apply --skip index.ts"
   },
   "//sampleConfiguration": {
     "productName": "@azure/web-pubsub-chat",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -14,14 +14,15 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply --skip index.ts --skip README.md",
+    "generate:client": "tsp-client update -d && npm run customize",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets"
+    "update-snippets": "dev-tool run update-snippets",
+    "customize": "npm run format && dev-tool customization apply --skip index.ts --skip README.md"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## What this does

Makes package customization **opt-in via a per-package `customize` npm script**, building on the management-plane customization work in #39688.

#39688 enabled customization for modular management SDKs by detecting a root `generated/` directory and running a hard-coded `dev-tool customization apply -s ./generated -t ./src`. That's great for packages whose customization is the plain apply, but it can't express the non-default cases some packages need (skip lists, extra generators). This PR keeps everything #39688 added and moves the *invocation* to a per-package script:

- `customizeCodes` now runs `npm run --if-present customize`. A package customizes itself exactly as its `customize` script says; a package without one is a silent no-op. This preserves #39688's caller wiring (modular mgmt + data-plane, RLC) and its `generated/`-cleanup preservation untouched.
- Every package with a root `generated/` merge layer now declares a `customize` script:
  - Packages that embedded `dev-tool customization apply` in `generate:client` / `regenerate` are converted to a `customize` script, preserving their flags and steps (`--skip index.ts`, `--skip README.md`, Event Grid's mapping step, etc.), and their generation script now ends with `npm run customize`.
  - The rest get the default `dev-tool customization apply -s ./generated -t ./src && npm run format`.
- `dev-tool customization init` now also adds the default `customize` script when one isn't already present, so newly-initialized packages stay in sync.
- Version bumps for the 9 already-published packages whose `package.json` changed here (required by the package-version check).

## Notes

- **Forgiving by design:** automation never assumes a `customize` script exists — `--if-present` makes absence a no-op. Customization failures are logged and advisory during the migration.
- **Ordering:** the default is apply-then-format. Committed `generated/` is already emitter-formatted, so there's no pre-merge format mismatch; `format` runs to tidy the post-merge `src/`.
- Builds on #39688 (management SDK customization). No changes to `spec-gen-sdk`, `tsp-client`, or `eng/common`.

## Validation

- `js-sdk-release-tools`: build + full test suite (279 tests) green; `dev-tool` builds (validates `init.ts`).
- All changed `package.json` files pass the repo's Prettier (with `prettier-plugin-packagejson`).
