### PR TITLE
Initialize OneSettings from monitor exporter

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Enabled process-wide OneSettings polling from exporter initialization and populated the standalone exporter profile for future feature targeting. Feature callbacks remain disabled.
+- Enabled process-wide OneSettings polling from exporter initialization and populated the standalone exporter profile for future feature targeting. Feature callbacks remain disabled. [#39764](https://github.com/Azure/azure-sdk-for-js/pull/39764)
 - Refactored internal Network and Long Interval Statsbeat lifecycle management behind a process-global manager. [#39693](https://github.com/Azure/azure-sdk-for-js/pull/39693)
 - Updated OpenTelemetry stable dependencies to `^2.10.0`, experimental dependencies to `^0.221.0`, and semantic conventions to `^1.43.0`. [#39649](https://github.com/Azure/azure-sdk-for-js/pull/39649)
 - Centralized native process execution and hardened Windows system executable

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Other Changes
 
+- Enabled process-wide OneSettings polling from exporter initialization and populated the standalone exporter profile for future feature targeting. Feature callbacks remain disabled.
 - Refactored internal Network and Long Interval Statsbeat lifecycle management behind a process-global manager. [#39693](https://github.com/Azure/azure-sdk-for-js/pull/39693)
 - Updated OpenTelemetry stable dependencies to `^2.10.0`, experimental dependencies to `^0.221.0`, and semantic conventions to `^1.43.0`. [#39649](https://github.com/Azure/azure-sdk-for-js/pull/39649)
 - Centralized native process execution and hardened Windows system executable

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -14,6 +14,8 @@ import {
 import type { OneSettingsResponse } from "./utils.js";
 import { makeOneSettingsRequest } from "./utils.js";
 import { ConfigurationWorker } from "./configurationWorker.js";
+import type { ConfigurationProfileValues } from "./configurationProfile.js";
+import { ConfigurationProfile } from "./configurationProfile.js";
 
 interface ConfigurationState {
   etag?: string;
@@ -72,8 +74,12 @@ export class ConfigurationManager {
   /**
    * Start the OneSettings polling worker. Idempotent: safe to call from every exporter
    * constructor, since only the first call has any effect.
+   *
+   * @param profile - Running SDK attributes contributed by the caller. Existing profile fields
+   * remain unchanged.
    */
-  public initialize(): void {
+  public initialize(profile: Partial<ConfigurationProfileValues> = {}): void {
+    ConfigurationProfile.getInstance().fill(profile);
     if (this.worker) {
       return;
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -65,7 +65,7 @@ export abstract class AzureMonitorBaseExporter {
         parsedConnectionString.instrumentationkey || this.instrumentationKey;
       this.endpointUrl = parsedConnectionString.ingestionendpoint?.trim() || this.endpointUrl;
       this.aadAudience = parsedConnectionString.aadaudience;
-      region = parsedConnectionString.location || getRegion(this.endpointUrl);
+      region = parsedConnectionString.location?.trim().toLowerCase() || getRegion(this.endpointUrl);
     }
 
     // Instrumentation key is required

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -6,9 +6,14 @@ import { ConnectionStringParser } from "../utils/connectionStringParser.js";
 import type { AzureMonitorExporterOptions } from "../config.js";
 import {
   DEFAULT_BREEZE_ENDPOINT,
+  ENV_AZURE_MONITOR_AUTO_ATTACH,
   ENV_CONNECTION_STRING,
+  isEnvVarTrue,
   LEGACY_ENV_DISABLE_STATSBEAT,
 } from "../Declarations/Constants.js";
+import { ConfigurationManager } from "../_configuration/configurationManager.js";
+import type { ConfigurationProfileValues } from "../_configuration/configurationProfile.js";
+import * as ai from "../utils/constants/applicationinsights.js";
 
 /**
  * Azure Monitor OpenTelemetry Trace Exporter.
@@ -51,6 +56,7 @@ export abstract class AzureMonitorBaseExporter {
     this.endpointUrl = DEFAULT_BREEZE_ENDPOINT;
     const connectionString = this.options.connectionString || process.env[ENV_CONNECTION_STRING];
     this.isStatsbeatExporter = isStatsbeatExporter ? isStatsbeatExporter : false;
+    let region = "";
 
     if (connectionString) {
       const parsedConnectionString = ConnectionStringParser.parse(connectionString);
@@ -58,6 +64,7 @@ export abstract class AzureMonitorBaseExporter {
         parsedConnectionString.instrumentationkey || this.instrumentationKey;
       this.endpointUrl = parsedConnectionString.ingestionendpoint?.trim() || this.endpointUrl;
       this.aadAudience = parsedConnectionString.aadaudience;
+      region = parsedConnectionString.location || getRegion(this.endpointUrl);
     }
 
     // Instrumentation key is required
@@ -72,8 +79,62 @@ export abstract class AzureMonitorBaseExporter {
       diag.error(message);
       throw new Error(message);
     }
+    if (!this.isStatsbeatExporter) {
+      ConfigurationManager.getInstance().initialize(
+        createConfigurationProfile(this.instrumentationKey, region),
+      );
+    }
     this.trackStatsbeat = !this.isStatsbeatExporter && !process.env[LEGACY_ENV_DISABLE_STATSBEAT];
 
     diag.debug("AzureMonitorExporter was successfully setup");
+  }
+}
+
+function createConfigurationProfile(
+  instrumentationKey: string,
+  region: string,
+): Partial<ConfigurationProfileValues> {
+  return {
+    os: getOperatingSystem(),
+    rp: getResourceProvider(),
+    attach: isEnvVarTrue(ENV_AZURE_MONITOR_AUTO_ATTACH) ? "integratedauto" : "manual",
+    version: ai.packageVersion,
+    component: "ext",
+    region,
+    ikey: instrumentationKey,
+  };
+}
+
+function getOperatingSystem(): string {
+  switch (process.platform) {
+    case "win32":
+      return "windows";
+    case "linux":
+    case "darwin":
+      return process.platform;
+    default:
+      return "unknown";
+  }
+}
+
+function getResourceProvider(): string {
+  if (process.env.FUNCTIONS_WORKER_RUNTIME) {
+    return "fn";
+  }
+  if (process.env.WEBSITE_SITE_NAME) {
+    return "appsvc";
+  }
+  if (process.env.AKS_ARM_NAMESPACE_ID || process.env.KUBERNETES_SERVICE_HOST) {
+    return "aks";
+  }
+  return "unknown";
+}
+
+function getRegion(endpointUrl: string): string {
+  try {
+    const hostname = new URL(endpointUrl).hostname;
+    return /^([a-z0-9]+)(?:-\d+)?\.in\.applicationinsights\./i.exec(hostname)?.[1] ?? "";
+  } catch {
+    return "";
   }
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -5,6 +5,7 @@ import { diag } from "@opentelemetry/api";
 import { ConnectionStringParser } from "../utils/connectionStringParser.js";
 import type { AzureMonitorExporterOptions } from "../config.js";
 import {
+  ALLOWED_REDIRECT_DOMAIN_SUFFIX_GROUPS,
   DEFAULT_BREEZE_ENDPOINT,
   ENV_AZURE_MONITOR_AUTO_ATTACH,
   ENV_CONNECTION_STRING,
@@ -133,7 +134,16 @@ function getResourceProvider(): string {
 function getRegion(endpointUrl: string): string {
   try {
     const hostname = new URL(endpointUrl).hostname;
-    return /^([a-z0-9]+)(?:-\d+)?\.in\.applicationinsights\./i.exec(hostname)?.[1] ?? "";
+    const match = /^([a-z0-9]+)(?:-\d+)?\.in(\.applicationinsights\.[a-z.]+)$/i.exec(hostname);
+    if (
+      !match ||
+      !ALLOWED_REDIRECT_DOMAIN_SUFFIX_GROUPS.some((suffixGroup) =>
+        suffixGroup.includes(match[2].toLowerCase()),
+      )
+    ) {
+      return "";
+    }
+    return match[1];
   } catch {
     return "";
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
@@ -69,15 +69,34 @@ describe("OneSettings exporter initialization", () => {
     expect(configurationMocks.initialize).not.toHaveBeenCalled();
   });
 
-  it("extracts the region from an unstamped regional ingestion endpoint", () => {
+  it.each([
+    ["https://westus.in.applicationinsights.azure.com", "westus"],
+    ["https://westus-1.in.applicationinsights.azure.com", "westus"],
+    ["https://usgovvirginia.in.applicationinsights.azure.us", "usgovvirginia"],
+    ["https://chinaeast2-1.in.applicationinsights.azure.cn", "chinaeast2"],
+  ])("extracts the region from regional ingestion endpoint %s", (ingestionEndpoint, region) => {
     new TestExporter({
       connectionString:
-        `InstrumentationKey=${instrumentationKey};` +
-        "IngestionEndpoint=https://westus.in.applicationinsights.azure.com",
+        `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
     });
 
     expect(configurationMocks.initialize).toHaveBeenCalledWith(
-      expect.objectContaining({ region: "westus" }),
+      expect.objectContaining({ region }),
+    );
+  });
+
+  it.each([
+    "https://westus.in.applicationinsights.example.com",
+    "https://westus.in.applicationinsights.azure.com.example.com",
+    "https://prefix.westus.in.applicationinsights.azure.com",
+  ])("does not extract a region from unsupported endpoint %s", (ingestionEndpoint) => {
+    new TestExporter({
+      connectionString:
+        `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
+    });
+
+    expect(configurationMocks.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "" }),
     );
   });
 });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
@@ -76,13 +76,10 @@ describe("OneSettings exporter initialization", () => {
     ["https://chinaeast2-1.in.applicationinsights.azure.cn", "chinaeast2"],
   ])("extracts the region from regional ingestion endpoint %s", (ingestionEndpoint, region) => {
     new TestExporter({
-      connectionString:
-        `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
+      connectionString: `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
     });
 
-    expect(configurationMocks.initialize).toHaveBeenCalledWith(
-      expect.objectContaining({ region }),
-    );
+    expect(configurationMocks.initialize).toHaveBeenCalledWith(expect.objectContaining({ region }));
   });
 
   it.each([
@@ -91,8 +88,7 @@ describe("OneSettings exporter initialization", () => {
     "https://prefix.westus.in.applicationinsights.azure.com",
   ])("does not extract a region from unsupported endpoint %s", (ingestionEndpoint) => {
     new TestExporter({
-      connectionString:
-        `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
+      connectionString: `InstrumentationKey=${instrumentationKey};IngestionEndpoint=${ingestionEndpoint}`,
     });
 
     expect(configurationMocks.initialize).toHaveBeenCalledWith(

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const configurationMocks = vi.hoisted(() => ({
+  initialize: vi.fn(),
+}));
+
+vi.mock("../../src/_configuration/configurationManager.js", () => ({
+  ConfigurationManager: {
+    getInstance: vi.fn(() => configurationMocks),
+  },
+}));
+
+import type { AzureMonitorExporterOptions } from "../../src/config.js";
+import { AzureMonitorBaseExporter } from "../../src/export/base.js";
+import { packageVersion } from "../../src/utils/constants/applicationinsights.js";
+
+class TestExporter extends AzureMonitorBaseExporter {
+  public constructor(options: AzureMonitorExporterOptions, isStatsbeatExporter = false) {
+    super(options, isStatsbeatExporter);
+  }
+}
+
+describe("OneSettings exporter initialization", () => {
+  const instrumentationKey = "1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("FUNCTIONS_WORKER_RUNTIME", "");
+    vi.stubEnv("WEBSITE_SITE_NAME", "");
+    vi.stubEnv("AKS_ARM_NAMESPACE_ID", "");
+    vi.stubEnv("KUBERNETES_SERVICE_HOST", "");
+    vi.stubEnv("AZURE_MONITOR_AUTO_ATTACH", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("initializes OneSettings with the standalone exporter profile", () => {
+    new TestExporter({
+      connectionString:
+        `InstrumentationKey=${instrumentationKey};` +
+        "Location=westeurope;EndpointSuffix=applicationinsights.azure.com",
+    });
+
+    expect(configurationMocks.initialize).toHaveBeenCalledOnce();
+    expect(configurationMocks.initialize).toHaveBeenCalledWith({
+      os: process.platform === "win32" ? "windows" : process.platform,
+      rp: "unknown",
+      attach: "integratedauto",
+      version: packageVersion,
+      component: "ext",
+      region: "westeurope",
+      ikey: instrumentationKey,
+    });
+  });
+
+  it("does not initialize OneSettings for the internal Statsbeat exporter", () => {
+    new TestExporter(
+      {
+        connectionString: `InstrumentationKey=${instrumentationKey}`,
+      },
+      true,
+    );
+
+    expect(configurationMocks.initialize).not.toHaveBeenCalled();
+  });
+
+  it("extracts the region from an unstamped regional ingestion endpoint", () => {
+    new TestExporter({
+      connectionString:
+        `InstrumentationKey=${instrumentationKey};` +
+        "IngestionEndpoint=https://westus.in.applicationinsights.azure.com",
+    });
+
+    expect(configurationMocks.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "westus" }),
+    );
+  });
+});

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationInitialization.spec.ts
@@ -58,6 +58,21 @@ describe("OneSettings exporter initialization", () => {
     });
   });
 
+  it.each(["WestUS", " WestUS "])(
+    "normalizes explicit connection string location %j",
+    (location) => {
+      new TestExporter({
+        connectionString:
+          `InstrumentationKey=${instrumentationKey};Location=${location};` +
+          "IngestionEndpoint=https://westus.in.applicationinsights.azure.com",
+      });
+
+      expect(configurationMocks.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({ region: "westus" }),
+      );
+    },
+  );
+
   it("does not initialize OneSettings for the internal Statsbeat exporter", () => {
     new TestExporter(
       {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { ConfigurationManager } from "../../src/_configuration/configurationManager.js";
+import { ConfigurationProfile } from "../../src/_configuration/configurationProfile.js";
 import type { OneSettingsResponse } from "../../src/_configuration/utils.js";
 import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
 import {
@@ -33,11 +34,28 @@ describe("ConfigurationManager", () => {
 
   beforeEach(() => {
     manager.reset();
+    ConfigurationProfile.getInstance().reset();
     request.mockReset();
   });
 
   afterEach(() => {
     manager.reset();
+    ConfigurationProfile.getInstance().reset();
+  });
+
+  it("fills the write-once evaluation profile across repeated initialization", () => {
+    manager.initialize({ component: "ext", version: "1.0.0", os: "linux" });
+    manager.initialize({ component: "dst", region: "westus", ikey: "test-ikey" });
+
+    assert.deepStrictEqual(ConfigurationProfile.getInstance().snapshot(), {
+      os: "linux",
+      rp: "",
+      attach: "",
+      version: "1.0.0",
+      component: "ext",
+      region: "westus",
+      ikey: "test-ikey",
+    });
   });
 
   it("fetches and caches configuration when change detection reports an update", async () => {


### PR DESCRIPTION
## Summary
- initialize the process-wide OneSettings configuration manager from regular monitor exporters
- populate the standalone exporter profile for future feature targeting
- derive regions from explicit locations and stamped or unstamped regional ingestion endpoints on supported Application Insights domains
- keep feature callbacks and distro initialization out of scope

## Testing
- pnpm check-format
- pnpm lint
- pnpm test:node
- pnpm turbo build --filter=@azure/monitor-opentelemetry-exporter... --token 1