### PR TITLE
[storage] Restore core v1 user agent prefixes

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Restored the core v1 user agent string prefix, `azsdk-js-storageblob`. [#38265](https://github.com/Azure/azure-sdk-for-js/issues/38265)
+
 ### Other Changes
 
 ## 12.34.0-beta.1 (2026-08-03)

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -272,7 +272,7 @@ export function getCoreClientOptions(pipeline: PipelineLike): ExtendedServiceCli
 
   let corePipeline: CorePipeline = (pipeline as any)._corePipeline;
   if (!corePipeline) {
-    const packageDetails = `azsdk-js-azure-storage-blob/${SDK_VERSION}`;
+    const packageDetails = `azsdk-js-storageblob/${SDK_VERSION}`;
     const userAgentPrefix =
       restOptions.userAgentOptions && restOptions.userAgentOptions.userAgentPrefix
         ? `${restOptions.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-blob/test/node/pipeline.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pipeline.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { HttpClient } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { describe, it, assert } from "vitest";
+import { getCoreClientOptions, newPipeline } from "../../src/Pipeline.js";
+import { SDK_VERSION } from "../../src/utils/constants.js";
+
+describe("Pipeline", () => {
+  it("uses the core v1 user agent prefix", async () => {
+    let userAgent: string | undefined;
+    const httpClient: HttpClient = {
+      async sendRequest(request) {
+        userAgent = request.headers.get("user-agent");
+        return { request, status: 200, headers: createHttpHeaders() };
+      },
+    };
+    const options = getCoreClientOptions(
+      newPipeline(undefined, {
+        userAgentOptions: { userAgentPrefix: "custom-prefix" },
+      }),
+    );
+
+    await options.pipeline!.sendRequest(
+      httpClient,
+      createPipelineRequest({ url: "https://example.com" }),
+    );
+
+    assert.ok(userAgent?.startsWith(`custom-prefix azsdk-js-storageblob/${SDK_VERSION}`));
+  });
+});

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Restored the core v1 user agent string prefix, `azsdk-js-storagedatalake`. [#38265](https://github.com/Azure/azure-sdk-for-js/issues/38265)
+
 ### Other Changes
 
 ## 12.31.0 (2026-06-24)

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -172,7 +172,7 @@ export function getCoreClientOptions(pipeline: PipelineLike): ExtendedServiceCli
 
   let corePipeline: CorePipeline = (pipeline as any)._corePipeline;
   if (!corePipeline) {
-    const packageDetails = `azsdk-js-azure-storage-blob/${SDK_VERSION}`;
+    const packageDetails = `azsdk-js-storagedatalake/${SDK_VERSION}`;
     const userAgentPrefix =
       restOptions.userAgentOptions && restOptions.userAgentOptions.userAgentPrefix
         ? `${restOptions.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-datalake/src/StorageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/StorageClient.ts
@@ -4,7 +4,8 @@
 import type { TokenCredential } from "@azure/core-auth";
 import { StorageContextClient } from "./StorageContextClient.js";
 import type { StorageClient as StorageClientContext } from "./generated/src/index.js";
-import type { Pipeline, PipelineLike, StoragePipelineOptions } from "./Pipeline.js";
+import type { Pipeline, PipelineLike } from "./Pipeline.js";
+import { getCoreClientOptions } from "./Pipeline.js";
 import type { AnonymousCredential, StorageSharedKeyCredential } from "@azure/storage-common";
 import { BlobServiceClient } from "@azure/storage-blob";
 import { toBlobEndpointUrl, toDfsEndpointUrl } from "./transforms.js";
@@ -14,8 +15,6 @@ import {
   getURLScheme,
   iEqual,
 } from "./utils/utils.common.js";
-import type { ExtendedServiceClientOptions } from "@azure/core-http-compat";
-import type { HttpClient, Pipeline as CorePipeline } from "@azure/core-rest-pipeline";
 import type { OperationTracingOptions } from "@azure/core-tracing";
 import { DataLakeClientConfig } from "./models.js";
 
@@ -24,26 +23,6 @@ import { DataLakeClientConfig } from "./models.js";
  */
 export interface CommonOptions {
   tracingOptions?: OperationTracingOptions;
-}
-
-// This function relies on the Pipeline already being initialized by a storage-blob client
-function getCoreClientOptions(pipeline: Pipeline): ExtendedServiceClientOptions {
-  const { httpClient: v1Client, ...restOptions } = pipeline.options as StoragePipelineOptions;
-  const httpClient: HttpClient = (pipeline as any)._coreHttpClient;
-  if (!httpClient) {
-    throw new Error("Pipeline not correctly initialized; missing V2 HttpClient");
-  }
-
-  const corePipeline: CorePipeline = (pipeline as any)._corePipeline;
-  if (!corePipeline) {
-    throw new Error("Pipeline not correctly initialized; missing V2 Pipeline");
-  }
-  return {
-    ...restOptions,
-    allowInsecureConnection: true,
-    httpClient,
-    pipeline: corePipeline,
-  };
 }
 
 /**
@@ -113,12 +92,14 @@ export abstract class StorageClient {
     this.dfsEndpointUrl = toDfsEndpointUrl(this.url);
     this.accountName = getAccountNameFromUrl(this.blobEndpointUrl);
     this.pipeline = pipeline;
+    // Seed the shared core (V2) pipeline with Data Lake package details before constructing the
+    // inner BlobServiceClient. The Blob client only initializes `_corePipeline` when it is unset,
+    // so seeding it here ensures Data Lake requests carry the azsdk-js-storagedatalake user agent
+    // rather than azsdk-js-storageblob.
+    const coreClientOptions = getCoreClientOptions(pipeline);
     // creating this BlobServiceClient allows us to use the converted V2 Pipeline attached to `pipeline`.
     const blobClient = new BlobServiceClient(url, pipeline);
-    this.storageClientContext = new StorageContextClient(
-      this.dfsEndpointUrl,
-      getCoreClientOptions(pipeline),
-    );
+    this.storageClientContext = new StorageContextClient(this.dfsEndpointUrl, coreClientOptions);
 
     this.storageClientContextToBlobEndpoint = new StorageContextClient(
       this.blobEndpointUrl,

--- a/sdk/storage/storage-file-datalake/test/node/pipeline.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pipeline.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { HttpClient } from "@azure/core-rest-pipeline";
+import type { HttpClient, Pipeline as CorePipeline } from "@azure/core-rest-pipeline";
 import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { describe, it, assert } from "vitest";
 import { getCoreClientOptions, newPipeline } from "../../src/Pipeline.js";
+import { DataLakeServiceClient } from "../../src/DataLakeServiceClient.js";
 import { SDK_VERSION } from "../../src/utils/constants.js";
 
 describe("Pipeline", () => {
@@ -28,5 +29,34 @@ describe("Pipeline", () => {
     );
 
     assert.ok(userAgent?.startsWith(`custom-prefix azsdk-js-storagedatalake/${SDK_VERSION}`));
+  });
+
+  it("uses the data lake user agent prefix for requests from public clients", async () => {
+    let userAgent: string | undefined;
+    const httpClient: HttpClient = {
+      async sendRequest(request) {
+        userAgent = request.headers.get("user-agent");
+        return { request, status: 200, headers: createHttpHeaders() };
+      },
+    };
+
+    const pipeline = newPipeline(undefined, {
+      userAgentOptions: { userAgentPrefix: "custom-prefix" },
+    });
+    // Constructing a public Data Lake client seeds the shared core (V2) pipeline. It must be
+    // initialized with the Data Lake package details rather than the inner Blob client's, so
+    // that requests carry azsdk-js-storagedatalake instead of azsdk-js-storageblob.
+    new DataLakeServiceClient("https://myaccount.dfs.core.windows.net", pipeline);
+
+    const corePipeline = (pipeline as unknown as { _corePipeline: CorePipeline })._corePipeline;
+    await corePipeline.sendRequest(
+      httpClient,
+      createPipelineRequest({ url: "https://example.com" }),
+    );
+
+    assert.ok(
+      userAgent?.startsWith(`custom-prefix azsdk-js-storagedatalake/${SDK_VERSION}`),
+      `Expected the data lake user agent prefix but got: ${userAgent}`,
+    );
   });
 });

--- a/sdk/storage/storage-file-datalake/test/node/pipeline.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pipeline.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { HttpClient } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { describe, it, assert } from "vitest";
+import { getCoreClientOptions, newPipeline } from "../../src/Pipeline.js";
+import { SDK_VERSION } from "../../src/utils/constants.js";
+
+describe("Pipeline", () => {
+  it("uses the core v1 user agent prefix", async () => {
+    let userAgent: string | undefined;
+    const httpClient: HttpClient = {
+      async sendRequest(request) {
+        userAgent = request.headers.get("user-agent");
+        return { request, status: 200, headers: createHttpHeaders() };
+      },
+    };
+    const options = getCoreClientOptions(
+      newPipeline(undefined, {
+        userAgentOptions: { userAgentPrefix: "custom-prefix" },
+      }),
+    );
+
+    await options.pipeline!.sendRequest(
+      httpClient,
+      createPipelineRequest({ url: "https://example.com" }),
+    );
+
+    assert.ok(userAgent?.startsWith(`custom-prefix azsdk-js-storagedatalake/${SDK_VERSION}`));
+  });
+});

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Restored the core v1 user agent string prefix, `azsdk-js-storagefile`. [#38265](https://github.com/Azure/azure-sdk-for-js/issues/38265)
+
 ### Other Changes
 
 ## 12.33.0-beta.1 (2026-08-03)

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -277,7 +277,7 @@ export function getCoreClientOptions(pipeline: PipelineLike): ExtendedServiceCli
 
   let corePipeline: CorePipeline = (pipeline as any)._corePipeline;
   if (!corePipeline) {
-    const packageDetails = `azsdk-js-storage-file-share/${SDK_VERSION}`;
+    const packageDetails = `azsdk-js-storagefile/${SDK_VERSION}`;
     const userAgentPrefix =
       restOptions.userAgentOptions && restOptions.userAgentOptions.userAgentPrefix
         ? `${restOptions.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-share/test/node/pipeline.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/pipeline.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { HttpClient } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { describe, it, assert } from "vitest";
+import { getCoreClientOptions, newPipeline } from "../../src/Pipeline.js";
+import { SDK_VERSION } from "../../src/utils/constants.js";
+
+describe("Pipeline", () => {
+  it("uses the core v1 user agent prefix", async () => {
+    let userAgent: string | undefined;
+    const httpClient: HttpClient = {
+      async sendRequest(request) {
+        userAgent = request.headers.get("user-agent");
+        return { request, status: 200, headers: createHttpHeaders() };
+      },
+    };
+    const options = getCoreClientOptions(
+      newPipeline(undefined, {
+        userAgentOptions: { userAgentPrefix: "custom-prefix" },
+      }),
+    );
+
+    await options.pipeline!.sendRequest(
+      httpClient,
+      createPipelineRequest({ url: "https://example.com" }),
+    );
+
+    assert.ok(userAgent?.startsWith(`custom-prefix azsdk-js-storagefile/${SDK_VERSION}`));
+  });
+});

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Restored the core v1 user agent string prefix, `azsdk-js-storagequeue`. [#38265](https://github.com/Azure/azure-sdk-for-js/issues/38265)
+
 ### Other Changes
 
 ## 12.32.0-beta.1 (2026-08-03)

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -271,7 +271,7 @@ export function getCoreClientOptions(pipeline: PipelineLike): ExtendedServiceCli
 
   let corePipeline: CorePipeline = (pipeline as any)._corePipeline;
   if (!corePipeline) {
-    const packageDetails = `azsdk-js-storage-queue/${SDK_VERSION}`;
+    const packageDetails = `azsdk-js-storagequeue/${SDK_VERSION}`;
     const userAgentPrefix =
       restOptions.userAgentOptions && restOptions.userAgentOptions.userAgentPrefix
         ? `${restOptions.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-queue/test/node/pipeline.spec.ts
+++ b/sdk/storage/storage-queue/test/node/pipeline.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { HttpClient } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { describe, it, assert } from "vitest";
+import { getCoreClientOptions, newPipeline } from "../../src/Pipeline.js";
+import { SDK_VERSION } from "../../src/utils/constants.js";
+
+describe("Pipeline", () => {
+  it("uses the core v1 user agent prefix", async () => {
+    let userAgent: string | undefined;
+    const httpClient: HttpClient = {
+      async sendRequest(request) {
+        userAgent = request.headers.get("user-agent");
+        return { request, status: 200, headers: createHttpHeaders() };
+      },
+    };
+    const options = getCoreClientOptions(
+      newPipeline(undefined, {
+        userAgentOptions: { userAgentPrefix: "custom-prefix" },
+      }),
+    );
+
+    await options.pipeline!.sendRequest(
+      httpClient,
+      createPipelineRequest({ url: "https://example.com" }),
+    );
+
+    assert.ok(userAgent?.startsWith(`custom-prefix azsdk-js-storagequeue/${SDK_VERSION}`));
+  });
+});


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Restores the core v1 user agent string prefixes used by Storage service tracking.

## Summary
- Restore the Blob, File Share, Data Lake, and Queue prefixes in the hand-written convenience-layer pipelines.
- Leave generated client code unchanged.
- Add Node regression coverage and changelog entries for each package.

## Testing
- Built all four packages and their dependencies with Turbo.
- Passed full Node and browser test suites for all four packages.
- Passed package format and lint checks.

Fixes #38265