### PR TITLE
Fix shallow tag fetch in package verification

### DIFF
--- a/eng/tools/ci-runner/src/verifyPackages.js
+++ b/eng/tools/ci-runner/src/verifyPackages.js
@@ -51,12 +51,22 @@ const REMOTE_URL = "https://github.com/Azure/azure-sdk-for-js.git";
  * This is needed in CI where remote tags are not fetched locally.
  *
  * @param {string} tag - the git tag to resolve
+ * @param {{ repositoryDir?: string, repositoryUrl?: string }} [options] - repository overrides
  * @returns {string} the commit hash for the tag
  * @throws {Error} if the tag is not found on the remote or git ls-remote fails
  */
-export function resolveTagToCommit(tag) {
-  const baseDir = getBaseDir();
-  const result = spawnGitWithOutput(baseDir, "ls-remote", REMOTE_URL, "--tags", tag);
+export function resolveTagToCommit(tag, options = {}) {
+  const repositoryDir = options.repositoryDir ?? getBaseDir();
+  const repositoryUrl = options.repositoryUrl ?? REMOTE_URL;
+  const tagRef = `refs/tags/${tag}`;
+  const peeledTagRef = `${tagRef}^{}`;
+  const result = spawnGitWithOutput(
+    repositoryDir,
+    "ls-remote",
+    repositoryUrl,
+    "--tags",
+    `${tagRef}*`,
+  );
 
   if (result.status !== 0) {
     throw new Error(
@@ -69,30 +79,46 @@ export function resolveTagToCommit(tag) {
     throw new Error(`Tag "${tag}" not found on remote`);
   }
 
-  // git ls-remote output format: "<commit>\trefs/tags/<tagName>"
-  const commitHash = output.split("\t")[0];
-  return commitHash;
+  const refs = output.split(/\r?\n/);
+  const peeledTag = refs.find((line) => line.endsWith(`\t${peeledTagRef}`));
+  const tagObject = refs.find((line) => line.endsWith(`\t${tagRef}`));
+  const resolvedTag = peeledTag ?? tagObject;
+  if (!resolvedTag) {
+    throw new Error(`Tag "${tag}" not found on remote`);
+  }
+  return resolvedTag.split("\t")[0];
 }
 
 /**
- * Fetches the exact release tag into the local object database without fetching all tags.
+ * Ensures the release commit exists locally without introducing a shallow boundary.
  *
  * @param {string} tag - the git tag to fetch
+ * @param {string} commitHash - the resolved release commit
+ * @param {string} repositoryDir - local repository directory
+ * @param {string} repositoryUrl - remote repository URL
  * @throws {Error} if git fetch fails
  */
-function fetchTag(tag) {
-  const baseDir = getBaseDir();
-  const result = spawnGitWithOutput(
-    baseDir,
+function ensureCommitAvailable(tag, commitHash, repositoryDir, repositoryUrl) {
+  let result = spawnGitWithOutput(repositoryDir, "cat-file", "-e", commitHash);
+  if (result.status === 0) {
+    return;
+  }
+
+  result = spawnGitWithOutput(
+    repositoryDir,
     "fetch",
     "--no-tags",
-    "--depth=1",
-    REMOTE_URL,
+    repositoryUrl,
     `refs/tags/${tag}`,
   );
 
   if (result.status !== 0) {
     throw new Error(`git fetch failed with exit code ${result.status}: ${result.stderr.trim()}`);
+  }
+
+  result = spawnGitWithOutput(repositoryDir, "cat-file", "-e", commitHash);
+  if (result.status !== 0) {
+    throw new Error(`Fetched tag "${tag}" does not contain resolved commit ${commitHash}`);
   }
 }
 
@@ -103,17 +129,19 @@ function fetchTag(tag) {
  *
  * @param {string} tag - the git tag to diff against
  * @param {string} packageDir - absolute path to the package directory
+ * @param {{ repositoryDir?: string, repositoryUrl?: string }} [options] - repository overrides
  * @returns {string[]} list of modified file paths (relative to repo root)
  * @throws {Error} if the tag cannot be resolved or fetched, or git diff fails
  */
-export function getModifiedFilesSinceTag(tag, packageDir) {
-  const commitHash = resolveTagToCommit(tag);
-  fetchTag(tag);
+export function getModifiedFilesSinceTag(tag, packageDir, options = {}) {
+  const repositoryDir = options.repositoryDir ?? getBaseDir();
+  const repositoryUrl = options.repositoryUrl ?? REMOTE_URL;
+  const commitHash = resolveTagToCommit(tag, { repositoryDir, repositoryUrl });
+  ensureCommitAvailable(tag, commitHash, repositoryDir, repositoryUrl);
 
-  const baseDir = getBaseDir();
-  const relativePackageDir = path.relative(baseDir, packageDir).split(path.sep).join("/");
+  const relativePackageDir = path.relative(repositoryDir, packageDir).split(path.sep).join("/");
   const result = spawnGitWithOutput(
-    baseDir,
+    repositoryDir,
     "diff",
     "--name-only",
     commitHash,

--- a/eng/tools/ci-runner/test/verifyPackages.integration.spec.js
+++ b/eng/tools/ci-runner/test/verifyPackages.integration.spec.js
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, assert, describe, it } from "vitest";
+
+import { getModifiedFilesSinceTag } from "../src/verifyPackages.js";
+
+/**
+ * @param {string} cwd
+ * @param {string[]} args
+ */
+function runGit(cwd, ...args) {
+  return spawnSync("git", args, { cwd, encoding: "utf8" });
+}
+
+/**
+ * @param {string} cwd
+ * @param {string[]} args
+ */
+function git(cwd, ...args) {
+  const result = runGit(cwd, ...args);
+  assert.strictEqual(
+    result.status,
+    0,
+    `git ${args.join(" ")} failed:\n${result.stderr || result.stdout}`,
+  );
+  return result.stdout.trim();
+}
+
+describe("getModifiedFilesSinceTag git integration", () => {
+  /** @type {string | undefined} */
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not corrupt merge-base traversal when the release commit is already local", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-runner-tag-fetch-"));
+    const remoteDir = path.join(tempDir, "remote.git");
+    const seedDir = path.join(tempDir, "seed");
+    const corruptedDir = path.join(tempDir, "corrupted");
+    const safeDir = path.join(tempDir, "safe");
+
+    git(tempDir, "init", "--bare", "--initial-branch=main", remoteDir);
+    fs.mkdirSync(seedDir);
+    git(seedDir, "init", "--initial-branch=main");
+    git(seedDir, "config", "user.name", "CI Runner Test");
+    git(seedDir, "config", "user.email", "ci-runner-test@example.com");
+
+    const packageDir = path.join(seedDir, "pkg");
+    fs.mkdirSync(packageDir);
+    fs.writeFileSync(path.join(packageDir, "data.txt"), "base\n");
+    git(seedDir, "add", ".");
+    git(seedDir, "commit", "-m", "base");
+    const mergeBase = git(seedDir, "rev-parse", "HEAD");
+
+    fs.writeFileSync(path.join(packageDir, "data.txt"), "target\n");
+    git(seedDir, "commit", "-am", "target");
+    const targetCommit = git(seedDir, "rev-parse", "HEAD");
+    git(seedDir, "tag", "-a", "release", "-m", "release");
+
+    git(seedDir, "switch", "-c", "source", mergeBase);
+    fs.writeFileSync(path.join(packageDir, "data.txt"), "source\n");
+    git(seedDir, "commit", "-am", "source");
+    git(seedDir, "remote", "add", "origin", remoteDir);
+    git(seedDir, "push", "origin", "main", "source", "refs/tags/release");
+
+    git(seedDir, "switch", "--orphan", "hidden");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "data.txt"), "hidden\n");
+    git(seedDir, "add", ".");
+    git(seedDir, "commit", "-m", "hidden release");
+    const hiddenCommit = git(seedDir, "rev-parse", "HEAD");
+    git(seedDir, "tag", "-a", "hidden-release", "-m", "hidden release");
+    git(seedDir, "push", "origin", "refs/tags/hidden-release");
+
+    git(tempDir, "clone", "--no-local", "--no-tags", remoteDir, corruptedDir);
+    git(corruptedDir, "switch", "--detach", "origin/source");
+    assert.strictEqual(runGit(corruptedDir, "diff", "origin/main...HEAD").status, 0);
+
+    git(corruptedDir, "fetch", "--no-tags", "--depth=1", remoteDir, "refs/tags/release");
+    const shallowPath = path.resolve(
+      corruptedDir,
+      git(corruptedDir, "rev-parse", "--git-path", "shallow"),
+    );
+    assert.match(fs.readFileSync(shallowPath, "utf8"), new RegExp(targetCommit));
+    const corruptedDiff = runGit(corruptedDir, "diff", "origin/main...HEAD");
+    assert.strictEqual(corruptedDiff.status, 128);
+    assert.match(corruptedDiff.stderr, /no merge base/i);
+
+    git(tempDir, "clone", "--no-local", "--no-tags", remoteDir, safeDir);
+    git(safeDir, "switch", "--detach", "origin/source");
+    assert.deepStrictEqual(
+      getModifiedFilesSinceTag("release", path.join(safeDir, "pkg"), {
+        repositoryDir: safeDir,
+        repositoryUrl: remoteDir,
+      }),
+      ["pkg/data.txt"],
+    );
+    assert.strictEqual(fs.existsSync(path.join(safeDir, ".git", "shallow")), false);
+    assert.strictEqual(runGit(safeDir, "diff", "origin/main...HEAD").status, 0);
+
+    assert.notStrictEqual(runGit(safeDir, "cat-file", "-e", hiddenCommit).status, 0);
+    assert.deepStrictEqual(
+      getModifiedFilesSinceTag("hidden-release", path.join(safeDir, "pkg"), {
+        repositoryDir: safeDir,
+        repositoryUrl: remoteDir,
+      }),
+      ["pkg/data.txt"],
+    );
+    assert.strictEqual(runGit(safeDir, "cat-file", "-e", hiddenCommit).status, 0);
+    assert.strictEqual(fs.existsSync(path.join(safeDir, ".git", "shallow")), false);
+  });
+});

--- a/eng/tools/ci-runner/test/verifyPackages.spec.js
+++ b/eng/tools/ci-runner/test/verifyPackages.spec.js
@@ -100,6 +100,23 @@ describe("resolveTagToCommit", () => {
       stderr: "",
     });
     assert.strictEqual(resolveTagToCommit("@azure/storage-blob_1.2.3"), "abc123def456");
+    assert.deepStrictEqual(vi.mocked(spawnGitWithOutput).mock.calls[0].slice(1), [
+      "ls-remote",
+      "https://github.com/Azure/azure-sdk-for-js.git",
+      "--tags",
+      "refs/tags/@azure/storage-blob_1.2.3*",
+    ]);
+  });
+
+  it("returns the peeled commit hash for an annotated tag", () => {
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout:
+        "abc123def456\trefs/tags/@azure/storage-blob_1.2.3\n" +
+        "def456abc123\trefs/tags/@azure/storage-blob_1.2.3^{}\n",
+      stderr: "",
+    });
+    assert.strictEqual(resolveTagToCommit("@azure/storage-blob_1.2.3"), "def456abc123");
   });
 
   it("throws when the tag is not found on remote", () => {
@@ -132,14 +149,14 @@ describe("getModifiedFilesSinceTag", () => {
     vi.clearAllMocks();
   });
 
-  it("returns list of modified files when files have changed", () => {
+  it("does not fetch when the tag commit already exists locally", () => {
     // ls-remote resolves tag to commit hash
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
       stderr: "",
     });
-    // Fetch the exact tag into the local object database
+    // git cat-file confirms the commit is already present
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "",
@@ -159,14 +176,8 @@ describe("getModifiedFilesSinceTag", () => {
       "sdk/storage/storage-blob/src/index.ts",
       "sdk/storage/storage-blob/package.json",
     ]);
-    const fetchCall = vi.mocked(spawnGitWithOutput).mock.calls[1];
-    assert.deepStrictEqual(fetchCall.slice(1), [
-      "fetch",
-      "--no-tags",
-      "--depth=1",
-      "https://github.com/Azure/azure-sdk-for-js.git",
-      "refs/tags/@azure/storage-blob_1.2.3",
-    ]);
+    const objectCheckCall = vi.mocked(spawnGitWithOutput).mock.calls[1];
+    assert.deepStrictEqual(objectCheckCall.slice(1), ["cat-file", "-e", "abc123"]);
     // Verify git diff was called with the commit hash, not the tag name
     const diffCall = vi.mocked(spawnGitWithOutput).mock.calls[2];
     assert.strictEqual(diffCall[3], "abc123");
@@ -195,6 +206,50 @@ describe("getModifiedFilesSinceTag", () => {
     assert.deepStrictEqual(result, []);
   });
 
+  it("fetches a missing commit without creating a shallow boundary", () => {
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
+      stderr: "",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 128,
+      stdout: "",
+      stderr: "fatal: Not a valid object name",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "sdk/storage/storage-blob/src/index.ts\n",
+      stderr: "",
+    });
+
+    assert.deepStrictEqual(
+      getModifiedFilesSinceTag("@azure/storage-blob_1.2.3", "/repo/sdk/storage/storage-blob"),
+      ["sdk/storage/storage-blob/src/index.ts"],
+    );
+    assert.deepStrictEqual(vi.mocked(spawnGitWithOutput).mock.calls[2].slice(1), [
+      "fetch",
+      "--no-tags",
+      "https://github.com/Azure/azure-sdk-for-js.git",
+      "refs/tags/@azure/storage-blob_1.2.3",
+    ]);
+    assert.deepStrictEqual(vi.mocked(spawnGitWithOutput).mock.calls[3].slice(1), [
+      "cat-file",
+      "-e",
+      "abc123",
+    ]);
+  });
+
   it("throws when tag is not found on remote", () => {
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
@@ -216,6 +271,11 @@ describe("getModifiedFilesSinceTag", () => {
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 128,
       stdout: "",
+      stderr: "fatal: Not a valid object name",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 128,
+      stdout: "",
       stderr: "fatal: couldn't find remote ref",
     });
 
@@ -223,7 +283,35 @@ describe("getModifiedFilesSinceTag", () => {
       () => getModifiedFilesSinceTag("@azure/storage-blob_1.2.3", "/repo/sdk/storage/storage-blob"),
       /git fetch failed with exit code 128/,
     );
-    assert.strictEqual(vi.mocked(spawnGitWithOutput).mock.calls.length, 2);
+    assert.strictEqual(vi.mocked(spawnGitWithOutput).mock.calls.length, 3);
+  });
+
+  it("throws when the fetched tag does not contain the resolved commit", () => {
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
+      stderr: "",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 128,
+      stdout: "",
+      stderr: "fatal: Not a valid object name",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    });
+    vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
+      status: 128,
+      stdout: "",
+      stderr: "fatal: Not a valid object name",
+    });
+
+    assert.throws(
+      () => getModifiedFilesSinceTag("@azure/storage-blob_1.2.3", "/repo/sdk/storage/storage-blob"),
+      /Fetched tag "@azure\/storage-blob_1.2.3" does not contain resolved commit abc123/,
+    );
   });
 
   it("throws when git diff fails", () => {
@@ -382,7 +470,7 @@ describe("verifyPackages", () => {
       stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
       stderr: "",
     });
-    // git fetch
+    // git cat-file
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "",
@@ -411,7 +499,7 @@ describe("verifyPackages", () => {
       stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
       stderr: "",
     });
-    // git fetch
+    // git cat-file
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "",
@@ -450,7 +538,7 @@ describe("verifyPackages", () => {
       stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
       stderr: "",
     });
-    // git fetch
+    // git cat-file
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "",
@@ -494,7 +582,7 @@ describe("verifyPackages", () => {
       stdout: "abc123\trefs/tags/@azure/storage-blob_1.2.3\n",
       stderr: "",
     });
-    // git fetch
+    // git cat-file
     vi.mocked(spawnGitWithOutput).mockReturnValueOnce({
       status: 0,
       stdout: "",


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Fixes package-version verification so fetching a release tag cannot corrupt the active checkout's commit graph.

## Root cause

In [Azure DevOps build 6750182](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6750182&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=f929e5a6-261b-52b0-e236-09a5cb296769&l=29), the Analyze job checked out full history and `Generate PR Diff` successfully ran `git diff origin/main...77c7871dc51c9b190cc8a6f5ac5ceeaf68c2ab86`. Later, `Check package version` fetched package tags with `--depth=1` in the same repository. Fetching tag commit `1c9d9a870c70ab6385c6a8472950b3ff29e8aa45` wrote that existing commit into `.git/shallow`; because it is after the PR merge base on the target side but absent from the source side, subsequent protected-file three-dot diffs failed with `no merge base` even though the PR did not modify `eng/common`.

## Changes

- Resolve annotated tags to their peeled commit.
- Skip fetching when the resolved commit already exists locally.
- Fetch a missing exact tag without `--depth`, then verify the resolved commit is available.
- Add a temporary-repository regression test that reproduces the shallow-boundary merge-base failure and covers both locally available and tag-only missing commits.

The shared `eng/common` changed-file helper is sync-owned by `Azure/azure-sdk-tools`, so this PR does not introduce repo-local drift. A follow-up in that source repository should check the `git diff` exit code before logging `No changed files`.

## Validation

- `npm --prefix eng/tools/ci-runner run build`