### PR TITLE
[@azure/cosmos] Fix NSOB empty page handling

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/NonStreamingOrderByDistinctEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/NonStreamingOrderByDistinctEndpointComponent.ts
@@ -89,7 +89,7 @@ export class NonStreamingOrderByDistinctEndpointComponent implements ExecutionCo
 
   public hasMoreResults(): boolean {
     if (this.priorityQueueBufferSize === 0) return false;
-    return this.executionContext.hasMoreResults();
+    return this.executionContext.hasMoreResults() && !this.isCompleted;
   }
 
   public async fetchMore(diagnosticNode?: DiagnosticNodeInternal): Promise<Response<any>> {
@@ -128,9 +128,10 @@ export class NonStreamingOrderByDistinctEndpointComponent implements ExecutionCo
       }
 
       if (
-        response.result === undefined ||
-        !Array.isArray(response.result.buffer) ||
-        response.result.buffer.length === 0
+        (response.result === undefined ||
+          !Array.isArray(response.result.buffer) ||
+          response.result.buffer.length === 0) &&
+        !this.executionContext.hasMoreResults()
       ) {
         this.isCompleted = true;
         if (this.aggregateMap.size() > 0) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/NonStreamingOrderByEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/NonStreamingOrderByEndpointComponent.ts
@@ -53,7 +53,11 @@ export class NonStreamingOrderByEndpointComponent implements ExecutionContext {
    * @returns true if there is other elements to process in the NonStreamingOrderByEndpointComponent.
    */
   public hasMoreResults(): boolean {
-    return this.priorityQueueBufferSize > 0 && this.executionContext.hasMoreResults();
+    return (
+      this.priorityQueueBufferSize > 0 &&
+      this.executionContext.hasMoreResults() &&
+      !this.isCompleted
+    );
   }
 
   /**
@@ -90,9 +94,10 @@ export class NonStreamingOrderByEndpointComponent implements ExecutionContext {
 
       resHeaders = response.headers;
       if (
-        response.result === undefined ||
-        !response.result.buffer ||
-        response.result.buffer.length === 0
+        (response.result === undefined ||
+          !response.result.buffer ||
+          response.result.buffer.length === 0) &&
+        !this.executionContext.hasMoreResults()
       ) {
         this.isCompleted = true;
         if (!this.nonStreamingOrderByPQ.isEmpty()) {

--- a/sdk/cosmosdb/cosmos/test/public/functional/endpointComponent/NonStreamingOrderByDistinctEndpointComponent.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/endpointComponent/NonStreamingOrderByDistinctEndpointComponent.spec.ts
@@ -76,4 +76,87 @@ describe("NonStreamingOrderByDistinctEndpointComponent", () => {
       count++;
     }
   });
+
+  it("should continue after an empty page while the inner context has more results", async () => {
+    let fetchCount = 0;
+    let innerHasMoreResults = true;
+    const mockExecutionContext = {
+      hasMoreResults: () => innerHasMoreResults,
+      fetchMore: async () => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          return {
+            result: { buffer: [] },
+            headers: {},
+          };
+        }
+        if (fetchCount === 2) {
+          return {
+            result: {
+              buffer: [
+                {
+                  orderByItems: [{ item: 1 }],
+                  payload: { id: "later-result" },
+                },
+              ],
+            },
+            headers: {},
+          };
+        }
+        innerHasMoreResults = false;
+        return {
+          result: { buffer: [] },
+          headers: {},
+        };
+      },
+    } as ExecutionContext;
+    const queryInfo = {
+      orderBy: ["Ascending"],
+    } as QueryInfo;
+    const component = new NonStreamingOrderByDistinctEndpointComponent(
+      mockExecutionContext,
+      queryInfo,
+      10,
+    );
+
+    const firstResponse = await component.fetchMore();
+    assert.deepStrictEqual(firstResponse.result.buffer, []);
+    assert.isTrue(component.hasMoreResults());
+
+    const secondResponse = await component.fetchMore();
+    assert.deepStrictEqual(secondResponse.result.buffer, []);
+    assert.isTrue(component.hasMoreResults());
+
+    const finalResponse = await component.fetchMore();
+    assert.deepStrictEqual(finalResponse.result.buffer, [{ id: "later-result" }]);
+    assert.equal(fetchCount, 3);
+    assert.isFalse(component.hasMoreResults());
+  });
+
+  it("should stop reporting results after local completion", async () => {
+    let fetchCount = 0;
+    const mockExecutionContext = {
+      hasMoreResults: () => true,
+      fetchMore: async () => {
+        fetchCount++;
+        return undefined as never;
+      },
+    } as ExecutionContext;
+    const queryInfo = {
+      orderBy: ["Ascending"],
+    } as QueryInfo;
+    const component = new NonStreamingOrderByDistinctEndpointComponent(
+      mockExecutionContext,
+      queryInfo,
+      10,
+    );
+
+    const response = await component.fetchMore();
+    assert.isUndefined(response.result);
+    assert.isFalse(component.hasMoreResults());
+
+    const responseAfterCompletion = await component.fetchMore();
+    assert.isUndefined(responseAfterCompletion.result);
+    assert.equal(fetchCount, 1);
+  });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/endpointComponent/NonStreamingOrderByEndpointComponent.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/endpointComponent/NonStreamingOrderByEndpointComponent.spec.ts
@@ -71,4 +71,81 @@ describe("NonStreamingOrderByEndpointComponent", () => {
       count++;
     }
   });
+
+  it("should continue after an empty page while the inner context has more results", async () => {
+    let fetchCount = 0;
+    let innerHasMoreResults = true;
+    const mockExecutionContext = {
+      hasMoreResults: () => innerHasMoreResults,
+      fetchMore: async () => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          return {
+            result: { buffer: [] },
+            headers: {},
+          };
+        }
+        if (fetchCount === 2) {
+          return {
+            result: {
+              buffer: [
+                {
+                  orderByItems: [{ item: 1 }],
+                  payload: { id: "later-result" },
+                },
+              ],
+            },
+            headers: {},
+          };
+        }
+        innerHasMoreResults = false;
+        return {
+          result: { buffer: [] },
+          headers: {},
+        };
+      },
+    } as ExecutionContext;
+    const component = new NonStreamingOrderByEndpointComponent(
+      mockExecutionContext,
+      ["Ascending"],
+      10,
+    );
+
+    const firstResponse = await component.fetchMore();
+    assert.deepStrictEqual(firstResponse.result.buffer, []);
+    assert.isTrue(component.hasMoreResults());
+
+    const secondResponse = await component.fetchMore();
+    assert.deepStrictEqual(secondResponse.result.buffer, []);
+    assert.isTrue(component.hasMoreResults());
+
+    const finalResponse = await component.fetchMore();
+    assert.deepStrictEqual(finalResponse.result.buffer, [{ id: "later-result" }]);
+    assert.equal(fetchCount, 3);
+    assert.isFalse(component.hasMoreResults());
+  });
+
+  it("should stop reporting results after local completion", async () => {
+    let fetchCount = 0;
+    const mockExecutionContext = {
+      hasMoreResults: () => true,
+      fetchMore: async () => {
+        fetchCount++;
+        return undefined as never;
+      },
+    } as ExecutionContext;
+    const component = new NonStreamingOrderByEndpointComponent(
+      mockExecutionContext,
+      ["Ascending"],
+      10,
+    );
+
+    const response = await component.fetchMore();
+    assert.isUndefined(response.result);
+    assert.isFalse(component.hasMoreResults());
+
+    const responseAfterCompletion = await component.fetchMore();
+    assert.isUndefined(responseAfterCompletion.result);
+    assert.equal(fetchCount, 1);
+  });
 });

--- a/sdk/cosmosdb/cosmos/test/public/integration/nonStreamingOrderBy/emptyPageWithContinuationToken.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/nonStreamingOrderBy/emptyPageWithContinuationToken.spec.ts
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+  Container,
+  IndexingPolicy,
+  Next,
+  Plugin,
+  RequestContext,
+  SqlQuerySpec,
+} from "../../../../src/index.js";
+import { CosmosClient, OperationType, ResourceType } from "../../../../src/index.js";
+import { endpoint } from "../../common/_testConfig.js";
+import { masterKey } from "../../common/_fakeTestSecrets.js";
+import { getTestContainer, removeAllDatabases } from "../../common/TestHelpers.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface QueryResponseBody {
+  Documents?: unknown[];
+}
+
+interface SerializedQuery {
+  query: string;
+}
+
+describe("NSOB empty page with continuation token", { timeout: 60000 }, () => {
+  const continuationHeader = "x-ms-continuation";
+  const itemCount = 6;
+  const maxIteratorPages = 20;
+  let armed = false;
+  let injected = false;
+  let interceptedToken: string | undefined;
+  let removedDocumentCount = 0;
+  let tokenReuseSucceeded = false;
+  let sawLaterDocuments = false;
+  let rewrittenRequestCount = 0;
+  let container: Container;
+
+  const emptyOneTokenBearingPage: Plugin<QueryResponseBody> = async (
+    context: RequestContext,
+    _diagnosticNode,
+    next: Next<QueryResponseBody>,
+  ) => {
+    const isTargetQuery =
+      armed &&
+      context.operationType === OperationType.Query &&
+      context.resourceType === ResourceType.item &&
+      context.path?.includes(`/colls/${encodeURIComponent(container.id)}/docs`) === true;
+
+    if (!isTargetQuery) {
+      return next(context);
+    }
+
+    if (typeof context.body === "string") {
+      const request = JSON.parse(context.body) as SerializedQuery;
+      if (request.query.includes("_FullTextScore") && request.query.includes(" AS orderByItems")) {
+        request.query =
+          'SELECT c._rid, [{"item": c.id}] AS orderByItems, ' +
+          '{"payload": {"id": c.id, "body": c.body}, "componentScores": []} AS payload ' +
+          "FROM c WHERE c.category = @category";
+        context.body = JSON.stringify(request);
+        rewrittenRequestCount++;
+      }
+    }
+
+    const outgoingToken = context.headers?.[continuationHeader];
+    const reusesInterceptedToken =
+      interceptedToken !== undefined && outgoingToken === interceptedToken;
+    const response = await next(context);
+    const documents = response.result?.Documents;
+    const responseToken = response.headers[continuationHeader];
+
+    if (reusesInterceptedToken) {
+      tokenReuseSucceeded = true;
+    }
+
+    if (injected && Array.isArray(documents) && documents.length > 0) {
+      sawLaterDocuments = true;
+    }
+
+    if (
+      !injected &&
+      Array.isArray(documents) &&
+      documents.length > 0 &&
+      typeof responseToken === "string" &&
+      responseToken.length > 0
+    ) {
+      interceptedToken = responseToken;
+      removedDocumentCount = documents.length;
+      response.result.Documents = [];
+      injected = true;
+    }
+
+    return response;
+  };
+
+  const client = new CosmosClient({
+    endpoint,
+    key: masterKey,
+    plugins: [{ on: "request", plugin: emptyOneTokenBearingPage }],
+  });
+
+  beforeAll(async () => {
+    await removeAllDatabases(client);
+    const indexingPolicy: IndexingPolicy = {
+      automatic: true,
+      includedPaths: [{ path: "/*" }],
+      excludedPaths: [{ path: '/"_etag"/?' }],
+      fullTextIndexes: [{ path: "/body" }],
+    };
+    container = await getTestContainer("NSOB empty token page", client, {
+      partitionKey: { paths: ["/category"] },
+      indexingPolicy,
+      fullTextPolicy: {
+        defaultLanguage: "en-US",
+        fullTextPaths: [{ path: "/body", language: "en-US" }],
+      },
+    });
+
+    await Promise.all(
+      Array.from({ length: itemCount }, (_, index) =>
+        container.items.create({
+          id: `item-${index}`,
+          category: "target",
+          body: index % 2 === 0 ? "swim and run" : "run and swim",
+        }),
+      ),
+    );
+  });
+
+  afterAll(async () => {
+    armed = false;
+    await removeAllDatabases(client);
+    client.dispose();
+  });
+
+  it("continues with the same token and returns later pages", async () => {
+    const query: SqlQuerySpec = {
+      query:
+        "SELECT TOP 6 c.id, c.body FROM c " +
+        "WHERE c.category = @category " +
+        "ORDER BY RANK FullTextScore(c.body, 'swim', 'run')",
+      parameters: [{ name: "@category", value: "target" }],
+    };
+    const iterator = container.items.query<{ id: string }>(query, {
+      forceQueryPlan: true,
+      maxItemCount: 1,
+    });
+    const resultIds: string[] = [];
+    let iteratorPages = 0;
+    armed = true;
+
+    while (iterator.hasMoreResults()) {
+      expect(iteratorPages).toBeLessThan(maxIteratorPages);
+      const response = await iterator.fetchNext();
+      iteratorPages++;
+      resultIds.push(...response.resources.map((item) => item.id));
+    }
+
+    expect(rewrittenRequestCount).toBeGreaterThan(0);
+    expect(injected).toBe(true);
+    expect(interceptedToken).toBeDefined();
+    expect(tokenReuseSucceeded).toBe(true);
+    expect(sawLaterDocuments).toBe(true);
+    expect(resultIds).toHaveLength(itemCount - removedDocumentCount);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/cosmos`

### Problem

The non-streaming ORDER BY endpoints currently treat every empty backend page as terminal. An empty page can still have more pages available through the underlying execution context, so completing immediately can skip later results.

The endpoints also need to stop reporting more results after their own completion state is reached, even if the underlying context still reports more results.

### Changes

- Make `hasMoreResults()` respect `isCompleted` in both regular and distinct NSOB endpoint components.
- Mark an empty result as complete only after the underlying execution context is exhausted.
- Apply the same behavior to `NonStreamingOrderByEndpointComponent` and `NonStreamingOrderByDistinctEndpointComponent`.
- Add deterministic regression tests for intermediate empty pages and local completion in both components.
- Add a request-plugin integration test that preserves a real service continuation token on an injected empty page and verifies exact token reuse, later results, and bounded completion.

Related to #39626 and #39627.