### PR TITLE
Replace deprecated jsrsasign dependency in @azure/attestation

### DIFF
--- a/eng/approved-third-party-dependencies.yml
+++ b/eng/approved-third-party-dependencies.yml
@@ -66,7 +66,10 @@ exceptions:
     packages:
       - "@azure/web-pubsub"
       - "@azure/web-pubsub-chat"
-  - dependency: "jsrsasign"
+  - dependency: "@noble/curves"
+    packages:
+      - "@azure/attestation"
+  - dependency: "node-forge"
     packages:
       - "@azure/attestation"
   - dependency: "jssha"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2543,9 +2543,12 @@ importers:
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
-      jsrsasign:
-        specifier: ^11.0.0
-        version: 11.1.5
+      '@noble/curves':
+        specifier: ^2.0.1
+        version: 2.3.0
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2571,6 +2574,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
+      '@types/node-forge':
+        specifier: ^1.3.13
+        version: 1.3.14
       '@vitest/browser-playwright':
         specifier: catalog:testing
         version: 4.1.10(playwright@1.62.1)(vite@7.3.3(@types/node@22.20.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
@@ -37296,6 +37302,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@noble/curves@2.3.0':
+    resolution: {integrity: sha1-CsCbDA/Dzv+75ZnC5WhbX1mrAF0=}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha1-UF/TnDE0o35nyMTmxgSaSWFUh5w=}
+    engines: {node: '>= 20.19.0'}
+
   '@nodable/entities@3.0.0':
     resolution: {integrity: sha1-aUcDvIZNMOrtVcLj3vANvWFJNnA=}
 
@@ -40225,10 +40239,6 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=}
     engines: {node: '>=12', npm: '>=6'}
-
-  jsrsasign@11.1.5:
-    resolution: {integrity: sha1-e9CzrjILpnOBab3gaRoY+M4a8po=}
-    deprecated: This package is no longer maintained.
 
   jssha@3.3.2:
     resolution: {integrity: sha1-MMUbWri/ix7PJBYBWAPUT1y/Bp4=}
@@ -44149,6 +44159,12 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
+  '@noble/curves@2.3.0':
+    dependencies:
+      '@noble/hashes': 2.3.0
+
+  '@noble/hashes@2.3.0': {}
+
   '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -47486,8 +47502,6 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.8.5
-
-  jsrsasign@11.1.5: {}
 
   jssha@3.3.2: {}
 

--- a/sdk/attestation/attestation/CHANGELOG.md
+++ b/sdk/attestation/attestation/CHANGELOG.md
@@ -13,6 +13,7 @@ Fixed a bug where the client options are ignored when passed along with an AAD c
 
 ### Other Changes
 
+- Replaced the deprecated `jsrsasign` dependency with maintained isomorphic cryptography implementations. [#39762](https://github.com/Azure/azure-sdk-for-js/issues/39762)
 - Native ESM support has been added, and this package will now emit both CommonJS and ESM. [#31433](https://github.com/Azure/azure-sdk-for-js/pull/31433)
 
 ## 1.0.0 (2021-08-10)

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -73,7 +73,8 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.1.4",
-    "jsrsasign": "^11.0.0",
+    "@noble/curves": "^2.0.1",
+    "node-forge": "^1.4.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
@@ -84,6 +85,7 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
     "@types/node": "catalog:",
+    "@types/node-forge": "^1.3.13",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",
     "buffer": "^6.0.0",

--- a/sdk/attestation/attestation/sample.env
+++ b/sdk/attestation/attestation/sample.env
@@ -6,6 +6,7 @@ policySigningCertificate1=""
 policySigningCertificate0=""
 ATTESTATION_ISOLATED_SIGNING_CERTIFICATE="Base64 encoded DER X.509 certificate which was used to configure an isolated mode attestation instance"
 ATTESTATION_ISOLATED_SIGNING_KEY="Base64 encoded DER RSA Private Key associated with ATTESTATION_ISOLATED_SIGNING_CERTIFICATE"
+ATTESTATION_NEW_SIGNING_CERTIFICATE="Base64 encoded DER X.509 certificate to add and remove from an isolated mode attestation instance"
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
+++ b/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
@@ -24,7 +24,6 @@
 
 import { AttestationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { X509 } from "jsrsasign";
 import { writeBanner } from "./utils/helpers.js";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
@@ -76,12 +75,10 @@ async function getSigningCertificates(): Promise<void> {
 
   console.log(`There are ${attestationSigners.length} signers`);
 
-  // Now print the Key ID and certificate subject for each signer.
+  // Print the Key ID and certificate count for each signer.
   attestationSigners.forEach((element) => {
     console.log(`  Element Key ID: ${element.keyId};`);
-    const cert = new X509();
-    cert.readCertPEM(element.certificates[0]);
-    console.log(`    Certificate subject: ${cert.getSubjectString()}`);
+    console.log(`    Certificate count: ${element.certificates.length}`);
   });
 }
 

--- a/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
@@ -26,7 +26,6 @@
 
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { X509 } from "jsrsasign";
 import { writeBanner } from "./utils/helpers.js";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
@@ -45,12 +44,10 @@ async function getPolicyManagementCertificates(): Promise<void> {
   console.log(
     `Attestation Instance ${endpoint} has ${policyCertificates.body.length} certificates.`,
   );
-  // Now print the Key ID and certificate subject for each signer.
+  // Print the Key ID and certificate count for each signer.
   policyCertificates.body.forEach((element) => {
     console.log(`  Element Key ID: ${element.keyId};`);
-    const cert = new X509();
-    cert.readCertPEM(element.certificates[0]);
-    console.log(`    Certificate subject: ${cert.getSubjectString()}`);
+    console.log(`    Certificate count: ${element.certificates.length}`);
   });
 }
 

--- a/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
@@ -21,6 +21,8 @@
  *      mode signing certificates.
  *  3) ATTESTATION_ISOLATED_SIGNING_KEY - A Base64 encoded DER RSA Private key which
  *      corresponds to the ATTESTATION_ISOLATED_SIGNING_CERTIFICATE.
+ *  4) ATTESTATION_NEW_SIGNING_CERTIFICATE - A Base64 encoded DER X.509 certificate
+ *      to add and then remove from the isolated instance.
  *
  * To authorize access to the service, this sample also depends on the following
  * environment variables:
@@ -31,8 +33,7 @@
 
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { createRSAKey, createX509Certificate, generateSha1Hash } from "./utils/cryptoUtils.js";
-import { X509 } from "jsrsasign";
+import { certificateToDer, generateSha1Hash } from "./utils/cryptoUtils.js";
 import { writeBanner } from "./utils/helpers.js";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
@@ -57,17 +58,17 @@ async function modifyPolicyManagementCertificates(): Promise<void> {
   if (base64Certificate === undefined) {
     throw new Error("ATTESTATION_ISOLATED_SIGNING_CERTIFICATE must be provided.");
   }
+  const base64NewCertificate = process.env.ATTESTATION_NEW_SIGNING_CERTIFICATE;
+  if (base64NewCertificate === undefined) {
+    throw new Error("ATTESTATION_NEW_SIGNING_CERTIFICATE must be provided.");
+  }
 
   const client = new AttestationAdministrationClient(endpoint, new DefaultAzureCredential());
 
-  const [rsaKey, rsaPubKey] = createRSAKey();
-  const rsaCertificate = createX509Certificate(rsaKey, rsaPubKey, "CertificateName");
-
-  // Decode the PEM encoded certificate for validation later.
-  const cert = new X509();
-  await cert.readCertPEM(rsaCertificate);
-
-  const expectedThumbprint = byteArrayToHex(generateSha1Hash(cert.hex)).toUpperCase();
+  const newCertificate = pemFromBase64(base64NewCertificate, "CERTIFICATE");
+  const expectedThumbprint = byteArrayToHex(
+    generateSha1Hash(certificateToDer(newCertificate)),
+  ).toUpperCase();
 
   // Add the new attestation signing certificate.
   //
@@ -80,7 +81,7 @@ async function modifyPolicyManagementCertificates(): Promise<void> {
   {
     // Add a new signing certificate.
     const setResult = await client.addPolicyManagementCertificate(
-      rsaCertificate,
+      newCertificate,
       privateKey,
       certificate,
     );
@@ -92,7 +93,7 @@ async function modifyPolicyManagementCertificates(): Promise<void> {
 
   {
     const removeResult = await client.removePolicyManagementCertificate(
-      rsaCertificate,
+      newCertificate,
       privateKey,
       certificate,
     );

--- a/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
@@ -37,8 +37,7 @@ import {
 } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 import { writeBanner } from "./utils/helpers.js";
-import { createRSAKey, createX509Certificate, generateSha256Hash } from "./utils/cryptoUtils.js";
-import { X509 } from "jsrsasign";
+import { generateSha256Hash } from "./utils/cryptoUtils.js";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 
@@ -53,7 +52,6 @@ async function setOpenEnclaveAttestationPolicyAadUnsecured(): Promise<void> {
   if (endpoint === undefined) {
     throw new Error("ATTESTATION_AAD_URL must be defined.");
   }
-
   const client = new AttestationAdministrationClient(endpoint, new DefaultAzureCredential());
 
   // This attestation policy blocks all non-debug SGX enclaves,
@@ -106,6 +104,14 @@ async function setOpenEnclaveAttestationPolicyAadSecured(): Promise<void> {
   if (endpoint === undefined) {
     throw new Error("ATTESTATION_AAD_URL must be defined.");
   }
+  const base64PrivateKey = process.env.ATTESTATION_ISOLATED_SIGNING_KEY;
+  if (base64PrivateKey === undefined) {
+    throw new Error("ATTESTATION_ISOLATED_SIGNING_KEY must be provided.");
+  }
+  const base64Certificate = process.env.ATTESTATION_ISOLATED_SIGNING_CERTIFICATE;
+  if (base64Certificate === undefined) {
+    throw new Error("ATTESTATION_ISOLATED_SIGNING_CERTIFICATE must be provided.");
+  }
 
   const client = new AttestationAdministrationClient(endpoint, new DefaultAzureCredential());
 
@@ -124,12 +130,8 @@ async function setOpenEnclaveAttestationPolicyAadSecured(): Promise<void> {
 
   // Set the new attestation policy. Set the policy as an secured policy.
 
-  // Start by creating an RSA Key and Certificate (note: normally the key would
-  // be stored securely in Key Value or other location. For the purposes of this
-  // sample, an ephemeral key and self-signed certificate is sufficient).
-
-  const [privateKey, publicKey] = createRSAKey();
-  const certificate = createX509Certificate(privateKey, publicKey, "Test Certificate.");
+  const privateKey = pemFromBase64(base64PrivateKey, "PRIVATE KEY");
+  const certificate = pemFromBase64(base64Certificate, "CERTIFICATE");
 
   const setPolicyResult = await client.setPolicy(KnownAttestationType.OpenEnclave, newPolicy, {
     privateKey: privateKey,
@@ -146,12 +148,7 @@ async function setOpenEnclaveAttestationPolicyAadSecured(): Promise<void> {
   console.log("Expected token hash: ", expectedHash);
   console.log("Actual token hash: ", Uint8Array.from(setPolicyResult.body.policyTokenHash));
 
-  // Also verify that the signer of the certificate recevied by the service was
-  // the certificate sent in the request.
-
-  const policySetCertificate = new X509();
-  await policySetCertificate.readCertPEM(setPolicyResult.body.policySigner?.certificates[0]);
-  console.log("Signer subject name: ", policySetCertificate.getSubjectString());
+  console.log("Policy signer key ID: ", setPolicyResult.body.policySigner?.keyId);
 
   // Now reset the policy to the default policy. Note that we use an unsecured
   // attestation token - that is because AAD instances do not require a signed
@@ -216,12 +213,7 @@ async function setSgxEnclaveAttestationPolicyIsolatedSecured(): Promise<void> {
   console.log("Expected token hash: ", expectedHash);
   console.log("Actual token hash: ", Uint8Array.from(setPolicyResult.body.policyTokenHash));
 
-  // Also verify that the signer of the certificate recevied by the service was
-  // the certificate sent in the request.
-
-  const policySetCertificate = new X509();
-  await policySetCertificate.readCertPEM(setPolicyResult.body.policySigner?.certificates[0]);
-  console.log("Signer subject name: ", policySetCertificate.getSubjectString());
+  console.log("Policy signer key ID: ", setPolicyResult.body.policySigner?.keyId);
 
   // Now reset the policy to the default policy.
   const resetPolicyResult = await client.resetPolicy(KnownAttestationType.SgxEnclave, {

--- a/sdk/attestation/attestation/samples-dev/utils/cryptoUtils.ts
+++ b/sdk/attestation/attestation/samples-dev/utils/cryptoUtils.ts
@@ -5,108 +5,41 @@
  * @azsdk-util true
  */
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../src/jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
+import forge from "node-forge";
+import { stringToUint8Array, uint8ArrayToString } from "@azure/core-util";
 
-function hexToByteArray(value: string): Uint8Array {
-  if (value.length % 2 !== 0) {
-    throw new Error("base64FromHex: Input must be a multiple of 2 characters");
+function binaryStringToBytes(value: string): Uint8Array {
+  return Uint8Array.from(value, (character) => character.charCodeAt(0));
+}
+
+export function certificateToDer(certificate: string): Uint8Array {
+  const base64 = certificate
+    .replace("-----BEGIN CERTIFICATE-----", "")
+    .replace("-----END CERTIFICATE-----", "")
+    .replace(/\s/g, "");
+  const der = stringToUint8Array(base64, "base64");
+  if (uint8ArrayToString(der, "base64") !== base64) {
+    throw new Error("Invalid PEM encoded certificate.");
   }
-  const byteArray = new Array();
-  for (let i = 0; i < value.length; i += 2) {
-    byteArray.push(parseInt(value.substr(i, 2), 16));
-  }
-  return Uint8Array.from(byteArray);
-}
-
-export function createECDSKey(): [string, string] {
-  const keyPair = jsrsasign.KEYUTIL.generateKeypair("EC", "secp256r1");
-  return [
-    jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
-  ];
-}
-
-export function createRSAKey(): [string, string] {
-  const keyPair = jsrsasign.KEYUTIL.generateKeypair("RSA", 1024);
-  return [
-    jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
-  ];
-}
-
-function localDateToUtc(d: Date): Date {
-  const utc = d.getTime() + d.getTimezoneOffset() * 60000;
-  return new Date(utc);
-}
-
-function zeroPadding(s: string, len: number): any {
-  if (s.length >= len) return s;
-  return new Array(len - s.length + 1).join("0") + s;
-}
-
-function formatDateString(dateObject: Date): string {
-  const pad = zeroPadding;
-  const d = localDateToUtc(dateObject);
-  let year = String(d.getFullYear());
-  // Extract first two digits of year for UTC encoding.
-  year = year.substr(2, 2);
-  const month = pad(String(d.getMonth() + 1), 2);
-  const day = pad(String(d.getDate()), 2);
-  const hour = pad(String(d.getHours()), 2);
-  const min = pad(String(d.getMinutes()), 2);
-  const sec = pad(String(d.getSeconds()), 2);
-  const s = year + month + day + hour + min + sec;
-  return s + "Z";
-}
-
-// Create a self-signed X.509 certificZTe
-export function createX509Certificate(
-  privKeyPEM: string,
-  pubKeyPEM: string,
-  subject_name: string,
-): string {
-  const pubKey = jsrsasign.KEYUTIL.getKey(pubKeyPEM);
-  const privKey = jsrsasign.KEYUTIL.getKey(privKeyPEM);
-
-  const timeEnd = new Date();
-  timeEnd.setFullYear(timeEnd.getFullYear() + 1);
-
-  const cert = new jsrsasign.KJUR.asn1.x509.Certificate({
-    //    tbsobj: tbs,
-    serial: { int: 4 },
-    issuer: { str: "/CN=" + subject_name },
-    subject: { str: "/CN=" + subject_name },
-    notafter: { str: formatDateString(timeEnd) },
-    sbjpubkey: pubKey,
-    ext: [
-      { extname: "basicConstraints", critical: false, cA: false, pathLen: 0 },
-      { extname: "subjectAltName", critical: false, array: [{ uri: "https://" + subject_name }] },
-      { extname: "keyUsage", critical: true, names: ["digitalSignature"] },
-    ],
-    sigalg: { name: "SHA256withRSA" },
-    cakey: privKey,
-  });
-
-  const x509 = new jsrsasign.X509();
-  x509.readCertPEM(cert.getPEM());
-
-  return cert.getPEM();
+  return der;
 }
 
 /**
  * Generate the SHA256 hash of the specified buffer.
  */
 export function generateSha256Hash(buffer: string): Uint8Array {
-  return hexToByteArray(jsrsasign.KJUR.crypto.Util.hashString(buffer, "sha256"));
+  const digest = forge.md.sha256.create();
+  digest.update(buffer, "utf8");
+  return binaryStringToBytes(digest.digest().getBytes());
 }
 
 /** Generate the SHA1 hash of the specified buffer.
  *
- * @param buffer - HEX encoded buffer to be hashed.
+ * @param buffer - Buffer to be hashed.
  * @returns SHA1 hash of the buffer.
  */
-export function generateSha1Hash(buffer: string): Uint8Array {
-  return hexToByteArray(jsrsasign.KJUR.crypto.Util.hashHex(buffer, "sha1"));
+export function generateSha1Hash(buffer: Uint8Array): Uint8Array {
+  const digest = forge.md.sha1.create();
+  digest.update(String.fromCharCode(...buffer), "raw");
+  return binaryStringToBytes(digest.digest().getBytes());
 }

--- a/sdk/attestation/attestation/src/attestationAdministrationClient.ts
+++ b/sdk/attestation/attestation/src/attestationAdministrationClient.ts
@@ -29,15 +29,13 @@ import type { TokenCredential } from "@azure/core-auth";
 import { TypeDeserializer } from "./utils/typeDeserializer.js";
 import * as Mappers from "./generated/models/mappers.js";
 
-/// <reference path="../jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
-import { hexToBase64 } from "./utils/helpers.js";
 import { _policyResultFromGenerated } from "./models/policyResult.js";
 import { _attestationSignerFromGenerated } from "./models/attestationSigner.js";
 import { verifyAttestationSigningKey } from "./utils/helpers.js";
 import { createAttestationResponse } from "./models/attestationResponse.js";
 import { AttestationTokenImpl } from "./models/attestationToken.js";
 import { tracingClient } from "./generated/tracing.js";
+import { certificateToBase64, keyTypeFromCertificate } from "./utils/jws.js";
 
 /**
  * Attestation Client Construction Options.
@@ -436,13 +434,9 @@ export class AttestationAdministrationClient {
           verifyAttestationSigningKey(privateKey, certificate);
         }
 
-        const cert = new jsrsasign.X509();
-        cert.readCertPEM(pemCertificate);
-        const kty = this.keyTypeFromCertificate(cert);
-
         const jwk: JsonWebKey = {
-          x5C: [hexToBase64(cert.hex)],
-          kty: kty,
+          x5C: [certificateToBase64(pemCertificate)],
+          kty: keyTypeFromCertificate(pemCertificate),
         };
 
         const addBody: AttestationCertificateManagementBody = {
@@ -493,25 +487,6 @@ export class AttestationAdministrationClient {
     );
   }
 
-  private keyTypeFromCertificate(cert: any): string {
-    let kty: string;
-    switch (cert.getSignatureAlgorithmName()) {
-      case "SHA256withRSA":
-      case "SHA384withRSA":
-      case "SHA512withRSA":
-        kty = "RSA";
-        break;
-      case "SHA256withECDSA":
-      case "SHA384withECDSA":
-        kty = "EC";
-        break;
-      default:
-        kty = "RSA";
-        break;
-    }
-    return kty;
-  }
-
   /** Add a new certificate chain to the set of policy management certificates.
    *
    * @param pemCertificate - PEM encoded certificate to add to the set of policy management certificates.
@@ -549,13 +524,9 @@ export class AttestationAdministrationClient {
           verifyAttestationSigningKey(privateKey, certificate);
         }
 
-        const cert = new jsrsasign.X509();
-        cert.readCertPEM(pemCertificate);
-        const kty = this.keyTypeFromCertificate(cert);
-
         const jwk: JsonWebKey = {
-          x5C: [hexToBase64(cert.hex)],
-          kty: kty,
+          x5C: [certificateToBase64(pemCertificate)],
+          kty: keyTypeFromCertificate(pemCertificate),
         };
 
         const addBody: AttestationCertificateManagementBody = {

--- a/sdk/attestation/attestation/src/jsrsasign.d.ts
+++ b/sdk/attestation/attestation/src/jsrsasign.d.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-declare module 'jsrsasign';

--- a/sdk/attestation/attestation/src/models/attestationToken.ts
+++ b/sdk/attestation/attestation/src/models/attestationToken.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
-
 import type { JsonWebKey } from "../generated/models/index.js";
 import { base64UrlDecodeString } from "../utils/base64.js";
 import { bytesToString } from "../utils/utf8.js";
@@ -13,7 +9,7 @@ import { _attestationSignerFromGenerated } from "./attestationSigner.js";
 
 import * as Mappers from "../generated/models/mappers.js";
 import { TypeDeserializer } from "../utils/typeDeserializer.js";
-import { hexToBase64, verifyAttestationSigningKey } from "../utils/helpers.js";
+import { createAttestationJws, verifyAttestationJws } from "../utils/jws.js";
 
 /**
  * Options used to validate attestation tokens.
@@ -248,9 +244,6 @@ export class AttestationTokenImpl implements AttestationToken {
     this._header = safeJsonParse(bytesToString(this._headerBytes));
     this._bodyBytes = base64UrlDecodeString(pieces[1]);
     this._body = safeJsonParse(bytesToString(this._bodyBytes));
-    //      this._signature = base64UrlDecodeString(pieces[2]);
-
-    this._jwsVerifier = jsrsasign.KJUR.jws.JWS.parse(token);
   }
 
   private _token: string;
@@ -258,17 +251,13 @@ export class AttestationTokenImpl implements AttestationToken {
   private _header: any;
   private _bodyBytes: Uint8Array;
   private _body: any;
-  //    private _signature: Uint8Array;
-
-  private _jwsVerifier: any; // jsrsasign.KJUR.jws.JWS.JWSResult;
-
   /**
    * Returns the deserialized body of the AttestationToken object.
    *
    * @returns The body of the attestation token as an object.
    */
   public getBody(): unknown {
-    return this._jwsVerifier.payloadObj;
+    return this._body ?? null;
   }
 
   /**
@@ -308,14 +297,12 @@ export class AttestationTokenImpl implements AttestationToken {
       const signers = this.getCandidateSigners(possibleSigners);
 
       signers.some((signer) => {
-        const cert = this.certFromSigner(signer);
-        //          const pubKeyObj = cert.getPublicKey();
-
-        const isValid = jsrsasign.KJUR.jws.JWS.verify(this._token, cert);
+        const isValid = verifyAttestationJws(this._token, this.certFromSigner(signer));
 
         if (isValid) {
           foundSigner = signer;
         }
+        return isValid;
       });
 
       if (foundSigner === undefined) {
@@ -582,42 +569,16 @@ export class AttestationTokenImpl implements AttestationToken {
     privateKey?: string;
     certificate?: string;
   }): AttestationToken {
-    const header: {
-      alg: string;
-      [k: string]: any;
-    } = { alg: "none" };
-
     if ((!params.privateKey && params.certificate) || (params.privateKey && !params.certificate)) {
       throw new Error(
         "If privateKey is specified, certificate must also be provided. If certificate is provided, privateKey must also be provided.",
       );
     }
 
-    if (params.privateKey && params.certificate) {
-      verifyAttestationSigningKey(params.privateKey, params.certificate);
-    }
-
-    if (params.privateKey || params.certificate) {
-      const x5c = new jsrsasign.X509();
-      x5c.readCertPEM(params.certificate);
-      const pubKey = x5c.getPublicKey();
-      if (pubKey instanceof jsrsasign.RSAKey) {
-        header.alg = "RS256";
-      } else if (pubKey instanceof jsrsasign.KJUR.crypto.ECDSA) {
-        header.alg = "ES256";
-      } else {
-        throw new Error("Unknown public key type: " + typeof pubKey);
-      }
-      header.x5c = [hexToBase64(x5c.hex)];
-    } else {
-      header.alg = "none";
-    }
-
-    const encodedToken = jsrsasign.KJUR.jws.JWS.sign(
-      header.alg,
-      header,
+    const encodedToken = createAttestationJws(
       params.body ?? "",
       params.privateKey,
+      params.certificate,
     );
     return new AttestationTokenImpl(encodedToken);
   }

--- a/sdk/attestation/attestation/src/node-forge-submodules.d.ts
+++ b/sdk/attestation/attestation/src/node-forge-submodules.d.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+declare module "node-forge/lib/forge.js" {
+  import forge from "node-forge";
+  export default forge;
+}
+
+declare module "node-forge/lib/asn1.js";
+declare module "node-forge/lib/rsa.js";
+declare module "node-forge/lib/sha256.js";

--- a/sdk/attestation/attestation/src/utils/helpers.ts
+++ b/sdk/attestation/attestation/src/utils/helpers.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
-import { base64EncodeByteArray, hexToByteArray } from "./base64.js";
+import { validateAttestationSigningKey } from "./jws.js";
 
 /** Create an AttestationSigningKey from the provided private key and certificate.
  *
@@ -15,31 +12,7 @@ export function verifyAttestationSigningKey(
   privateKey: string,
   certificate: string,
 ): { certificate: string; privateKey: string } {
-  //
-  // Ensure that the key and certificate are associated with each other.
-  //
-  // Sign a buffer with the key, then verify the signature with the
-  // certificate.
-  const x509 = new jsrsasign.X509();
-  x509.readCertPEM(certificate);
-
-  const alg = x509.getSignatureAlgorithmName();
-
-  const signer = new jsrsasign.KJUR.crypto.Signature({ alg: alg });
-
-  // Confirm that the certificate and private key are related to each other.
-  const bufferToSign = "1234";
-
-  signer.init(privateKey);
-  signer.updateString(bufferToSign);
-  const sigVal = signer.sign();
-
-  const verifier = new jsrsasign.KJUR.crypto.Signature({ alg: alg });
-  verifier.init(x509.getPublicKey());
-  verifier.updateString(bufferToSign);
-  if (!verifier.verify(sigVal)) {
-    throw new Error("verifyAttestationSigningKey: Key does not match Certificate.");
-  }
+  validateAttestationSigningKey(privateKey, certificate);
   return { certificate: certificate, privateKey: privateKey };
 }
 
@@ -59,12 +32,4 @@ export function pemFromBase64(base64: string, pemType: PemType): string {
   pem += "-----END " + pemType + "-----\n";
 
   return pem;
-}
-
-/**
- * Converts a hex encoded string to its base64 equivalent.
- * @param value - Hex encoded value
- */
-export function hexToBase64(value: string): string {
-  return base64EncodeByteArray(hexToByteArray(value));
 }

--- a/sdk/attestation/attestation/src/utils/jws.ts
+++ b/sdk/attestation/attestation/src/utils/jws.ts
@@ -1,0 +1,593 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { p256 } from "@noble/curves/nist.js";
+import forge from "node-forge/lib/forge.js";
+import "node-forge/lib/asn1.js";
+import "node-forge/lib/rsa.js";
+import "node-forge/lib/sha256.js";
+import {
+  base64DecodeString,
+  base64EncodeByteArray,
+  base64UrlDecodeString,
+  base64UrlEncodeByteArray,
+  byteArrayToHex,
+} from "./base64.js";
+import { bytesToString, stringToBytes } from "./utf8.js";
+
+// Web Crypto-based JOSE implementations are asynchronous, but this package's stable token APIs
+// are synchronous. Forge 1.4+ provides patched synchronous RSA, while Noble provides audited
+// P-256 primitives. The DER reader below is intentionally limited to locating PKCS#8 and X.509
+// public-key material; it does not attempt to implement general certificate validation.
+
+const rsaEncryptionOid = "2a864886f70d010101";
+const ecPublicKeyOid = "2a8648ce3d0201";
+const p256Oid = "2a8648ce3d030107";
+
+type KeyType = "RSA" | "EC";
+
+interface DerElement {
+  tag: number;
+  contentStart: number;
+  end: number;
+}
+
+interface RsaCertificateInfo {
+  base64: string;
+  keyType: "RSA";
+  publicKey: forge.pki.rsa.PublicKey;
+}
+
+interface EcCertificateInfo {
+  base64: string;
+  keyType: "EC";
+  publicKey: Uint8Array;
+}
+
+type CertificateInfo = EcCertificateInfo | RsaCertificateInfo;
+
+interface EcPrivateKeyInfo {
+  keyType: "EC";
+  privateKey: Uint8Array;
+}
+
+interface RsaPrivateKeyInfo {
+  keyType: "RSA";
+  privateKey: forge.pki.rsa.PrivateKey;
+}
+
+type PrivateKeyInfo = EcPrivateKeyInfo | RsaPrivateKeyInfo;
+
+function readDerElement(data: Uint8Array, offset: number, containerEnd = data.length): DerElement {
+  if (offset < 0 || offset + 2 > containerEnd) {
+    throw new Error("Invalid DER: truncated element.");
+  }
+
+  const tag = data[offset];
+  let contentStart = offset + 2;
+  let length = data[offset + 1];
+
+  if ((length & 0x80) !== 0) {
+    const lengthBytes = length & 0x7f;
+    if (lengthBytes === 0 || lengthBytes > 4 || contentStart + lengthBytes > containerEnd) {
+      throw new Error("Invalid DER: malformed length.");
+    }
+    if (data[contentStart] === 0) {
+      throw new Error("Invalid DER: non-canonical length.");
+    }
+
+    length = 0;
+    for (let i = 0; i < lengthBytes; i++) {
+      length = length * 256 + data[contentStart + i];
+    }
+    if (length < 0x80) {
+      throw new Error("Invalid DER: non-canonical length.");
+    }
+    contentStart += lengthBytes;
+  }
+
+  const end = contentStart + length;
+  if (end > containerEnd) {
+    throw new Error("Invalid DER: element exceeds its container.");
+  }
+  return { tag, contentStart, end };
+}
+
+function readDerChildren(data: Uint8Array, element: DerElement): DerElement[] {
+  const children: DerElement[] = [];
+  let offset = element.contentStart;
+  while (offset < element.end) {
+    const child = readDerElement(data, offset, element.end);
+    children.push(child);
+    offset = child.end;
+  }
+  if (offset !== element.end) {
+    throw new Error("Invalid DER: child elements do not fill their container.");
+  }
+  return children;
+}
+
+function requireTag(element: DerElement | undefined, tag: number, description: string): DerElement {
+  if (!element || element.tag !== tag) {
+    throw new Error(`Invalid DER: expected ${description}.`);
+  }
+  return element;
+}
+
+function readOid(data: Uint8Array, element: DerElement | undefined): string {
+  const oid = requireTag(element, 0x06, "object identifier");
+  if (oid.contentStart === oid.end) {
+    throw new Error("Invalid DER: empty object identifier.");
+  }
+  return byteArrayToHex(data.subarray(oid.contentStart, oid.end));
+}
+
+function requireChildren(
+  data: Uint8Array,
+  element: DerElement,
+  count: number,
+  description: string,
+): DerElement[] {
+  const children = readDerChildren(data, element);
+  if (children.length !== count) {
+    throw new Error(`Invalid DER: malformed ${description}.`);
+  }
+  return children;
+}
+
+function requireNull(element: DerElement | undefined, description: string): void {
+  const nullElement = requireTag(element, 0x05, description);
+  if (nullElement.contentStart !== nullElement.end) {
+    throw new Error(`Invalid DER: malformed ${description}.`);
+  }
+}
+
+function validateInteger(
+  data: Uint8Array,
+  element: DerElement | undefined,
+  description: string,
+  allowZero: boolean,
+): DerElement {
+  const integer = requireTag(element, 0x02, description);
+  if (integer.contentStart === integer.end || (data[integer.contentStart] & 0x80) !== 0) {
+    throw new Error(`Invalid DER: malformed ${description}.`);
+  }
+  if (
+    integer.end - integer.contentStart > 1 &&
+    data[integer.contentStart] === 0 &&
+    (data[integer.contentStart + 1] & 0x80) === 0
+  ) {
+    throw new Error(`Invalid DER: non-canonical ${description}.`);
+  }
+  if (!allowZero && data.subarray(integer.contentStart, integer.end).every((byte) => byte === 0)) {
+    throw new Error(`Invalid DER: malformed ${description}.`);
+  }
+  return integer;
+}
+
+function requireIntegerValue(
+  data: Uint8Array,
+  element: DerElement | undefined,
+  expectedValue: number,
+  description: string,
+): void {
+  const integer = validateInteger(data, element, description, true);
+  let value = 0;
+  for (let offset = integer.contentStart; offset < integer.end; offset++) {
+    value = value * 256 + data[offset];
+  }
+  if (!Number.isSafeInteger(value) || value !== expectedValue) {
+    throw new Error(`Invalid DER: unsupported ${description}.`);
+  }
+}
+
+function parsePem(
+  value: string,
+  type: "CERTIFICATE" | "PRIVATE KEY",
+): {
+  base64: string;
+  der: Uint8Array;
+} {
+  const expression = new RegExp(
+    `^-----BEGIN ${type}-----\\s+([A-Za-z0-9+/=\\r\\n]+?)\\s+-----END ${type}-----$`,
+  );
+  const match = expression.exec(value.trim());
+  if (!match) {
+    throw new Error(`Invalid PEM encoded ${type.toLowerCase()}.`);
+  }
+
+  const base64 = match[1].replace(/\s/g, "");
+  const der = base64DecodeString(base64);
+  if (der.length === 0 || base64EncodeByteArray(der) !== base64) {
+    throw new Error(`Invalid PEM encoded ${type.toLowerCase()}.`);
+  }
+
+  const root = requireTag(readDerElement(der, 0), 0x30, "sequence");
+  if (root.end !== der.length) {
+    throw new Error("Invalid DER: trailing data.");
+  }
+  return { base64, der };
+}
+
+function getCertificateInfo(certificate: string): CertificateInfo {
+  const { base64, der } = parsePem(certificate, "CERTIFICATE");
+  const root = readDerElement(der, 0);
+  const certificateChildren = readDerChildren(der, root);
+  if (certificateChildren.length !== 3) {
+    throw new Error("Invalid DER: malformed certificate sequence.");
+  }
+  requireTag(certificateChildren[1], 0x30, "certificate signature algorithm");
+  const certificateSignature = requireTag(
+    certificateChildren[2],
+    0x03,
+    "certificate signature bit string",
+  );
+  if (
+    certificateSignature.contentStart === certificateSignature.end ||
+    der[certificateSignature.contentStart] !== 0
+  ) {
+    throw new Error("Invalid DER: malformed certificate signature bit string.");
+  }
+
+  const tbsCertificate = requireTag(certificateChildren[0], 0x30, "TBSCertificate sequence");
+  const tbsChildren = readDerChildren(der, tbsCertificate);
+  const versionOffset = tbsChildren[0]?.tag === 0xa0 ? 1 : 0;
+  if (versionOffset === 1) {
+    const version = requireChildren(der, tbsChildren[0], 1, "certificate version");
+    const versionInteger = validateInteger(der, version[0], "certificate version", true);
+    if (
+      versionInteger.end - versionInteger.contentStart !== 1 ||
+      der[versionInteger.contentStart] > 2
+    ) {
+      throw new Error("Invalid DER: unsupported certificate version.");
+    }
+  }
+  validateInteger(der, tbsChildren[versionOffset], "certificate serial number", false);
+  requireTag(tbsChildren[versionOffset + 1], 0x30, "certificate signature algorithm");
+  requireTag(tbsChildren[versionOffset + 2], 0x30, "certificate issuer");
+  requireTag(tbsChildren[versionOffset + 3], 0x30, "certificate validity");
+  requireTag(tbsChildren[versionOffset + 4], 0x30, "certificate subject");
+  const subjectPublicKeyInfo = requireTag(
+    tbsChildren[versionOffset + 5],
+    0x30,
+    "subjectPublicKeyInfo sequence",
+  );
+  const subjectPublicKeyInfoChildren = requireChildren(
+    der,
+    subjectPublicKeyInfo,
+    2,
+    "subjectPublicKeyInfo sequence",
+  );
+  const algorithm = requireTag(
+    subjectPublicKeyInfoChildren[0],
+    0x30,
+    "public key algorithm sequence",
+  );
+  const algorithmChildren = requireChildren(der, algorithm, 2, "public key algorithm");
+  const algorithmOid = readOid(der, algorithmChildren[0]);
+  const subjectPublicKey = requireTag(
+    subjectPublicKeyInfoChildren[1],
+    0x03,
+    "public key bit string",
+  );
+
+  if (
+    subjectPublicKey.contentStart === subjectPublicKey.end ||
+    der[subjectPublicKey.contentStart] !== 0
+  ) {
+    throw new Error("Invalid DER: public key bit string has unused bits.");
+  }
+
+  if (algorithmOid === rsaEncryptionOid) {
+    requireNull(algorithmChildren[1], "RSA algorithm parameters");
+    const publicKeyDer = der.slice(subjectPublicKey.contentStart + 1, subjectPublicKey.end);
+    const publicKeyRoot = requireTag(
+      readDerElement(publicKeyDer, 0),
+      0x30,
+      "RSA public key sequence",
+    );
+    if (publicKeyRoot.end !== publicKeyDer.length) {
+      throw new Error("Invalid DER: trailing RSA public key data.");
+    }
+    const publicKeyChildren = requireChildren(
+      publicKeyDer,
+      publicKeyRoot,
+      2,
+      "RSA public key sequence",
+    );
+    validateInteger(publicKeyDer, publicKeyChildren[0], "RSA modulus", false);
+    validateInteger(publicKeyDer, publicKeyChildren[1], "RSA public exponent", false);
+    const publicKey = forge.pki.publicKeyFromAsn1(
+      forge.asn1.fromDer(bytesToBinaryString(publicKeyDer), true),
+    );
+    return { base64, keyType: "RSA", publicKey };
+  }
+  if (algorithmOid !== ecPublicKeyOid || readOid(der, algorithmChildren[1]) !== p256Oid) {
+    throw new Error("Unsupported certificate public key algorithm.");
+  }
+
+  const publicKey = der.slice(subjectPublicKey.contentStart + 1, subjectPublicKey.end);
+  if (publicKey.length !== 65 || publicKey[0] !== 0x04 || !p256.utils.isValidPublicKey(publicKey)) {
+    throw new Error("Invalid P-256 certificate public key.");
+  }
+  return { base64, keyType: "EC", publicKey };
+}
+
+function getPrivateKeyInfo(privateKey: string): PrivateKeyInfo {
+  const { der } = parsePem(privateKey, "PRIVATE KEY");
+  const root = readDerElement(der, 0);
+  const privateKeyInfoChildren = readDerChildren(der, root);
+  if (privateKeyInfoChildren.length < 3 || privateKeyInfoChildren.length > 4) {
+    throw new Error("Invalid DER: malformed PKCS#8 private key.");
+  }
+  requireIntegerValue(der, privateKeyInfoChildren[0], 0, "PKCS#8 version");
+  if (privateKeyInfoChildren[3]) {
+    requireTag(privateKeyInfoChildren[3], 0xa0, "PKCS#8 attributes");
+    readDerChildren(der, privateKeyInfoChildren[3]);
+  }
+  const algorithm = requireTag(privateKeyInfoChildren[1], 0x30, "private key algorithm sequence");
+  const algorithmChildren = requireChildren(der, algorithm, 2, "private key algorithm");
+  const algorithmOid = readOid(der, algorithmChildren[0]);
+  const privateKeyOctets = requireTag(privateKeyInfoChildren[2], 0x04, "private key octet string");
+
+  if (algorithmOid === rsaEncryptionOid) {
+    requireNull(algorithmChildren[1], "RSA algorithm parameters");
+    const rsaPrivateKeyDer = der.slice(privateKeyOctets.contentStart, privateKeyOctets.end);
+    const rsaPrivateKeyRoot = requireTag(
+      readDerElement(rsaPrivateKeyDer, 0),
+      0x30,
+      "RSA private key sequence",
+    );
+    if (rsaPrivateKeyRoot.end !== rsaPrivateKeyDer.length) {
+      throw new Error("Invalid DER: trailing RSA private key data.");
+    }
+    const rsaPrivateKeyChildren = requireChildren(
+      rsaPrivateKeyDer,
+      rsaPrivateKeyRoot,
+      9,
+      "RSA private key sequence",
+    );
+    requireIntegerValue(rsaPrivateKeyDer, rsaPrivateKeyChildren[0], 0, "RSA private key version");
+    for (const [index, description] of [
+      [1, "RSA modulus"],
+      [2, "RSA public exponent"],
+      [3, "RSA private exponent"],
+      [4, "RSA prime 1"],
+      [5, "RSA prime 2"],
+      [6, "RSA exponent 1"],
+      [7, "RSA exponent 2"],
+      [8, "RSA coefficient"],
+    ] as const) {
+      validateInteger(rsaPrivateKeyDer, rsaPrivateKeyChildren[index], description, false);
+    }
+    return {
+      keyType: "RSA",
+      privateKey: forge.pki.privateKeyFromAsn1(
+        forge.asn1.fromDer(bytesToBinaryString(rsaPrivateKeyDer), true),
+      ),
+    };
+  }
+  if (algorithmOid !== ecPublicKeyOid || readOid(der, algorithmChildren[1]) !== p256Oid) {
+    throw new Error("Unsupported private key algorithm.");
+  }
+
+  const ecPrivateKey = requireTag(
+    readDerElement(der, privateKeyOctets.contentStart, privateKeyOctets.end),
+    0x30,
+    "EC private key sequence",
+  );
+  if (ecPrivateKey.end !== privateKeyOctets.end) {
+    throw new Error("Invalid DER: trailing EC private key data.");
+  }
+  const ecPrivateKeyChildren = readDerChildren(der, ecPrivateKey);
+  if (ecPrivateKeyChildren.length < 2 || ecPrivateKeyChildren.length > 4) {
+    throw new Error("Invalid DER: malformed EC private key.");
+  }
+  requireIntegerValue(der, ecPrivateKeyChildren[0], 1, "EC private key version");
+  const privateKeyValue = requireTag(ecPrivateKeyChildren[1], 0x04, "EC private key value");
+  const privateKeyBytes = der.slice(privateKeyValue.contentStart, privateKeyValue.end);
+  if (privateKeyBytes.length !== 32 || !p256.utils.isValidSecretKey(privateKeyBytes)) {
+    throw new Error("Invalid P-256 private key.");
+  }
+
+  let optionalFieldIndex = 2;
+  if (ecPrivateKeyChildren[optionalFieldIndex]?.tag === 0xa0) {
+    const parameters = requireChildren(
+      der,
+      ecPrivateKeyChildren[optionalFieldIndex],
+      1,
+      "EC parameters",
+    );
+    if (readOid(der, parameters[0]) !== p256Oid) {
+      throw new Error("Unsupported EC private key parameters.");
+    }
+    optionalFieldIndex++;
+  }
+  if (ecPrivateKeyChildren[optionalFieldIndex]?.tag === 0xa1) {
+    const publicKeyElements = requireChildren(
+      der,
+      ecPrivateKeyChildren[optionalFieldIndex],
+      1,
+      "EC public key",
+    );
+    const publicKey = requireTag(publicKeyElements[0], 0x03, "EC public key bit string");
+    if (publicKey.contentStart === publicKey.end || der[publicKey.contentStart] !== 0) {
+      throw new Error("Invalid DER: EC public key bit string has unused bits.");
+    }
+    const encodedPublicKey = der.slice(publicKey.contentStart + 1, publicKey.end);
+    const derivedPublicKey = p256.getPublicKey(privateKeyBytes, false);
+    if (
+      encodedPublicKey.length !== derivedPublicKey.length ||
+      !encodedPublicKey.every((byte, index) => byte === derivedPublicKey[index])
+    ) {
+      throw new Error("Invalid DER: EC private key public key does not match.");
+    }
+    optionalFieldIndex++;
+  }
+  if (optionalFieldIndex !== ecPrivateKeyChildren.length) {
+    throw new Error("Invalid DER: malformed EC private key fields.");
+  }
+  return { keyType: "EC", privateKey: privateKeyBytes };
+}
+
+function bytesToBinaryString(value: Uint8Array): string {
+  let result = "";
+  for (const byte of value) {
+    result += String.fromCharCode(byte);
+  }
+  return result;
+}
+
+function binaryStringToBytes(value: string): Uint8Array {
+  return Uint8Array.from(value, (character) => character.charCodeAt(0));
+}
+
+function assertMatchingKey(privateKeyInfo: PrivateKeyInfo, certificateInfo: CertificateInfo): void {
+  if (privateKeyInfo.keyType !== certificateInfo.keyType) {
+    throw new Error("verifyAttestationSigningKey: Key does not match Certificate.");
+  }
+
+  let matches: boolean;
+  if (privateKeyInfo.keyType === "RSA" && certificateInfo.keyType === "RSA") {
+    matches =
+      privateKeyInfo.privateKey.n.compareTo(certificateInfo.publicKey.n) === 0 &&
+      privateKeyInfo.privateKey.e.compareTo(certificateInfo.publicKey.e) === 0;
+  } else if (privateKeyInfo.keyType === "EC" && certificateInfo.keyType === "EC") {
+    const derivedPublicKey = p256.getPublicKey(privateKeyInfo.privateKey, false);
+    matches =
+      derivedPublicKey.length === certificateInfo.publicKey.length &&
+      derivedPublicKey.every((byte, index) => byte === certificateInfo.publicKey[index]);
+  } else {
+    matches = false;
+  }
+
+  if (!matches) {
+    throw new Error("verifyAttestationSigningKey: Key does not match Certificate.");
+  }
+}
+
+function getSigningMaterial(
+  privateKey: string,
+  certificate: string,
+): { certificateInfo: CertificateInfo; privateKeyInfo: PrivateKeyInfo } {
+  const certificateInfo = getCertificateInfo(certificate);
+  const privateKeyInfo = getPrivateKeyInfo(privateKey);
+  assertMatchingKey(privateKeyInfo, certificateInfo);
+  return { certificateInfo, privateKeyInfo };
+}
+
+function sign(
+  algorithm: KeyType,
+  signingInput: Uint8Array,
+  privateKey: PrivateKeyInfo,
+): Uint8Array {
+  if (algorithm === "RSA" && privateKey.keyType === "RSA") {
+    const digest = forge.md.sha256.create();
+    digest.update(bytesToBinaryString(signingInput), "raw");
+    return binaryStringToBytes(privateKey.privateKey.sign(digest));
+  }
+  if (algorithm === "EC" && privateKey.keyType === "EC") {
+    return p256.sign(signingInput, privateKey.privateKey, {
+      format: "compact",
+      lowS: true,
+    });
+  }
+  throw new Error("Private key algorithm does not match signing algorithm.");
+}
+
+function verifyRsa(
+  signingInput: Uint8Array,
+  signature: Uint8Array,
+  publicKey: forge.pki.rsa.PublicKey,
+): boolean {
+  const expectedSignatureLength = Math.ceil(publicKey.n.bitLength() / 8);
+  if (signature.length !== expectedSignatureLength) {
+    return false;
+  }
+
+  const digest = forge.md.sha256.create();
+  digest.update(bytesToBinaryString(signingInput), "raw");
+  return publicKey.verify(digest.digest().getBytes(), bytesToBinaryString(signature));
+}
+
+export function createAttestationJws(
+  body: string,
+  privateKey?: string,
+  certificate?: string,
+): string {
+  const payload = base64UrlEncodeByteArray(stringToBytes(body));
+  if (!privateKey && !certificate) {
+    const protectedHeader = base64UrlEncodeByteArray(
+      stringToBytes(JSON.stringify({ alg: "none" })),
+    );
+    return `${protectedHeader}.${payload}.`;
+  }
+  if (!privateKey || !certificate) {
+    throw new Error(
+      "If privateKey is specified, certificate must also be provided. If certificate is provided, privateKey must also be provided.",
+    );
+  }
+
+  const { certificateInfo, privateKeyInfo } = getSigningMaterial(privateKey, certificate);
+  const alg = certificateInfo.keyType === "RSA" ? "RS256" : "ES256";
+  const protectedHeader = base64UrlEncodeByteArray(
+    stringToBytes(JSON.stringify({ alg, x5c: [certificateInfo.base64] })),
+  );
+  const signingInput = stringToBytes(`${protectedHeader}.${payload}`);
+  const signature = sign(certificateInfo.keyType, signingInput, privateKeyInfo);
+  return `${protectedHeader}.${payload}.${base64UrlEncodeByteArray(signature)}`;
+}
+
+export function verifyAttestationJws(token: string, certificate: string): boolean {
+  try {
+    const pieces = token.split(".");
+    if (pieces.length !== 3 || pieces[2].length === 0) {
+      return false;
+    }
+
+    const headerBytes = base64UrlDecodeString(pieces[0]);
+    if (base64UrlEncodeByteArray(headerBytes) !== pieces[0]) {
+      return false;
+    }
+    const payloadBytes = base64UrlDecodeString(pieces[1]);
+    if (base64UrlEncodeByteArray(payloadBytes) !== pieces[1]) {
+      return false;
+    }
+    const header = JSON.parse(bytesToString(headerBytes)) as { alg?: unknown };
+    const certificateInfo = getCertificateInfo(certificate);
+    const signingInput = stringToBytes(`${pieces[0]}.${pieces[1]}`);
+    const signature = base64UrlDecodeString(pieces[2]);
+    if (base64UrlEncodeByteArray(signature) !== pieces[2]) {
+      return false;
+    }
+
+    if (header.alg === "RS256" && certificateInfo.keyType === "RSA") {
+      return verifyRsa(signingInput, signature, certificateInfo.publicKey);
+    }
+    if (header.alg === "ES256" && certificateInfo.keyType === "EC") {
+      return (
+        signature.length === 64 &&
+        p256.verify(signature, signingInput, certificateInfo.publicKey, {
+          format: "compact",
+          lowS: false,
+        })
+      );
+    }
+    return false;
+  } catch {
+    // Malformed tokens, certificates, and signatures are all invalid verification inputs.
+    return false;
+  }
+}
+
+export function validateAttestationSigningKey(privateKey: string, certificate: string): void {
+  getSigningMaterial(privateKey, certificate);
+}
+
+export function certificateToBase64(certificate: string): string {
+  return getCertificateInfo(certificate).base64;
+}
+
+export function keyTypeFromCertificate(certificate: string): KeyType {
+  return getCertificateInfo(certificate).keyType;
+}

--- a/sdk/attestation/attestation/test/browser/tokenCrypto.browser.spec.ts
+++ b/sdk/attestation/attestation/test/browser/tokenCrypto.browser.spec.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AttestationTokenImpl } from "../../src/models/attestationToken.js";
+import { createECDSKey, createRSAKey, createX509Certificate } from "../utils/cryptoUtils.js";
+import { assert, describe, it } from "vitest";
+
+describe("Attestation token cryptography in browser", () => {
+  for (const [algorithm, createKey] of [
+    ["RS256", createRSAKey],
+    ["ES256", createECDSKey],
+  ] as const) {
+    it(`creates and validates ${algorithm} tokens`, () => {
+      const [privateKey, publicKey] = createKey();
+      const certificate = createX509Certificate(privateKey, publicKey, "certificate");
+      const token = AttestationTokenImpl.create({
+        body: JSON.stringify({ runtime: "browser" }),
+        privateKey,
+        certificate,
+      });
+
+      assert.equal(token.algorithm, algorithm);
+      assert.deepEqual(token.getTokenProblems([{ certificates: [certificate] }]), []);
+    });
+  }
+});

--- a/sdk/attestation/attestation/test/node/tokenInterop.spec.ts
+++ b/sdk/attestation/attestation/test/node/tokenInterop.spec.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { sign as nodeSign, verify as nodeVerify } from "node:crypto";
+import { base64UrlDecodeString, base64UrlEncodeByteArray } from "../../src/utils/base64.js";
+import { stringToBytes } from "../../src/utils/utf8.js";
+import { AttestationTokenImpl } from "../../src/models/attestationToken.js";
+import {
+  certificateToBase64,
+  createECDSKey,
+  createRSAKey,
+  createX509Certificate,
+} from "../utils/cryptoUtils.js";
+import { assert, describe, it } from "vitest";
+
+type SupportedAlgorithm = "RS256" | "ES256";
+
+function createNodeSignedToken(
+  body: string,
+  privateKey: string,
+  certificate: string,
+  algorithm: SupportedAlgorithm,
+): string {
+  const header = base64UrlEncodeByteArray(
+    stringToBytes(JSON.stringify({ alg: algorithm, x5c: [certificateToBase64(certificate)] })),
+  );
+  const payload = base64UrlEncodeByteArray(stringToBytes(body));
+  const signingInput = stringToBytes(`${header}.${payload}`);
+  const signature =
+    algorithm === "RS256"
+      ? nodeSign("sha256", signingInput, privateKey)
+      : nodeSign("sha256", signingInput, {
+          key: privateKey,
+          dsaEncoding: "ieee-p1363",
+        });
+  return `${header}.${payload}.${base64UrlEncodeByteArray(signature)}`;
+}
+
+function verifyTokenWithNode(
+  token: string,
+  certificate: string,
+  algorithm: SupportedAlgorithm,
+): boolean {
+  const [header, payload, encodedSignature] = token.split(".");
+  const signingInput = stringToBytes(`${header}.${payload}`);
+  const signature = base64UrlDecodeString(encodedSignature);
+  return algorithm === "RS256"
+    ? nodeVerify("sha256", signingInput, certificate, signature)
+    : nodeVerify(
+        "sha256",
+        signingInput,
+        { key: certificate, dsaEncoding: "ieee-p1363" },
+        signature,
+      );
+}
+
+describe("Attestation token Node interoperability", () => {
+  for (const [algorithm, createKey] of [
+    ["RS256", createRSAKey],
+    ["ES256", createECDSKey],
+  ] as const) {
+    it(`produces ${algorithm} tokens accepted by Node crypto`, () => {
+      const [privateKey, publicKey] = createKey();
+      const certificate = createX509Certificate(privateKey, publicKey, "certificate");
+      const token = AttestationTokenImpl.create({
+        body: JSON.stringify({ source: "attestation" }),
+        privateKey,
+        certificate,
+      });
+
+      assert.isTrue(verifyTokenWithNode(token.serialize(), certificate, algorithm));
+    });
+
+    it(`accepts ${algorithm} tokens produced by Node crypto`, () => {
+      const [privateKey, publicKey] = createKey();
+      const certificate = createX509Certificate(privateKey, publicKey, "certificate");
+      const token = new AttestationTokenImpl(
+        createNodeSignedToken(
+          JSON.stringify({ source: "node" }),
+          privateKey,
+          certificate,
+          algorithm,
+        ),
+      );
+
+      assert.deepEqual(token.getTokenProblems([{ certificates: [certificate] }]), []);
+    });
+  }
+});

--- a/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
@@ -1,29 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../src/jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
-import { Recorder } from "@azure-tools/test-recorder";
+import { base64UrlEncodeByteArray } from "../../src/utils/base64.js";
 import { bytesToString, stringToBytes } from "../../src/utils/utf8.js";
-import { createECDSKey, createRSAKey, createX509Certificate } from "../utils/cryptoUtils.js";
+import {
+  certificateToBase64,
+  createECDSKey,
+  createRSAKey,
+  createX509Certificate,
+} from "../utils/cryptoUtils.js";
 import { verifyAttestationSigningKey } from "../../src/utils/helpers.js";
 import { AttestationTokenImpl } from "../../src/models/attestationToken.js";
-import { recorderOptions } from "../utils/recordedClient.js";
-import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, assert, expect } from "vitest";
 
 describe("AttestationTokenTests", () => {
-  let recorder: Recorder;
-
-  beforeEach(async (ctx) => {
-    recorder = new Recorder(ctx);
-    await recorder.start(recorderOptions);
-  });
-
-  afterEach(async () => {
-    await recorder.stop();
-  });
-
   it("#testUtf8ConversionFunctions", async () => {
     const buffer = stringToBytes("ABCDEF");
     assert.equal(buffer[0], 65);
@@ -62,12 +52,41 @@ describe("AttestationTokenTests", () => {
     const [privKey, pubKey] = createECDSKey();
     const cert = createX509Certificate(privKey, pubKey, "testCert");
 
-    const [key2] = createECDSKey();
+    const [key2] = createECDSKey(1);
 
     assert.isTrue(privKey.length !== 0);
     assert.isTrue(cert.length !== 0);
 
     assert.throws(() => verifyAttestationSigningKey(key2, cert));
+  });
+
+  it("#createRsaSigningKeyWrongKey", async () => {
+    const [privateKey, publicKey] = createRSAKey();
+    const certificate = createX509Certificate(privateKey, publicKey, "testCert");
+    const [mismatchedKey] = createRSAKey(1);
+
+    expect(() => verifyAttestationSigningKey(mismatchedKey, certificate)).toThrow(
+      "Key does not match Certificate",
+    );
+  });
+
+  it("#rejectMalformedSigningMaterial", async () => {
+    const [privateKey, publicKey] = createRSAKey();
+    const certificate = createX509Certificate(privateKey, publicKey, "testCert");
+
+    expect(() => verifyAttestationSigningKey("not a key", certificate)).toThrow(
+      "Invalid PEM encoded private key",
+    );
+    expect(() => verifyAttestationSigningKey(privateKey, "not a certificate")).toThrow(
+      "Invalid PEM encoded certificate",
+    );
+
+    const truncatedCertificate = `-----BEGIN CERTIFICATE-----
+${certificateToBase64(certificate).slice(0, -4)}
+-----END CERTIFICATE-----`;
+    expect(() => verifyAttestationSigningKey(privateKey, truncatedCertificate)).toThrow(
+      "Invalid DER",
+    );
   });
 
   /**
@@ -109,13 +128,7 @@ describe("AttestationTokenTests", () => {
     if (token.certificateChain) {
       const pemCert: string = token.certificateChain.certificates[0];
 
-      const expectedCert = new jsrsasign.X509();
-      expectedCert.readCertPEM(cert);
-
-      const actualCert = new jsrsasign.X509();
-      actualCert.readCertPEM(pemCert);
-
-      assert.equal(expectedCert.hex, actualCert.hex);
+      assert.equal(certificateToBase64(cert), certificateToBase64(pemCert));
     }
 
     // The token of course should validate.
@@ -159,6 +172,38 @@ describe("AttestationTokenTests", () => {
     expect(token.notBefore?.getTime()).to.equal(currentDate.getTime());
     expect(token.expiresOn?.getTime()).to.equal(currentDate.getTime() + 30 * 1000);
     expect(token.issuer).to.equal("this is an issuer");
+  });
+
+  it("#createEcSecuredAttestationToken", async () => {
+    const [privateKey, publicKey] = createECDSKey();
+    const certificate = createX509Certificate(privateKey, publicKey, "certificate");
+    const token = AttestationTokenImpl.create({
+      body: JSON.stringify({ foo: "bar" }),
+      privateKey,
+      certificate,
+    });
+
+    assert.equal(token.algorithm, "ES256");
+    assert.equal(token.certificateChain?.certificates.length, 1);
+    assert.deepEqual(token.getTokenProblems([{ certificates: [certificate] }]), []);
+  });
+
+  it("#rejectTamperedRsaAndEcTokens", async () => {
+    for (const createKey of [createRSAKey, createECDSKey]) {
+      const [privateKey, publicKey] = createKey();
+      const certificate = createX509Certificate(privateKey, publicKey, "certificate");
+      const token = AttestationTokenImpl.create({
+        body: JSON.stringify({ foo: "bar" }),
+        privateKey,
+        certificate,
+      });
+      const pieces = token.serialize().split(".");
+      pieces[1] = base64UrlEncodeByteArray(stringToBytes(JSON.stringify({ foo: "tampered" })));
+      const tamperedToken = new AttestationTokenImpl(pieces.join("."));
+      assert.deepEqual(tamperedToken.getTokenProblems([{ certificates: [certificate] }]), [
+        "Attestation Token is not properly signed.",
+      ]);
+    }
   });
 
   it("#verifyAttestationTokenCallback", async () => {

--- a/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../src/jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
 import { Recorder, isLiveMode } from "@azure-tools/test-recorder";
 import type { EndpointType } from "../utils/recordedClient.js";
 import {
@@ -13,7 +10,12 @@ import {
 } from "../utils/recordedClient.js";
 import type { AttestationType } from "../../src/index.js";
 import { KnownAttestationType, createAttestationPolicyToken } from "../../src/index.js";
-import { createRSAKey, createX509Certificate, generateSha256Hash } from "../utils/cryptoUtils.js";
+import {
+  certificateToBase64,
+  createRSAKey,
+  createX509Certificate,
+  generateSha256Hash,
+} from "../utils/cryptoUtils.js";
 import { KnownPolicyModification } from "../../src/generated/index.js";
 import { verifyAttestationSigningKey } from "../../src/utils/helpers.js";
 import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";
@@ -52,7 +54,7 @@ describe("PolicyGetSetTests ", () => {
     const minimalPolicy = "version=1.0; authorizationrules{=> permit();}; issuancerules{};";
 
     const [rsaKey, rsapubKey] = createRSAKey();
-    const [rsaKey2] = createRSAKey();
+    const [rsaKey2] = createRSAKey(1);
     const rsaCertificate = createX509Certificate(rsaKey, rsapubKey, "CertificateName");
 
     await expect(
@@ -77,7 +79,7 @@ describe("PolicyGetSetTests ", () => {
         privateKey: "BogusKey",
         certificate: rsaCertificate,
       }),
-    ).rejects.toThrow("not supported argument");
+    ).rejects.toThrow("Invalid PEM encoded private key");
 
     await adminClient.setPolicy(KnownAttestationType.SgxEnclave, minimalPolicy);
 
@@ -88,7 +90,7 @@ describe("PolicyGetSetTests ", () => {
     const adminClient = createRecordedAdminClient(recorder, "AAD");
 
     const [rsaKey, rsapubKey] = createRSAKey();
-    const [rsaKey2] = createRSAKey();
+    const [rsaKey2] = createRSAKey(1);
     const rsaCertificate = createX509Certificate(rsaKey, rsapubKey, "CertificateName");
 
     await expect(
@@ -104,7 +106,7 @@ describe("PolicyGetSetTests ", () => {
         privateKey: "BogusKey",
         certificate: rsaCertificate,
       }),
-    ).rejects.toThrow("not supported argument");
+    ).rejects.toThrow("Invalid PEM encoded private key");
 
     await expect(
       adminClient.resetPolicy(KnownAttestationType.SgxEnclave, {
@@ -194,14 +196,11 @@ describe("PolicyGetSetTests ", () => {
       assert.isNotNull(policyResult.body.policySigner);
 
       if (policyResult.body.policySigner) {
-        const expectedCert = new jsrsasign.X509();
-        expectedCert.readCertPEM(signer.certificate);
-
-        const actualCert = new jsrsasign.X509();
-        actualCert.readCertPEM(policyResult.body.policySigner.certificates[0]);
-
         // The signer in the response should match the signer we set in the request.
-        assert.equal(expectedCert.hex, actualCert.hex);
+        assert.equal(
+          certificateToBase64(signer.certificate),
+          certificateToBase64(policyResult.body.policySigner.certificates[0]),
+        );
       }
     } else {
       assert.isUndefined(policyResult.body.policySigner);

--- a/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
@@ -7,10 +7,13 @@ import {
   getIsolatedSigningKey,
   recorderOptions,
 } from "../utils/recordedClient.js";
-import { createRSAKey, createX509Certificate, generateSha1Hash } from "../utils/cryptoUtils.js";
+import {
+  certificateToDer,
+  createRSAKey,
+  createX509Certificate,
+  generateSha1Hash,
+} from "../utils/cryptoUtils.js";
 import { KnownCertificateModification } from "../../src/generated/index.js";
-/// <reference path="../jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
 import { byteArrayToHex } from "../../src/utils/base64.js";
 import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";
 
@@ -58,12 +61,12 @@ describe("PolicyManagementTests ", () => {
     const adminClient = createRecordedAdminClient(recorder, "Isolated");
 
     const [rsaKey, rsapubKey] = createRSAKey();
-    const [rsaKey2] = createRSAKey();
+    const [rsaKey2] = createRSAKey(1);
     const rsaCertificate = createX509Certificate(rsaKey, rsapubKey, "CertificateName");
 
     await expect(
       adminClient.addPolicyManagementCertificate(rsaCertificate, "Foo", "Bar"),
-    ).rejects.toThrow("can't find PEM header");
+    ).rejects.toThrow("Invalid PEM encoded certificate");
 
     await expect(
       adminClient.addPolicyManagementCertificate(rsaCertificate, rsaKey2, rsaCertificate),
@@ -74,12 +77,12 @@ describe("PolicyManagementTests ", () => {
     const adminClient = createRecordedAdminClient(recorder, "Isolated");
 
     const [rsaKey, rsapubKey] = createRSAKey();
-    const [rsaKey2] = createRSAKey();
+    const [rsaKey2] = createRSAKey(1);
     const rsaCertificate = createX509Certificate(rsaKey, rsapubKey, "CertificateName");
 
     await expect(
       adminClient.removePolicyManagementCertificate(rsaCertificate, "Foo", "Bar"),
-    ).rejects.toThrow("can't find PEM header");
+    ).rejects.toThrow("Invalid PEM encoded certificate");
 
     await expect(
       adminClient.removePolicyManagementCertificate(rsaCertificate, rsaKey2, rsaCertificate),
@@ -96,11 +99,9 @@ describe("PolicyManagementTests ", () => {
     const [rsaKey, rsaPubKey] = createRSAKey();
     const rsaCertificate = createX509Certificate(rsaKey, rsaPubKey, "CertificateName");
 
-    // Decode the PEM encoded certificate for validation later.
-    const cert = new jsrsasign.X509();
-    cert.readCertPEM(rsaCertificate);
-
-    const expectedThumbprint = byteArrayToHex(generateSha1Hash(cert.hex)).toUpperCase();
+    const expectedThumbprint = byteArrayToHex(
+      generateSha1Hash(certificateToDer(rsaCertificate)),
+    ).toUpperCase();
 
     {
       // Add a new signing certificate.

--- a/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../src/jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
 import { Recorder } from "@azure-tools/test-recorder";
 import {
   createRecordedClient,
@@ -12,6 +9,7 @@ import {
 } from "../utils/recordedClient.js";
 import type { AttestationClient } from "../../src/index.js";
 import { describe, it, assert, beforeEach, afterEach } from "vitest";
+import { certificateToBase64 } from "../utils/cryptoUtils.js";
 
 describe("TokenCertTests", () => {
   let recorder: Recorder;
@@ -49,8 +47,7 @@ describe("TokenCertTests", () => {
       key.certificates.forEach((certBuffer) => {
         assert.isDefined(certBuffer);
 
-        const cert = new jsrsasign.X509();
-        cert.readCertPEM(certBuffer);
+        assert.isNotEmpty(certificateToBase64(certBuffer));
       });
     }
   }

--- a/sdk/attestation/attestation/test/utils/cryptoUtils.ts
+++ b/sdk/attestation/attestation/test/utils/cryptoUtils.ts
@@ -1,98 +1,197 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../src/jsrsasign.d.ts"/>
-import * as jsrsasign from "jsrsasign";
-import { hexToByteArray } from "../../src/utils/base64.js";
+import forge from "node-forge";
+import { base64DecodeString, base64EncodeByteArray } from "../../src/utils/base64.js";
 
-export function createECDSKey(): [string, string] {
-  const keyPair = jsrsasign.KEYUTIL.generateKeypair("EC", "secp256r1");
-  return [
-    jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
-  ];
+// These static credentials are generated solely for local interoperability tests.
+const rsaPrivateKeys = [
+  `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCoYx3YwwAvjFDd
+P1p+c53vJudOD244MDjy+l8La40jQeNJZ/ACmourrljP98DiTd2OTpM5hwnTdwgn
+pdvxMICZ6HJzE15dxBhl8D6lGJg+y1dYmMk35OZ+kcAghjit+6rpV9jkclaVjNIs
+oW+LlqhDSIlDG3X+Mhr8YQdxY2n8uyLoy/sqkGDfLYuDLw20WWBEycOt809ae6/W
+VNjfHBy1ALaLcm2RtPXNmZcqNEWfn+ZmrhU0d+2OusJmL8pPbmPEz+Hx2XT6L2rK
+f3iGAIkRvSNO6VhXge8FOR+fe9zi3/dtxYNNM7Wgd58B6DNRSJwZEtDTvBFsXCIZ
+4vTf26lRAgMBAAECggEAClPgcXJV10S7U7OSWb++ebvci1QM0/1Iq+XtaQhW3OkK
+Tz70yHsZOo2YIMLCwbqJ/oO9GcXZlV7HSTO99Xk+pPnt1ZckNjrsDmoFlJeJZG4R
+MJPX4RHM7YnD03baAHlHYHYQ7WOCIhxjymUZH+IM1kobUZpsQmvJLg4nMEYbOrr3
+w59qoaf/vS5knWoT5zc9bGkcb/2rm3n5ukAFt7NgmzF52+zye0Q9fQSiWiMt5Lb+
+7pc0k+7Dw9VD9R/MMmqjP2eGXUnR1z4b3yW8kIyW7MetoE8ZoEpHbDOkDTAHJQKZ
+8vHodvTk/hAihuRD80TqoBZcnww8KLNrrm5erHZdIQKBgQDiIbwqna3Q77Agbn31
+uBb0niIqky7MZDBp6n+V+sFwhI5RqvqQBZk6u6/Rop1ll1MEc+Bh/qQYj4Mn8hj/
+eZb22J4X11yOUjtRecjn22kj7W56DVuaLh9A3LOSsJtcmXxpPYd7xLSYWdXXbpfp
+sF2GQUNyb1UuCgNsumCGgKOacQKBgQC+oNhZggOKJ/9CpJZzoF0c8TpOaUz3R6KK
+kSsgnxAgJELc98I7TpxjoxVWvfkvMi/CeAf562vjQccZVP8r2eRsY/quiMTOGaUL
+0yoK8zXakWEVxi/BL5bV6sWIjK4cPM+HrGBY7YLza1kmJ7qkP0fETTJfBdyJHiOV
+dm8hfZ2s4QKBgQDDutt6L51BmhXjHIBebYdBGJcOLvN06suVAeqJUNCaqcHeIpZa
+jt4AnnAijhSa2I587ier6pLyx1WI/95vUzk+VGUS0dBFSBwb+8PQHHQ3Ks5TSrid
+DYrzw5STRdZUIm4zUZSxpqOCs0+K9yj6lzN8f4T3yjH6daRdOj1Obo4toQKBgHIB
+ykKF4k4PK7eUrbJLV0TG9IMOsQw22Hwc4/kniEJgzWhP+Ob1Vcy1LT7qcQwL7MpW
+dRa/+I86uLNqxQ1ZzCYTCUq221UTu0S+LqfL2wpz5eda1xanuoMHXMoUsNCMgeV3
+b0vgCHBCZFfQbOxsOCSrspNn8wRCdS+fXElgUhuhAoGAUUUkB9n+ckEUd45bIJ72
+FZblqkONi03i2OJrp9Nm8JfEFbG9Jnxk9td5mae7HAC/9is5f91imarM8eY1YKCk
+JR6ymXbMAuoQqXi/qGugdOzuB+zujjqunAnQFkB51XBd0uoaH5LzHwRVP2nlsHAo
+mqPPcU6ntMSQF5O4sFoOH8g=
+-----END PRIVATE KEY-----`,
+  `-----BEGIN PRIVATE KEY-----
+MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQDRuA34T0aCm5Ak
+b0/4QeKqi3iHMESiTaI9RbVuRrvM6xo86aNwK5ZihSNzaXWWvGWioW9rU/9ducdu
+2rYop6MmTrykqwL6jDrWF/Wa2tG0LyK5UfzgM9dAhR3FTgadd8n/+u+7lfCi9beR
+IFKmWpS6Wv2PIhSsT8W0+ty8p0+sbGd7z9KJs5oJbfconyHWM+XHlT2s11hJ0U8Y
+piFFgLIbJbRKEQjwH4tqmCVG8aeKPO77y7uGR4QyGX7SyWCe96wrVpYG9H4VHIom
+RZD36i3t0O08EG52DBuwwpkaietYufpd1/Ocna5ul8cSOUrDpbLhwYt8l3/cy2Kz
+sNdXidCtAgMBAAECgf8HBFLwsAsXnAQmv2hT+Yuff7EZd0m2lX3BOJBW1hUoX6yS
+uPtr+JMWnIntKEOlZmGyfousz55B52ut3+ofpxJRCats/6XYisp5h/RbCJ79XcmT
+JO8YlNhtdw+SiK39qjlbGXQ7bebl5TaM0Ktbb0KB2C26o1egRXh7TVGg4gnhH5cx
+ISLUBjixjCxoT08g+tWqgoQkbxlkVbJNNWApWAlDsu739kiZmUx/6wHUA1ROr1Lr
+ZPkZIvyDB039m50E3NDnFrA2eVvN+7e5nOWzaPV/jl1Uehu3g9QtcQQbNl7bTJpp
+3CI0z3m5P8Dj0J0LGKKltQTNM3F0xzhxv2sW1EECgYEA6VuvwhtcoDrZxh/y8Guu
+D1UA9D7dKDqo60okrp5V0abbMe2lWioHhbvfFJi8KnkevoFLkOBsrrqT4lXXhVPF
+ka3hZ15OjC3Z5IB3q2dXmfjzyKfGStMgEP2oTL1/KRBEL/fkTjZQxQxnwcGcuqHb
+ijidKBM19+xfVZkw4gHD4OkCgYEA5hEziAJIF+HZgYc27oJ0YQgGzTroC6BIK0Y2
+/4EsY4C9ysA2l8rYQ3W+Us33r63BvOvVadaEn0A/qBNYy9tFdm1YLoNvJcLdf161
+HR3bMySKrBsWFZkonZQlNZo7/g5PhRIH+6Pz5cnapnhOpyApGGqNmKPyvoCvOPOr
+OeZ+dyUCgYEAnuoXWOJ1Q5CQOUIMmPlbgYlrqukchobb/c9yB5A/9RPh9bBWiH5S
+vRnhow8YJPxymV1HbpPGr37TsrCuolcYFksJUvGAICohVmC+HfW0TGCi86R9fvsj
+vS5gbFInxHkVVm1EBpcqjeYSynnlF5ud/BTtwRrEB9/qVEqMZXy6PfECgYASQSsl
+j4jI3FK1xFTHd/JkAI8JmbLvuTgAtwGGJGmxO3XTsIykXqPqNl1zlIQinFbS9qNo
+Um0TdbWXUHGrOyq3ytVEW4lmJaANiyYzuTq7RBr8rOmDrTNbzXVmW2aHMft9Q4D+
+pnOjt/BxZPpYqGSaW1oA0oFgPDWq/yqG3ZMLQQKBgDuATytHlJBaXQVglI5L8Tch
+7OSncjzhud851XxODC4C/gmByR3OyNnrbP+UwFGkYZ70A8q6Y1TG75kBpiNFu78o
+3WdqoptywfLRYpSe4Ok/n+6Fxand6CLl96Ogr/1zKhD2NA5VpyGGajSfhufDk1Di
+HKItemIAGU1kitxl3c18
+-----END PRIVATE KEY-----`,
+] as const;
+
+const rsaPublicKeys = [
+  `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqGMd2MMAL4xQ3T9afnOd
+7ybnTg9uODA48vpfC2uNI0HjSWfwApqLq65Yz/fA4k3djk6TOYcJ03cIJ6Xb8TCA
+mehycxNeXcQYZfA+pRiYPstXWJjJN+TmfpHAIIY4rfuq6VfY5HJWlYzSLKFvi5ao
+Q0iJQxt1/jIa/GEHcWNp/Lsi6Mv7KpBg3y2Lgy8NtFlgRMnDrfNPWnuv1lTY3xwc
+tQC2i3JtkbT1zZmXKjRFn5/mZq4VNHftjrrCZi/KT25jxM/h8dl0+i9qyn94hgCJ
+Eb0jTulYV4HvBTkfn3vc4t/3bcWDTTO1oHefAegzUUicGRLQ07wRbFwiGeL039up
+UQIDAQAB
+-----END PUBLIC KEY-----`,
+  `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0bgN+E9GgpuQJG9P+EHi
+qot4hzBEok2iPUW1bka7zOsaPOmjcCuWYoUjc2l1lrxloqFva1P/XbnHbtq2KKej
+Jk68pKsC+ow61hf1mtrRtC8iuVH84DPXQIUdxU4GnXfJ//rvu5XwovW3kSBSplqU
+ulr9jyIUrE/FtPrcvKdPrGxne8/SibOaCW33KJ8h1jPlx5U9rNdYSdFPGKYhRYCy
+GyW0ShEI8B+LapglRvGnijzu+8u7hkeEMhl+0slgnvesK1aWBvR+FRyKJkWQ9+ot
+7dDtPBBudgwbsMKZGonrWLn6XdfznJ2ubpfHEjlKw6Wy4cGLfJd/3Mtis7DXV4nQ
+rQIDAQAB
+-----END PUBLIC KEY-----`,
+] as const;
+
+const rsaCertificate = `-----BEGIN CERTIFICATE-----
+MIIDMzCCAhugAwIBAgIUK7412OplPIO4LGVL2zgl3oYjzbwwDQYJKoZIhvcNAQEL
+BQAwKTEnMCUGA1UEAwweQXp1cmUgU0RLIEF0dGVzdGF0aW9uIFJTQSBUZXN0MB4X
+DTI2MDgyNzE3MjkzMFoXDTM2MDgyNDE3MjkzMFowKTEnMCUGA1UEAwweQXp1cmUg
+U0RLIEF0dGVzdGF0aW9uIFJTQSBUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAqGMd2MMAL4xQ3T9afnOd7ybnTg9uODA48vpfC2uNI0HjSWfwApqL
+q65Yz/fA4k3djk6TOYcJ03cIJ6Xb8TCAmehycxNeXcQYZfA+pRiYPstXWJjJN+Tm
+fpHAIIY4rfuq6VfY5HJWlYzSLKFvi5aoQ0iJQxt1/jIa/GEHcWNp/Lsi6Mv7KpBg
+3y2Lgy8NtFlgRMnDrfNPWnuv1lTY3xwctQC2i3JtkbT1zZmXKjRFn5/mZq4VNHft
+jrrCZi/KT25jxM/h8dl0+i9qyn94hgCJEb0jTulYV4HvBTkfn3vc4t/3bcWDTTO1
+oHefAegzUUicGRLQ07wRbFwiGeL039upUQIDAQABo1MwUTAdBgNVHQ4EFgQUBEPS
+Do/NcihfvjlmPRqVao4qohwwHwYDVR0jBBgwFoAUBEPSDo/NcihfvjlmPRqVao4q
+ohwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAkM5Tz945F+iP
+7P+k/i7VeMyNjhwlXzuYUs3Jyg93J5Z7NRJUrhKtBzPUW1slL6GILeoYq/cLpmOv
+b6WtnziQaizx0dyKcQkt617Bf+G4B7d0PX2urjqXlw/xnpZzPbUZDdcCJ8amMLMg
+xMm0EAGqQ7O3hM2n+nFEa0UjVNpm2b7Me1g1Imn1wAnnYzLyV1B9J0Ptic9jQt1U
+fNFDJPE0umVzaPy+LgWfNIJr9kbJssMQQc4iNaFe4T2tUiNiNK8NhR3PzfwoAZG4
++frDRIa9JHQWpPira2jF77y6JylvHnP3LEM6/GvKjF25RwCjmo0Y2pwrQsKAObKO
+yXUVMqiFiQ==
+-----END CERTIFICATE-----`;
+
+const ecPrivateKeys = [
+  `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgytJtkmxN32P7kQHv
+BPNbrbdC3Fx5JH0CytI7P1kGKL2hRANCAASBgIsF54HmeHyiMQTkMHv4ynz+Sxmb
+V97pEeVTwgfj8TGutKQzQJgV/Cy6m2s84KlImI/1/RxivYx+/5Zla9aA
+-----END PRIVATE KEY-----`,
+  `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgDFmJe/Ltv0Q8jTsq
+HYqQA/yjICbq40j/HvKVqtc3lTihRANCAAQP7W+ywHXv4vKiDeMAwKzeEpJmN4Bn
+tsEYh7tiQk4v51bX3R1EcacwouMM2iwXiS0kF2BySJ8ySJIpa20/WNXC
+-----END PRIVATE KEY-----`,
+] as const;
+
+const ecPublicKeys = [
+  `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgYCLBeeB5nh8ojEE5DB7+Mp8/ksZ
+m1fe6RHlU8IH4/ExrrSkM0CYFfwsuptrPOCpSJiP9f0cYr2Mfv+WZWvWgA==
+-----END PUBLIC KEY-----`,
+  `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED+1vssB17+Lyog3jAMCs3hKSZjeA
+Z7bBGIe7YkJOL+dW190dRHGnMKLjDNosF4ktJBdgckifMkiSKWttP1jVwg==
+-----END PUBLIC KEY-----`,
+] as const;
+
+const ecCertificate = `-----BEGIN CERTIFICATE-----
+MIIBpjCCAUugAwIBAgIULFj+4eCQePJrqns3kUZIgzW7BfEwCgYIKoZIzj0EAwIw
+KDEmMCQGA1UEAwwdQXp1cmUgU0RLIEF0dGVzdGF0aW9uIEVDIFRlc3QwHhcNMjYw
+ODI3MTcyOTMxWhcNMzYwODI0MTcyOTMxWjAoMSYwJAYDVQQDDB1BenVyZSBTREsg
+QXR0ZXN0YXRpb24gRUMgVGVzdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIGA
+iwXngeZ4fKIxBOQwe/jKfP5LGZtX3ukR5VPCB+PxMa60pDNAmBX8LLqbazzgqUiY
+j/X9HGK9jH7/lmVr1oCjUzBRMB0GA1UdDgQWBBQW39uilSP/EotB9UEHCpt29vjh
+qzAfBgNVHSMEGDAWgBQW39uilSP/EotB9UEHCpt29vjhqzAPBgNVHRMBAf8EBTAD
+AQH/MAoGCCqGSM49BAMCA0kAMEYCIQCFNZxW9bEEzj+9Sro7TVYOawosF/0UMYzo
+xtbaSkJIkgIhALti2JsXEM8EOeEldYFbRiV/vfovDJ1Ml0LiaPMWy3SQ
+-----END CERTIFICATE-----`;
+
+export function createECDSKey(index = 0): [string, string] {
+  return [ecPrivateKeys[index], ecPublicKeys[index]];
 }
 
-export function createRSAKey(): [string, string] {
-  const keyPair = jsrsasign.KEYUTIL.generateKeypair("RSA", 1024);
-  return [
-    jsrsasign.KEYUTIL.getPEM(keyPair.prvKeyObj, "PKCS8PRV"),
-    jsrsasign.KEYUTIL.getPEM(keyPair.pubKeyObj, "PKCS8PUB"),
-  ];
+export function createRSAKey(index = 0): [string, string] {
+  return [rsaPrivateKeys[index], rsaPublicKeys[index]];
 }
 
-function localDateToUtc(d: Date): Date {
-  const utc = d.getTime() + d.getTimezoneOffset() * 60000;
-  return new Date(utc);
-}
-
-function zeroPadding(s: string, len: number): any {
-  if (s.length >= len) return s;
-  return new Array(len - s.length + 1).join("0") + s;
-}
-
-function formatDateString(dateObject: Date): string {
-  const pad = zeroPadding;
-  const d = localDateToUtc(dateObject);
-  let year = String(d.getFullYear());
-  // Extract first two digits of year for UTC encoding.
-  year = year.substr(2, 2);
-  const month = pad(String(d.getMonth() + 1), 2);
-  const day = pad(String(d.getDate()), 2);
-  const hour = pad(String(d.getHours()), 2);
-  const min = pad(String(d.getMinutes()), 2);
-  const sec = pad(String(d.getSeconds()), 2);
-  const s = year + month + day + hour + min + sec;
-  return s + "Z";
-}
-
-// Create a self-signed X.509 certificZTe
 export function createX509Certificate(
-  privKeyPEM: string,
-  pubKeyPEM: string,
-  subject_name: string,
+  _privateKeyPem: string,
+  publicKeyPem: string,
+  _subjectName: string,
 ): string {
-  const pubKey = jsrsasign.KEYUTIL.getKey(pubKeyPEM);
-  const privKey = jsrsasign.KEYUTIL.getKey(privKeyPEM);
-
-  const timeEnd = new Date();
-  timeEnd.setFullYear(timeEnd.getFullYear() + 1);
-
-  const cert = new jsrsasign.KJUR.asn1.x509.Certificate({
-    //    tbsobj: tbs,
-    serial: { int: 4 },
-    issuer: { str: "/CN=" + subject_name },
-    subject: { str: "/CN=" + subject_name },
-    notafter: { str: formatDateString(timeEnd) },
-    sbjpubkey: pubKey,
-    ext: [
-      { extname: "basicConstraints", critical: false, cA: false, pathLen: 0 },
-      { extname: "subjectAltName", critical: false, array: [{ uri: "https://" + subject_name }] },
-      { extname: "keyUsage", critical: true, names: ["digitalSignature"] },
-    ],
-    sigalg: { name: "SHA256withRSA" },
-    cakey: privKey,
-  });
-
-  const x509 = new jsrsasign.X509();
-  x509.readCertPEM(cert.getPEM());
-
-  return cert.getPEM();
+  if (publicKeyPem === rsaPublicKeys[0]) {
+    return rsaCertificate;
+  }
+  if (publicKeyPem === ecPublicKeys[0]) {
+    return ecCertificate;
+  }
+  throw new Error("No test certificate matches the requested public key.");
 }
 
-/**
- * Generate the SHA256 hash of the specified buffer.
- */
+export function certificateToBase64(certificate: string): string {
+  const base64 = certificate
+    .replace("-----BEGIN CERTIFICATE-----", "")
+    .replace("-----END CERTIFICATE-----", "")
+    .replace(/\s/g, "");
+  const der = base64DecodeString(base64);
+  if (base64EncodeByteArray(der) !== base64) {
+    throw new Error("Invalid test certificate.");
+  }
+  return base64;
+}
+
+export function certificateToDer(certificate: string): Uint8Array {
+  return base64DecodeString(certificateToBase64(certificate));
+}
+
+function binaryStringToBytes(value: string): Uint8Array {
+  return Uint8Array.from(value, (character) => character.charCodeAt(0));
+}
+
 export function generateSha256Hash(buffer: string): Uint8Array {
-  return hexToByteArray(jsrsasign.KJUR.crypto.Util.hashString(buffer, "sha256"));
+  const digest = forge.md.sha256.create();
+  digest.update(buffer, "utf8");
+  return binaryStringToBytes(digest.digest().getBytes());
 }
 
-/** Generate the SHA1 hash of the specified buffer.
- *
- * @param buffer - HEX encoded buffer to be hashed.
- * @returns SHA1 hash of the buffer.
- */
-export function generateSha1Hash(buffer: string): Uint8Array {
-  return hexToByteArray(jsrsasign.KJUR.crypto.Util.hashHex(buffer, "sha1"));
+export function generateSha1Hash(buffer: Uint8Array): Uint8Array {
+  const digest = forge.md.sha1.create();
+  digest.update(String.fromCharCode(...buffer), "raw");
+  return binaryStringToBytes(digest.digest().getBytes());
 }

--- a/sdk/attestation/attestation/vitest.browser.config.ts
+++ b/sdk/attestation/attestation/vitest.browser.config.ts
@@ -2,5 +2,18 @@
 // Licensed under the MIT License.
 
 import viteConfig from "../../../vitest.browser.shared.config.ts";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    optimizeDeps: {
+      include: [
+        "node-forge/lib/forge.js",
+        "node-forge/lib/asn1.js",
+        "node-forge/lib/rsa.js",
+        "node-forge/lib/sha256.js",
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): This PR replaces the deprecated `jsrsasign` production dependency in `@azure/attestation` while preserving its synchronous GA token APIs and Node >=22, browser, and React Native build targets.

## Design

- Uses audited `@noble/curves` P-256 primitives for synchronous ES256 signing and verification.
- Uses patched `node-forge` 1.4+ for synchronous RS256/PKCS#1 v1.5 instead of hand-rolling modular exponentiation, padding, or DigestInfo encoding.
- Imports only Forge's ASN.1, RSA, and SHA-256 modules in production. The measured minified+gzip crypto bundle is about 51 KB total, compared with about 95 KB when importing Forge's default entrypoint.
- Adds a private, narrowly scoped DER reader for PKCS#8 and X.509 SubjectPublicKeyInfo extraction. It rejects indefinite, non-canonical, truncated, malformed, and trailing encodings, validates RSA/P-256 structures, and compares private keys with certificate public keys.
- Preserves RS256, ES256, unsecured (`alg: none`) tokens, canonical x5c encoding, token validation, tamper rejection, and private-key/certificate matching.
- Derives certificate `kty` from the subject public-key algorithm rather than the certificate issuer's signature algorithm.

`jose` was explicitly evaluated but was not usable here because its Web Crypto operations are asynchronous and would break the stable synchronous API. A separate X.509 dependency was not needed.

## Dependencies and security

- Removes `jsrsasign`.
- Adds `@noble/curves: ^2.0.1` (MIT; lockfile resolves 2.3.0).
- Adds `node-forge: ^1.4.0` (BSD-3-Clause licensing option; lockfile resolves 1.4.0). The minimum version excludes earlier RSA signature-forgery vulnerabilities, and verification additionally enforces the RSA modulus signature length.
- Adds `@types/node-forge: ^1.3.13` as a development dependency.
- Updates the scoped third-party dependency approvals and generated lockfile state.

## Validation

- `pnpm format` and `pnpm check-format`
- `pnpm lint` (no errors; four existing `no-param-reassign` warnings)
- `pnpm turbo build --filter=@azure/attestation... --token 1` (browser, React Native, ESM, CommonJS, and API extraction)
- `pnpm build:samples`
- `pnpm test:node` — 44 passed, 5 skipped across 6 files
- `pnpm test:browser` — 49 passed, 5 skipped across 7 files in Chromium

The regression coverage includes SDK-to-Node and Node-to-SDK RS256/ES256 interoperability, browser-native RSA/EC paths, tampered tokens, malformed signing material, and mismatched RSA/EC keys.

## Remaining limitation

The package has no React Native device/runtime test harness. The React Native target compiles successfully, and the same isomorphic dependency graph bundles and executes in Chromium without Node built-ins.

Fixes #39762