### PR TITLE
[js-sdk-release-tools] Enhance npm configuration handling and testing

### DIFF
--- a/eng/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
+++ b/eng/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
@@ -8,6 +8,7 @@ import { generateRLCInPipeline } from "./llc/generateRLCInPipeline/generateRLCIn
 import { ModularClientPackageOptions, SDKType, RunMode } from "./common/types.js";
 import { generateAzureSDKPackage } from "./mlc/clientGenerator/modularClientPackageGenerator.js";
 import { parseInputJson } from "./utils/generateInputUtils.js";
+import { configureNpmFromRepo } from "./common/npmUtils.js";
 import shell from "shelljs";
 import fs from "fs";
 
@@ -38,6 +39,9 @@ async function automationGenerateInPipeline(
   // If --local parameter is used, local is true; otherwise, determine from runMode
   const local = localOverride || runMode === RunMode.Local;
   try {
+    if (local) {
+      configureNpmFromRepo(String(shell.pwd()));
+    }
     if (!local) {
       await backupNodeModules(String(shell.pwd()));
     }

--- a/eng/tools/js-sdk-release-tools/src/common/npmUtils.ts
+++ b/eng/tools/js-sdk-release-tools/src/common/npmUtils.ts
@@ -11,6 +11,37 @@ import { logger } from "../utils/logger.js";
 import { error } from "console";
 import fs from "fs";
 
+export function configureNpmFromRepo(sdkRepoPath: string): void {
+  const npmConfigPath = path.resolve(sdkRepoPath, ".npmrc");
+  if (!fs.existsSync(npmConfigPath)) {
+    throw new Error(`Npm configuration file does not exist: ${npmConfigPath}`);
+  }
+
+  const npmArgs = ["config", "get", "registry"];
+  const command = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npm";
+  const commandArgs =
+    process.platform === "win32" ? ["/d", "/s", "/c", "npm", ...npmArgs] : npmArgs;
+  const npmEnvironment = { ...process.env };
+  for (const variableName of Object.keys(npmEnvironment)) {
+    if (variableName.toLowerCase() === "npm_config_registry") {
+      delete npmEnvironment[variableName];
+    }
+  }
+  const result = spawnSync(command, commandArgs, {
+    cwd: sdkRepoPath,
+    encoding: "utf8",
+    env: npmEnvironment,
+  });
+  const registry = result.stdout?.trim();
+  if (result.status !== 0 || !registry) {
+    const details = result.error?.message ?? result.stderr;
+    throw new Error(`Failed to resolve the npm registry from ${npmConfigPath}: ${details}`);
+  }
+
+  process.env.npm_config_registry = registry;
+  logger.info(`Using npm configuration from: ${npmConfigPath}`);
+}
+
 export async function getNpmPackageInfo(packageDirectory): Promise<NpmPackageInfo> {
   const packageJson = await load(packageDirectory);
   if (!packageJson.content.name) {
@@ -51,7 +82,8 @@ export async function tryGetNpmView(
 ): Promise<{ [id: string]: unknown } | undefined> {
   try {
     logger.info(`[tryGetNpmView] Fetching npm registry info for: ${packageName}`);
-    const result = await fetch.json(`/${packageName}`);
+    const registry = process.env.npm_config_registry;
+    const result = await fetch.json(`/${packageName}`, registry ? { registry } : undefined);
     logger.info(`[tryGetNpmView] Successfully fetched info for: ${packageName}`);
     return result;
   } catch (err) {

--- a/eng/tools/js-sdk-release-tools/src/generateChangelogCli.ts
+++ b/eng/tools/js-sdk-release-tools/src/generateChangelogCli.ts
@@ -5,6 +5,7 @@ import {
   generateChangelogAndBumpVersion,
   UpdateMode,
 } from "./common/changelog/automaticGenerateChangeLogAndBumpVersion.js";
+import { configureNpmFromRepo } from "./common/npmUtils.js";
 import { logger } from "./utils/logger.js";
 
 const generateChangelogCli = async (
@@ -19,6 +20,7 @@ const generateChangelogCli = async (
     process.exit(1);
   }
 
+  configureNpmFromRepo(sdkRepoPath);
   await generateChangelogAndBumpVersion(
     packageFolderPath,
     {

--- a/eng/tools/js-sdk-release-tools/src/test/npm/npm.test.ts
+++ b/eng/tools/js-sdk-release-tools/src/test/npm/npm.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { updatePackageVersion } from "../../mlc/clientGenerator/utils/typeSpecUtils.js";
 import { join } from "path";
 import { load } from "@npmcli/package-json";
-import { tryGetNpmView } from "../../common/npmUtils.js";
+import { configureNpmFromRepo, tryGetNpmView } from "../../common/npmUtils.js";
 
 describe("Npm package json", () => {
   test("Replace package version", async () => {
@@ -14,11 +14,22 @@ describe("Npm package json", () => {
 });
 
 describe("Npm view", () => {
-  test.skip("View package version", async () => {
-    const nonExistResult = await tryGetNpmView("non-exist");
-    expect(nonExistResult).toBeUndefined();
+  test("View package version", async () => {
+    const originalRegistry = process.env.npm_config_registry;
+    configureNpmFromRepo(join(__dirname, "../../../../../.."));
 
-    const normalResult = await tryGetNpmView("connect");
-    expect(normalResult!["name"]).toBe("connect");
+    try {
+      const nonExistResult = await tryGetNpmView("non-exist");
+      expect(nonExistResult).toBeUndefined();
+
+      const normalResult = await tryGetNpmView("connect");
+      expect(normalResult!["name"]).toBe("connect");
+    } finally {
+      if (originalRegistry) {
+        process.env.npm_config_registry = originalRegistry;
+      } else {
+        delete process.env.npm_config_registry;
+      }
+    }
   });
 });

--- a/eng/tools/js-sdk-release-tools/src/test/npm/npmRegistry.test.ts
+++ b/eng/tools/js-sdk-release-tools/src/test/npm/npmRegistry.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import * as fetch from "npm-registry-fetch";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { configureNpmFromRepo, tryGetNpmView } from "../../common/npmUtils.js";
+
+vi.mock("npm-registry-fetch", () => ({
+  json: vi.fn().mockResolvedValue({ name: "test-package" }),
+}));
+
+describe("npm registry", () => {
+  let originalRegistry: string | undefined;
+  let originalUserConfig: string | undefined;
+
+  beforeAll(() => {
+    originalRegistry = process.env.npm_config_registry;
+    originalUserConfig = process.env.npm_config_userconfig;
+  });
+
+  afterEach(() => {
+    delete process.env.npm_config_registry;
+    if (originalUserConfig) {
+      process.env.npm_config_userconfig = originalUserConfig;
+    } else {
+      delete process.env.npm_config_userconfig;
+    }
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalRegistry) {
+      process.env.npm_config_registry = originalRegistry;
+    }
+    if (originalUserConfig) {
+      process.env.npm_config_userconfig = originalUserConfig;
+    }
+  });
+
+  test("loads configuration from the repository root", () => {
+    const repoPath = mkdtempSync(join(tmpdir(), "release-tools-npm-"));
+    const npmConfigPath = join(repoPath, ".npmrc");
+    const userConfig = process.env.npm_config_userconfig;
+    writeFileSync(npmConfigPath, "registry=https://example.test/repository/npm/\n");
+
+    try {
+      configureNpmFromRepo(repoPath);
+
+      expect(process.env.npm_config_userconfig).toBe(userConfig);
+      expect(process.env.npm_config_registry).toBe("https://example.test/repository/npm/");
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  test("uses the registry from npm configuration", async () => {
+    process.env.npm_config_registry = "https://example.test/npm/registry/";
+
+    await tryGetNpmView("test-package");
+
+    expect(fetch.json).toHaveBeenCalledWith("/test-package", {
+      registry: "https://example.test/npm/registry/",
+    });
+  });
+
+  test("uses the default registry when npm configuration is unavailable", async () => {
+    await tryGetNpmView("test-package");
+
+    expect(fetch.json).toHaveBeenCalledWith("/test-package", undefined);
+  });
+});

--- a/eng/tools/js-sdk-release-tools/src/test/version/version.test.ts
+++ b/eng/tools/js-sdk-release-tools/src/test/version/version.test.ts
@@ -59,6 +59,19 @@ describe("Get latest stable version after GA but beta version before GA", () => 
       expect(version).toBe(expectedVersion);
     },
   );
+
+  test("uses the latest published stable version when latest points to alpha", () => {
+    const npmView = {
+      "dist-tags": { latest: "2.0.5-alpha.20260312.1" },
+      versions: {
+        "2.0.3": {},
+        "2.0.4": {},
+        "2.0.5-alpha.20260312.1": {},
+      },
+    };
+
+    expect(getLatestStableVersion(npmView)).toBe("2.0.4");
+  });
 });
 
 describe("Get next beta version from beta and next tags", () => {

--- a/eng/tools/js-sdk-release-tools/src/updateBumpVersionCli.ts
+++ b/eng/tools/js-sdk-release-tools/src/updateBumpVersionCli.ts
@@ -5,6 +5,7 @@ import {
   generateChangelogAndBumpVersion,
   UpdateMode,
 } from "./common/changelog/automaticGenerateChangeLogAndBumpVersion.js";
+import { configureNpmFromRepo } from "./common/npmUtils.js";
 import { logger } from "./utils/logger.js";
 
 const updateBumpVersionCli = async (
@@ -22,6 +23,7 @@ const updateBumpVersionCli = async (
     process.exit(1);
   }
 
+  configureNpmFromRepo(sdkRepoPath);
   await generateChangelogAndBumpVersion(
     packageFolderPath,
     {

--- a/eng/tools/js-sdk-release-tools/src/utils/version.ts
+++ b/eng/tools/js-sdk-release-tools/src/utils/version.ts
@@ -88,11 +88,11 @@ export function getLatestStableVersion(npmViewResult: Record<string, unknown>) {
   const isLatestComparable =
     latestVersion && (!latestVersion.includes("-") || latestVersion.includes("beta"));
   if (isLatestComparable) return latestVersion;
-  if (betaVersion) return betaVersion;
   const latestPublishedStableVersion = getUsedVersions(npmViewResult)
     .filter((version) => valid(version) && prerelease(version) === null)
     .sort(rcompare)[0];
   if (latestPublishedStableVersion) return latestPublishedStableVersion;
+  if (betaVersion) return betaVersion;
   if (latestVersion) return latestVersion;
   logger.warn(`Failed to find latest or beta version found in dist-tags.`);
   return undefined;

--- a/eng/tools/js-sdk-release-tools/src/utils/version.ts
+++ b/eng/tools/js-sdk-release-tools/src/utils/version.ts
@@ -1,5 +1,5 @@
 import { logger } from "./logger.js";
-import { inc as semverInc } from "semver";
+import { inc as semverInc, prerelease, rcompare, valid } from "semver";
 import { ApiVersionType } from "../common/types.js";
 
 function getDistTags(npmViewResult: Record<string, unknown>): Record<string, string> | undefined {
@@ -89,6 +89,10 @@ export function getLatestStableVersion(npmViewResult: Record<string, unknown>) {
     latestVersion && (!latestVersion.includes("-") || latestVersion.includes("beta"));
   if (isLatestComparable) return latestVersion;
   if (betaVersion) return betaVersion;
+  const latestPublishedStableVersion = getUsedVersions(npmViewResult)
+    .filter((version) => valid(version) && prerelease(version) === null)
+    .sort(rcompare)[0];
+  if (latestPublishedStableVersion) return latestPublishedStableVersion;
   if (latestVersion) return latestVersion;
   logger.warn(`Failed to find latest or beta version found in dist-tags.`);
   return undefined;


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-js/issues/39777
test job: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6758055&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=1858
test job: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6758497&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=1709
test  job from  SDK Validation - JS: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6758761&view=logs&si=6884a131-87da-5381-61f3-d7acc3b91d76

This pull request enhances npm registry handling in the JS SDK release tools by introducing a consistent way to load and use npm configuration from the repository, ensuring that all relevant scripts and utilities use the correct registry. It also adds new tests to validate this logic and improves version selection for stable releases.

**Npm registry configuration and usage improvements:**

* Added a new `configureNpmFromRepo` function in `npmUtils.ts` that loads the npm registry from the repository's `.npmrc` file and sets the `npm_config_registry` environment variable accordingly. This ensures all npm-related operations use the correct registry. (`[eng/tools/js-sdk-release-tools/src/common/npmUtils.tsR14-R44](diffhunk://#diff-5994e0b1f0864b16f3b55b3a60a11c2a474634cc3a08f05640cb47314b860723R14-R44)`)
* Updated CLI entry points (`generateChangelogCli.ts`, `updateBumpVersionCli.ts`, and `autoGenerateInPipeline.ts`) to call `configureNpmFromRepo` so that npm configuration is always set before running changelog, version bump, or package generation logic. (`[[1]](diffhunk://#diff-8c4b49af6acdf1ffb6db1061a48074ed71559ac25eb4be67f10f28cfcc052b31R8)`, `[[2]](diffhunk://#diff-8c4b49af6acdf1ffb6db1061a48074ed71559ac25eb4be67f10f28cfcc052b31R23)`, `[[3]](diffhunk://#diff-58cb0f80f4e33c04e4c8f3a1f82500840a5d255bfc592990aa61dc2378c78f85R8)`, `[[4]](diffhunk://#diff-58cb0f80f4e33c04e4c8f3a1f82500840a5d255bfc592990aa61dc2378c78f85R26)`, `[[5]](diffhunk://#diff-39e762d97d5c51223f77b1354fb3698f29fae48d1b95a984235b0e0ecb6c9079R11)`, `[[6]](diffhunk://#diff-39e762d97d5c51223f77b1354fb3698f29fae48d1b95a984235b0e0ecb6c9079R42-R44)`)
* Modified `tryGetNpmView` in `npmUtils.ts` to use the registry from the environment variable if set, ensuring all npm view operations respect the configured registry. (`[eng/tools/js-sdk-release-tools/src/common/npmUtils.tsL54-R86](diffhunk://#diff-5994e0b1f0864b16f3b55b3a60a11c2a474634cc3a08f05640cb47314b860723L54-R86)`)

**Testing enhancements:**

* Added a new test suite `npmRegistry.test.ts` to verify that npm registry configuration is correctly loaded and used, including edge cases where configuration is missing. (`[eng/tools/js-sdk-release-tools/src/test/npm/npmRegistry.test.tsR1-R71](diffhunk://#diff-9c652516e95fd2bce95be87ceed20f777a186515d5d13464ef269bc31f49315dR1-R71)`)
* Updated `npm.test.ts` to test registry configuration logic and to ensure environment variables are restored after each test. (`[[1]](diffhunk://#diff-e4bac62b0e165b1998f9383043c8529e55711431941dd502d2dc109b6d1e92bdL5-R5)`, `[[2]](diffhunk://#diff-e4bac62b0e165b1998f9383043c8529e55711431941dd502d2dc109b6d1e92bdL17-R33)`)

**Version selection improvements:**

* Improved `getLatestStableVersion` in `version.ts` to fall back to the latest published stable version if the `latest` dist-tag points to a prerelease (e.g., alpha). Added a corresponding test case. (`[[1]](diffhunk://#diff-636f39449a811f17f0bb411a00c583dc2f217194a5ecf4fde9b4befad7aeb055L2-R2)`, `[[2]](diffhunk://#diff-636f39449a811f17f0bb411a00c583dc2f217194a5ecf4fde9b4befad7aeb055R92-R95)`, `[[3]](diffhunk://#diff-6167428b0aa4fd3df7614c87b2dce95ae9ecd7bde83602f9698fbfff38d8f7daR62-R74)`)