### PR TITLE
Migrate ci-runner to pnpm workspace

### DIFF
--- a/eng/tools/ci-runner/eslint.config.mjs
+++ b/eng/tools/ci-runner/eslint.config.mjs
@@ -8,7 +8,7 @@ export default [
     languageOptions: {
       globals: {
         ...globals.node,
-      }
-    }
+      },
+    },
   },
 ];

--- a/eng/tools/ci-runner/package.json
+++ b/eng/tools/ci-runner/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "prettier": "../../../common/tools/eslint-plugin-azure-sdk/prettier.json",
   "scripts": {
-    "build": "pnpm typecheck",
+    "build": "pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run test",
     "build:samples": "echo skipped",
     "build:test": "echo skipped",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{js,mjs,json,md}\"",

--- a/eng/tools/ci-runner/package.json
+++ b/eng/tools/ci-runner/package.json
@@ -1,21 +1,33 @@
 {
   "name": "@azure-tools/ci-runner",
+  "version": "1.0.0",
+  "sdk-type": "utility",
   "type": "module",
+  "private": true,
   "prettier": "../../../common/tools/eslint-plugin-azure-sdk/prettier.json",
   "scripts": {
-    "build": "npm run format && npm run lint && npm run typecheck && npm run test",
-    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore index.js \"src/**/*.js\" \"test/**/*.js\"",
+    "build": "pnpm typecheck",
+    "build:samples": "echo skipped",
+    "build:test": "echo skipped",
+    "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{js,mjs,json,md}\"",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{js,mjs,json,md}\"",
     "typecheck": "tsc",
     "lint": "eslint index.js src test",
-    "test": "vitest"
+    "lint:fix": "eslint index.js src test --fix --fix-type [problem,suggestion]",
+    "test": "vitest run",
+    "test:browser": "echo skipped",
+    "test:node": "pnpm test",
+    "test:watch": "vitest --watch",
+    "update-snippets": "echo skipped"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "@types/node": "^22.0.0",
-    "@vitest/coverage-istanbul": "^4.0.0",
-    "eslint": "^10.8.0",
-    "prettier": "^3.6.2",
-    "vitest": "^4.0.0",
-    "typescript": "~6.0.2"
+    "@eslint/js": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:testing",
+    "eslint": "catalog:",
+    "globals": "^17.11.0",
+    "prettier": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:testing"
   }
 }

--- a/eng/tools/ci-runner/turbo.json
+++ b/eng/tools/ci-runner/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,33 @@ importers:
         specifier: ^4.0.0
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@7.3.3(@types/node@22.20.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  eng/tools/ci-runner:
+    devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 10.0.1(eslint@10.8.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      '@vitest/coverage-istanbul':
+        specifier: catalog:testing
+        version: 4.1.10(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.1
+      globals:
+        specifier: ^17.11.0
+        version: 17.11.0
+      prettier:
+        specifier: 'catalog:'
+        version: 3.9.6
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@7.3.3(@types/node@22.20.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+
   sdk/advisor/arm-advisor:
     dependencies:
       '@azure-rest/core-client':
@@ -39701,6 +39728,10 @@ packages:
     resolution: {integrity: sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=}
     engines: {node: '>=18'}
 
+  globals@17.11.0:
+    resolution: {integrity: sha1-1kNIW7MCINd1HlEc9PaMc9OHDYc=}
+    engines: {node: '>=18'}
+
   globalthis@1.0.4:
     resolution: {integrity: sha1-dDDtOpddl7+1m8zkH1yruvplEjY=}
     engines: {node: '>= 0.4'}
@@ -46943,6 +46974,8 @@ snapshots:
   globals@14.0.0: {}
 
   globals@15.15.0: {}
+
+  globals@17.11.0: {}
 
   globalthis@1.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - common/tools/dev-tool
   - common/tools/eslint-plugin-azure-sdk
   - eng/containers/turborepo-remote-cache
+  - eng/tools/ci-runner
   - common/tools/vite-plugin-browser-test-map
   - common/tools/warp
   - '!sdk/**/src/**'


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): 

Migrate `eng/tools/ci-runner` as the first standalone engineering utility under the root pnpm workspace.

## Summary
- explicitly add `eng/tools/ci-runner` to `pnpm-workspace.yaml`
- normalize private utility metadata, scripts, and catalog-backed dependencies
- declare `globals` directly for the ESLint configuration
- make `build` run full validation (`format`, `lint`, `typecheck`, and `test`) while producing no build artifacts, and configure Turbo for intentional empty outputs
- regenerate the root `pnpm-lock.yaml` while preserving the existing CLI caller interface

No pipeline YAML changes are needed because relevant jobs already run the root pnpm install before invoking `node eng/tools/ci-runner/index.js ...`.

## Validation
- `pnpm install --filter @azure-tools/ci-runner...`
- `pnpm --dir eng/tools/ci-runner format`
- `pnpm --dir eng/tools/ci-runner check-format`
- `pnpm --dir eng/tools/ci-runner lint`
- `pnpm --dir eng/tools/ci-runner typecheck`
- `pnpm --dir eng/tools/ci-runner build`
- `pnpm --dir eng/tools/ci-runner test`
- `pnpm turbo build --filter=@azure-tools/ci-runner... --force --token 1`
- `pnpm turbo build --filter=@azure-tools/ci-runner... --dry --token 1`
- `pnpm install --filter @azure-tools/ci-runner... --frozen-lockfile`
