### PR TITLE
[EngSys] skip deprecated versions in dependency upgrade checks

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -133,6 +133,11 @@ foreach ($update in $availableUpdates.PSObject.Properties) {
         continue
       }
 
+      if ($p.IsDeprecated) {
+        Write-Host "Skipping deprecated version for $($p.Name): $($p.NewVersion)."
+        continue
+      }
+
       Write-Host $update.Name, $update.Value.'wanted', $update.Value.'latest'
       Set-GitHubIssue -Package $p
       Start-Sleep -s 5


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Prevent the weekly dependency automation from recommending deprecated package versions.

### Packages impacted by this PR

N/A - engineering automation only.

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

`pnpm outdated` can report a newer version that is marked as deprecated. The weekly dependency check previously filtered prerelease versions but could still file an upgrade issue for a deprecated target.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Skip entries whose existing `isDeprecated` metadata is true before calling the issue creation logic. This uses the registry metadata already returned by `pnpm outdated` and avoids an additional registry request.

### Are there test cases added in this PR? _(If not, why?)_

No. This script has no dedicated test harness, and the change is a direct conditional over existing `pnpm outdated` output metadata.

### Provide a list of related PRs _(if any)_

N/A

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here.)_
- [x] Added a changelog (if necessary).