### PR TITLE
[App Configuration] Audience auto detect

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Improved Microsoft Entra authentication in sovereign clouds when using a `TokenCredential`. When `audience` is not set, the client now infers it from the App Configuration endpoint. An explicitly configured audience continues to override the inferred value.
+
 ## 1.12.1 (2026-06-22)
 
 ### Bugs Fixed

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -508,24 +508,28 @@ export function hasUnderscoreResponse<T extends object>(
 /**
  * Get the scope for the App Configuration service based on the endpoint and audience.
  * If the audience is provided, it will be used as the scope.
- * If not, the scope is defaulted to Azure Public Cloud when not specified.
+ * If not, the scope is inferred from the endpoint.
  *
  * @internal
  */
 export function getScope(appConfigEndpoint: string, appConfigAudience?: string): string {
   if (appConfigAudience) {
     return `${appConfigAudience}/.default`;
-  } else if (
-    appConfigEndpoint.endsWith("azconfig.azure.us") ||
-    appConfigEndpoint.endsWith("appconfig.azure.us")
-  ) {
-    return `${KnownAppConfigAudience.AzureGovernment}/.default`;
-  } else if (
-    appConfigEndpoint.endsWith("azconfig.azure.cn") ||
-    appConfigEndpoint.endsWith("appconfig.azure.cn")
-  ) {
-    return `${KnownAppConfigAudience.AzureChina}/.default`;
-  } else {
-    return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
   }
+
+  const hostname = new URL(appConfigEndpoint).hostname;
+  const stagingDomain = "appconfig-staging.azure.com";
+  if (hostname.endsWith(`.${stagingDomain}`)) {
+    return `https://${stagingDomain}/.default`;
+  }
+
+  const labels = hostname.split(".");
+  for (let index = labels.length - 1; index >= 0; index--) {
+    const label = labels[index].toLowerCase();
+    if (label === "appconfig" || label === "azconfig") {
+      return `https://${labels.slice(index).join(".")}/.default`;
+    }
+  }
+
+  return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
 }

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -98,9 +98,11 @@ export interface AppConfigurationClientOptions extends CommonClientOptions {
   apiVersion?: string;
 
   /**
-   * The Audience to use for authentication with Azure Active Directory (AAD).
+   * The audience to use for authentication with Microsoft Entra ID.
    * {@link KnownAppConfigAudience} can be used interchangeably with audience.
-   * If not specified, the default audience will be set to Azure Public Cloud.
+   * If not specified, the audience is inferred from the App Configuration endpoint. If the
+   * endpoint does not contain a recognizable App Configuration domain, the audience defaults to
+   * Azure Public Cloud.
    */
   audience?: string;
 }

--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -371,28 +371,84 @@ describe("helper methods", () => {
         expected: `${KnownAppConfigAudience.AzureChina}/.default`,
       },
       {
-        name: "detects US Government cloud",
+        name: "uses a custom provided audience",
+        endpoint: "https://example.appconfig.azure.us",
+        audience: "https://custom.audience",
+        expected: "https://custom.audience/.default",
+      },
+      {
+        name: "derives the public cloud appconfig audience",
+        endpoint: "https://example.appconfig.azure.com",
+        expected: `${KnownAppConfigAudience.AzurePublicCloud}/.default`,
+      },
+      {
+        name: "derives the public cloud azconfig audience",
+        endpoint: "https://example.azconfig.io",
+        expected: "https://azconfig.io/.default",
+      },
+      {
+        name: "derives the US Government appconfig audience",
         endpoint: "https://example.appconfig.azure.us",
         expected: `${KnownAppConfigAudience.AzureGovernment}/.default`,
       },
       {
-        name: "detects US Government cloud for azconfig",
+        name: "derives the US Government azconfig audience",
         endpoint: "https://example.azconfig.azure.us",
-        expected: `${KnownAppConfigAudience.AzureGovernment}/.default`,
+        expected: "https://azconfig.azure.us/.default",
       },
       {
-        name: "detects China cloud for azconfig",
-        endpoint: "https://example.azconfig.azure.cn",
-        expected: `${KnownAppConfigAudience.AzureChina}/.default`,
-      },
-      {
-        name: "detects China cloud",
+        name: "derives the China appconfig audience",
         endpoint: "https://example.appconfig.azure.cn",
         expected: `${KnownAppConfigAudience.AzureChina}/.default`,
       },
       {
-        name: "defaults to Public cloud",
-        endpoint: "https://example.azconfig.azure.com",
+        name: "derives the China azconfig audience",
+        endpoint: "https://example.azconfig.azure.cn",
+        expected: "https://azconfig.azure.cn/.default",
+      },
+      {
+        name: "recognizes the staging domain",
+        endpoint: "https://example.appconfig-staging.azure.com",
+        expected: "https://appconfig-staging.azure.com/.default",
+      },
+      {
+        name: "derives an audience for a sovereign cloud",
+        endpoint: "https://example.appconfig.sovereign.cloud",
+        expected: "https://appconfig.sovereign.cloud/.default",
+      },
+      {
+        name: "ignores store and region labels",
+        endpoint: "https://example.eastus.appconfig.sovereign.cloud",
+        expected: "https://appconfig.sovereign.cloud/.default",
+      },
+      {
+        name: "uses the rightmost App Configuration service label",
+        endpoint: "https://appconfig-store.azconfig.example.appconfig.sovereign.cloud",
+        expected: "https://appconfig.sovereign.cloud/.default",
+      },
+      {
+        name: "matches service labels case-insensitively",
+        endpoint: "https://example.AZconfig.io/",
+        expected: "https://azconfig.io/.default",
+      },
+      {
+        name: "does not match a hyphenated service label",
+        endpoint: "https://example.appconfig-test.azure.com",
+        expected: `${KnownAppConfigAudience.AzurePublicCloud}/.default`,
+      },
+      {
+        name: "does not match a service label embedded in another label",
+        endpoint: "https://example.fooappconfig.azure.us",
+        expected: `${KnownAppConfigAudience.AzurePublicCloud}/.default`,
+      },
+      {
+        name: "does not match a look-alike host suffix",
+        endpoint: "https://myazconfig.io",
+        expected: `${KnownAppConfigAudience.AzurePublicCloud}/.default`,
+      },
+      {
+        name: "defaults an unrecognized host to the public cloud audience",
+        endpoint: "https://other.custom.audience",
         expected: `${KnownAppConfigAudience.AzurePublicCloud}/.default`,
       },
     ];


### PR DESCRIPTION
## Changes

- Derives scopes from `appconfig` or `azconfig` hostname labels, including sovereign and staging domains.
- Explicit `audience` values continue to take precedence.
- Unknown and look-alike domains fall back to Azure Public Cloud.
- Added comprehensive scope tests


Reference: https://github.com/Azure/azure-sdk-for-net/pull/60387


