### PR TITLE
[identity] Don't force a new browser instance when opening the auth page

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed `AzurePipelinesCredential` to include only relevant details in error messages and logs when the OIDC token request fails. [#39774](https://github.com/Azure/azure-sdk-for-js/pull/39774)
+- Fixed `InteractiveBrowserCredential` failing to authenticate when the user's default browser is already running and only permits a single instance. The browser is no longer launched with `newInstance`, which on macOS passed `open --new`.
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixed `AzurePipelinesCredential` to include only relevant details in error messages and logs when the OIDC token request fails. [#39774](https://github.com/Azure/azure-sdk-for-js/pull/39774)
-- Fixed `InteractiveBrowserCredential` failing to authenticate when the user's default browser is already running and only permits a single instance. The browser is no longer launched with `newInstance`, which on macOS passed `open --new`.
+- Fixed `InteractiveBrowserCredential` failing to authenticate when the user's default browser is already running and only permits a single instance. The browser is no longer launched with `newInstance`, which on macOS passed `open --new`. [#39814](https://github.com/Azure/azure-sdk-for-js/pull/39814)
 
 ### Other Changes
 

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -780,7 +780,7 @@ export function createMsalClient(
     return {
       openBrowser: async (url) => {
         const open = await import("open");
-        await open.default(url, { newInstance: true });
+        await open.default(url);
       },
       scopes,
       authority: calculateRequestAuthority(options),


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/identity`

### Issues associated with this PR

None found — I searched open issues and did not see this reported. Related to #35406, which removed the `wait` option this flag existed to support.

### Describe the problem that is addressed by this PR

`InteractiveBrowserCredential` launches the auth page with:

```ts
await open.default(url, { newInstance: true });
```

On macOS `newInstance: true` becomes `open --new`, which forces a **new browser instance**. Single-instance browsers refuse that. [Arc](https://arc.net/) shows:

> Arc is already open. Only one instance of Arc can be opened at a time.

and never navigates to the auth URL.

The failure mode is worse than an error: `open --new` still **exits 0** in that case, so nothing throws. Authentication hangs waiting for a redirect that will never arrive. The user cannot authenticate at all without first quitting their browser.

Safari is affected too, more quietly — with the flag it opens on `favorites://` rather than the requested URL.

### What are the possible designs available to address the problem?

`newInstance` was only ever there to support `wait: true`: `open` needs its own browser instance to have a process to wait on. #35406 ("[identity] Avoid waiting for app to close") removed `wait`, correctly noting that MSAL should regain control as soon as the browser opens rather than when it closes. That PR left `newInstance` behind.

With `wait` gone, `newInstance` serves no purpose — nothing waits on the spawned process any more — and it actively breaks single-instance browsers. Removing it restores the default behaviour of handing the URL to the running browser.

Alternatives considered:

- **Expose `openBrowser` as a credential option** so callers can supply their own launcher. More flexible, but a public API addition for what is a straightforward bug, and it would leave the default broken.
- **Detect single-instance browsers and branch.** Fragile and unbounded — the set of such browsers is not knowable.

Removing the flag is the smallest change that fixes the default path for everyone.

### Are there test cases added in this PR? _(If not, why?)_

No. The change removes an argument to a dynamically imported third-party module inside `openBrowser`, which is invoked by MSAL during an interactive flow — there is no existing unit-test seam for it, and asserting "we called `open` without options" would test the mock rather than the behaviour. The real behaviour is whether a browser navigates, which needs the manual matrix below.

Verified manually on macOS 15 against the `open` package directly:

| Browser | `{ newInstance: true }` | no options |
|---|---|---|
| Arc | Shows "Arc is already open" dialog, does not navigate | Navigates correctly |
| Safari | Opens on `favorites://` | Navigates correctly |

Happy to add a test if maintainers can point me at the right seam.

### Provide a list of related PRs _(if any)_

- #35406 — [identity] Avoid waiting for app to close (removed `wait`, left `newInstance`)

### Checklists

- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? — no
- [x] Added a changelog (if necessary)