### PR TITLE
[search] Fix platform stream typings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28887,7 +28887,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       '@azure/core-sse':
-        specifier: ^2.1.3
+        specifier: ^2.4.0
         version: link:../../core/core-sse
       '@azure/core-tracing':
         specifier: ^1.2.0

--- a/sdk/search/search-documents/config/tsconfig.src.browser.json
+++ b/sdk/search/search-documents/config/tsconfig.src.browser.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../../../eng/tsconfigs/src.browser.json",
   "compilerOptions": {
-    // @azure/core-sse ships type declarations that reference Node globals even in its browser
-    // entrypoint, which the browser src build (types: []) cannot resolve.
-    "skipLibCheck": true
+    "lib": ["DOM", "ES2023", "ESNext.Disposable"]
   },
   "include": [
     "../src/events.d.ts",

--- a/sdk/search/search-documents/config/tsconfig.src.react-native.json
+++ b/sdk/search/search-documents/config/tsconfig.src.react-native.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../../../eng/tsconfigs/src.react-native.json",
   "compilerOptions": {
-    "types": ["node"],
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2023", "ESNext.Disposable"],
+    // React Native redeclares several DOM globals, but API Extractor needs the DOM
+    // ReadableStream declaration to analyze the public FileContents type.
     "skipLibCheck": true
   },
   "include": [

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -74,7 +74,7 @@
     "@azure-rest/core-client": "^2.3.1",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
-    "@azure/core-sse": "^2.1.3",
+    "@azure/core-sse": "^2.4.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.2.0",
     "tslib": "^2.8.1"

--- a/sdk/search/search-documents/warp.config.yml
+++ b/sdk/search/search-documents/warp.config.yml
@@ -19,11 +19,9 @@ exports:
 targets:
   - name: browser
     tsconfig: "./config/tsconfig.src.browser.json"
-    polyfillSuffix: "-browser"
 
   - name: react-native
     tsconfig: "./config/tsconfig.src.react-native.json"
-    polyfillSuffix: "-react-native"
 
   - name: esm
     condition: import


### PR DESCRIPTION
This is stacked on #39459 to show an alternative to disabling declaration checking for the new SSE dependency.

I noticed the browser config attributed the failure to Node globals from `@azure/core-sse` and enabled `skipLibCheck`. After tracing this through Warp and the published Core SSE declarations, there are two separate issues:

- `@azure/core-sse` did not ship platform-specific Node stream declarations until `2.4.0`. Search Documents already uses Warp's `#platform/*` import resolution, so requiring that version lets browser and React Native builds resolve the appropriate declarations.
- The remaining browser error is `AsyncDisposable`, which can be supplied explicitly through `ESNext.Disposable` without disabling library checking.

This PR therefore:

- Raises the minimum `@azure/core-sse` version to `2.4.0`.
- Adds `ESNext.Disposable` to the browser and React Native target libraries.
- Removes the React Native override that replaced its ambient types with Node types.
- Removes the reintroduced `polyfillSuffix` settings; the package was already migrated to Warp's standards-based `#platform/*` imports.

React Native still needs `skipLibCheck` because its ambient declarations intentionally overlap with DOM globals, while API Extractor needs the DOM `ReadableStream` declaration to analyze the public `FileContents` type. The browser build no longer skips declaration checking.

I ran the Search Documents browser and React Native type checks, the filtered Turbo build, and the local build/browser-test/node-test checks.
