### PR TITLE
Wire OneSettings to internal Statsbeat

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Other Changes
 
+- Wired the OneSettings `FEATURE_SDK_STATS` setting to dynamically stop and restart process-wide internal Network and Long Interval Statsbeat.
 - Enabled process-wide OneSettings polling from exporter initialization and populated the standalone exporter profile for future feature targeting. Feature callbacks remain disabled. [#39764](https://github.com/Azure/azure-sdk-for-js/pull/39764)
 - Refactored internal Network and Long Interval Statsbeat lifecycle management behind a process-global manager. [#39693](https://github.com/Azure/azure-sdk-for-js/pull/39693)
 - Updated OpenTelemetry stable dependencies to `^2.10.0`, experimental dependencies to `^0.221.0`, and semantic conventions to `^1.43.0`. [#39649](https://github.com/Azure/azure-sdk-for-js/pull/39649)

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Other Changes
 
-- Wired the OneSettings `FEATURE_SDK_STATS` setting to dynamically stop and restart process-wide internal Network and Long Interval Statsbeat.
+- Wired the OneSettings `FEATURE_SDK_STATS` setting to dynamically stop and restart process-wide internal Network and Long Interval Statsbeat. [#39807](https://github.com/Azure/azure-sdk-for-js/pull/39807)
 - Enabled process-wide OneSettings polling from exporter initialization and populated the standalone exporter profile for future feature targeting. Feature callbacks remain disabled. [#39764](https://github.com/Azure/azure-sdk-for-js/pull/39764)
 - Refactored internal Network and Long Interval Statsbeat lifecycle management behind a process-global manager. [#39693](https://github.com/Azure/azure-sdk-for-js/pull/39693)
 - Updated OpenTelemetry stable dependencies to `^2.10.0`, experimental dependencies to `^0.221.0`, and semantic conventions to `^1.43.0`. [#39649](https://github.com/Azure/azure-sdk-for-js/pull/39649)

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -316,7 +316,7 @@ export const ONE_SETTINGS_MAX_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
  */
 export const ONE_SETTINGS_BACKOFF_BASE_MS = 3600 * 1000;
 /**
- * OneSettings feature key that gates customer-facing SDK stats.
+ * OneSettings feature key that gates internal SDK stats.
  * @internal
  */
 export const ONE_SETTINGS_FEATURE_SDK_STATS = "FEATURE_SDK_STATS";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/featureEvaluation.ts
@@ -32,16 +32,16 @@ type ValueConverter<T> = (value: string) => T;
  */
 export function evaluateFeature<T>(
   featureKey: string,
-  settings: Record<string, unknown>,
+  settings: Readonly<Record<string, unknown>>,
   valueConverter: ValueConverter<T>,
 ): T | undefined;
 export function evaluateFeature(
   featureKey: string,
-  settings: Record<string, unknown>,
+  settings: Readonly<Record<string, unknown>>,
 ): boolean | string | undefined;
 export function evaluateFeature<T>(
   featureKey: string,
-  settings: Record<string, unknown>,
+  settings: Readonly<Record<string, unknown>>,
   valueConverter?: ValueConverter<T>,
 ): boolean | string | T | undefined {
   if (!featureKey || !isRecord(settings) || !Object.hasOwn(settings, featureKey)) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatManager.ts
@@ -4,6 +4,10 @@
 import { LongIntervalStatsbeatMetrics } from "./longIntervalStatsbeatMetrics.js";
 import { NetworkStatsbeatMetrics } from "./networkStatsbeatMetrics.js";
 import type { StatsbeatOptions } from "./types.js";
+import { ONE_SETTINGS_FEATURE_SDK_STATS } from "../../Declarations/Constants.js";
+import type { ConfigurationChangeCallback } from "../../_configuration/configurationManager.js";
+import { ConfigurationManager } from "../../_configuration/configurationManager.js";
+import { evaluateFeature } from "../../_configuration/featureEvaluation.js";
 
 /**
  * Coordinates the process-wide internal Statsbeat providers.
@@ -16,6 +20,17 @@ export class StatsbeatManager {
   private longIntervalMetrics: LongIntervalStatsbeatMetrics | undefined;
   private shutdownPromise: Promise<void> | undefined;
   private shouldBeRunning = false;
+  private oneSettingsEnabled: boolean | undefined;
+  private configurationCallbackRegistered = false;
+  private readonly configurationCallback: ConfigurationChangeCallback = async (settings) => {
+    this.oneSettingsEnabled =
+      evaluateFeature(ONE_SETTINGS_FEATURE_SDK_STATS, settings) === true;
+    if (this.oneSettingsEnabled) {
+      this.initialize();
+    } else {
+      await this.shutdown();
+    }
+  };
 
   private constructor() {}
 
@@ -27,7 +42,6 @@ export class StatsbeatManager {
   }
 
   public initialize(options?: StatsbeatOptions): void {
-    this.shouldBeRunning = true;
     if (this.networkMetrics && this.longIntervalMetrics) {
       return;
     }
@@ -36,6 +50,12 @@ export class StatsbeatManager {
       this.options = { ...options };
     }
     if (!this.options) {
+      return;
+    }
+
+    this.registerConfigurationCallback();
+    this.shouldBeRunning = this.oneSettingsEnabled !== false;
+    if (!this.shouldBeRunning || (this.networkMetrics && this.longIntervalMetrics)) {
       return;
     }
     if (this.shutdownPromise) {
@@ -126,6 +146,14 @@ export class StatsbeatManager {
     }
     this.networkMetrics = NetworkStatsbeatMetrics.getInstance(this.options);
     this.longIntervalMetrics = LongIntervalStatsbeatMetrics.getInstance(this.options);
+  }
+
+  private registerConfigurationCallback(): void {
+    if (this.configurationCallbackRegistered) {
+      return;
+    }
+    this.configurationCallbackRegistered = true;
+    ConfigurationManager.getInstance().registerCallback(this.configurationCallback);
   }
 
   private async shutdownProviders(

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatManager.ts
@@ -23,8 +23,7 @@ export class StatsbeatManager {
   private oneSettingsEnabled: boolean | undefined;
   private configurationCallbackRegistered = false;
   private readonly configurationCallback: ConfigurationChangeCallback = async (settings) => {
-    this.oneSettingsEnabled =
-      evaluateFeature(ONE_SETTINGS_FEATURE_SDK_STATS, settings) === true;
+    this.oneSettingsEnabled = evaluateFeature(ONE_SETTINGS_FEATURE_SDK_STATS, settings) === true;
     if (this.oneSettingsEnabled) {
       this.initialize();
     } else {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeatManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeatManager.spec.ts
@@ -27,6 +27,10 @@ const providerMocks = vi.hoisted(() => {
   };
 });
 
+const configurationMocks = vi.hoisted(() => ({
+  registerCallback: vi.fn(),
+}));
+
 vi.mock("../../src/export/statsbeat/networkStatsbeatMetrics.js", () => ({
   NetworkStatsbeatMetrics: {
     getInstance: providerMocks.getNetworkInstance,
@@ -39,8 +43,21 @@ vi.mock("../../src/export/statsbeat/longIntervalStatsbeatMetrics.js", () => ({
   },
 }));
 
+vi.mock("../../src/_configuration/configurationManager.js", () => ({
+  ConfigurationManager: {
+    getInstance: vi.fn(() => configurationMocks),
+  },
+}));
+
 import { StatsbeatManager } from "../../src/export/statsbeat/statsbeatManager.js";
 import { AzureMonitorTraceExporter } from "../../src/export/trace.js";
+import type { ConfigurationChangeCallback } from "../../src/_configuration/configurationManager.js";
+
+function getConfigurationCallback(): ConfigurationChangeCallback {
+  const callback = configurationMocks.registerCallback.mock.calls[0]?.[0];
+  expect(callback).toBeTypeOf("function");
+  return callback;
+}
 
 describe("StatsbeatManager", () => {
   const options = {
@@ -69,6 +86,70 @@ describe("StatsbeatManager", () => {
     expect(providerMocks.getLongIntervalInstance).toHaveBeenCalledOnce();
     expect(manager.networkStatsbeatMetrics).toBe(providerMocks.network);
     expect(manager.longIntervalStatsbeatMetrics).toBe(providerMocks.longInterval);
+  });
+
+  it("registers the OneSettings callback once", () => {
+    const manager = StatsbeatManager.getInstance();
+
+    manager.initialize(options);
+    manager.initialize(options);
+
+    expect(configurationMocks.registerCallback).toHaveBeenCalledOnce();
+  });
+
+  it("does not duplicate registration when cached enabled settings are replayed", () => {
+    configurationMocks.registerCallback.mockImplementationOnce(
+      (callback: ConfigurationChangeCallback) => {
+        void callback({ FEATURE_SDK_STATS: '{"default":"enabled"}' });
+      },
+    );
+    const manager = StatsbeatManager.getInstance();
+
+    manager.initialize(options);
+
+    expect(configurationMocks.registerCallback).toHaveBeenCalledOnce();
+    expect(providerMocks.getNetworkInstance).toHaveBeenCalledOnce();
+    expect(providerMocks.getLongIntervalInstance).toHaveBeenCalledOnce();
+  });
+
+  it("stops and restarts internal Statsbeat when OneSettings changes", async () => {
+    const manager = StatsbeatManager.getInstance();
+    manager.initialize(options);
+    const callback = getConfigurationCallback();
+
+    await callback({ FEATURE_SDK_STATS: '{"default":"disabled"}' });
+
+    expect(providerMocks.network.shutdown).toHaveBeenCalledOnce();
+    expect(providerMocks.longInterval.shutdown).toHaveBeenCalledOnce();
+    expect(manager.networkStatsbeatMetrics).toBeUndefined();
+    expect(manager.longIntervalStatsbeatMetrics).toBeUndefined();
+
+    manager.initialize(options);
+    expect(providerMocks.getNetworkInstance).toHaveBeenCalledOnce();
+    expect(providerMocks.getLongIntervalInstance).toHaveBeenCalledOnce();
+
+    await callback({ FEATURE_SDK_STATS: '{"default":"enabled"}' });
+
+    expect(providerMocks.getNetworkInstance).toHaveBeenCalledTimes(2);
+    expect(providerMocks.getLongIntervalInstance).toHaveBeenCalledTimes(2);
+    expect(manager.networkStatsbeatMetrics).toBe(providerMocks.network);
+    expect(manager.longIntervalStatsbeatMetrics).toBe(providerMocks.longInterval);
+  });
+
+  it.each([
+    ["missing", { unrelated: "setting" }],
+    ["invalid", { FEATURE_SDK_STATS: "not-json" }],
+  ])("stops internal Statsbeat when the OneSettings feature is %s", async (_, settings) => {
+    const manager = StatsbeatManager.getInstance();
+    manager.initialize(options);
+    const callback = getConfigurationCallback();
+
+    await callback(settings);
+
+    expect(providerMocks.network.shutdown).toHaveBeenCalledOnce();
+    expect(providerMocks.longInterval.shutdown).toHaveBeenCalledOnce();
+    expect(manager.networkStatsbeatMetrics).toBeUndefined();
+    expect(manager.longIntervalStatsbeatMetrics).toBeUndefined();
   });
 
   it("coordinates shutdown and restarts with the last configuration", async () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeatManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeatManager.spec.ts
@@ -28,6 +28,7 @@ const providerMocks = vi.hoisted(() => {
 });
 
 const configurationMocks = vi.hoisted(() => ({
+  initialize: vi.fn(),
   registerCallback: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- `FEATURE_SDK_STATS` dynamically stops and restarts process-wide internal Network and Long Interval Statsbeat.
- Callback registration is replay-safe and preserves remote-disable state.
- Feature evaluation accepts read-only settings.

## Test
- `pnpm check-format`
- `pnpm lint`
- `pnpm test:node`
- `pnpm turbo build --filter=@azure/monitor-opentelemetry-exporter... --token 1`