### PR TITLE
[Monitor OpenTelemetry Exporter] Align availability distributed tracing and timestamps

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-- Preserved operation, session, user, device, and synthetic-source context tags on OpenTelemetry log records, including availability telemetry, for correlation behavior. [#39734](https://github.com/Azure/azure-sdk-for-js/pull/39734)
+- Preserved operation, session, user, device, and synthetic-source context tags on OpenTelemetry log records, including availability telemetry, for correlation behavior. [#39818](https://github.com/Azure/azure-sdk-for-js/pull/39818)
 - Fixed global-to-regional ingestion redirects across trusted same-cloud Azure Monitor host suffixes and updated internal Statsbeat routing so EU SDK statistics use the EU Statsbeat destination. [#39622](https://github.com/Azure/azure-sdk-for-js/pull/39622)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-- Preserved operation, session, user, device, and synthetic-source context tags on OpenTelemetry log records, including availability telemetry, for correlation behavior. [#39818](https://github.com/Azure/azure-sdk-for-js/pull/39818)
+- Mapped the .NET-aligned set of operation, session, user, device, and synthetic-source log attributes to Application Insights context tags, including for availability telemetry. [#39818](https://github.com/Azure/azure-sdk-for-js/pull/39818)
 - Fixed global-to-regional ingestion redirects across trusted same-cloud Azure Monitor host suffixes and updated internal Statsbeat routing so EU SDK statistics use the EU Statsbeat destination. [#39622](https://github.com/Azure/azure-sdk-for-js/pull/39622)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Bugs Fixed
 
-- Mapped the .NET-aligned set of operation, session, user, device, and synthetic-source log attributes to Application Insights context tags, including for availability telemetry. [#39818](https://github.com/Azure/azure-sdk-for-js/pull/39818)
 - Fixed global-to-regional ingestion redirects across trusted same-cloud Azure Monitor host suffixes and updated internal Statsbeat routing so EU SDK statistics use the EU Statsbeat destination. [#39622](https://github.com/Azure/azure-sdk-for-js/pull/39622)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- Removed `microsoft.availability.testTimestamp` support so availability telemetry uses the OpenTelemetry log record timestamp. [#39818](https://github.com/Azure/azure-sdk-for-js/pull/39818)
 - Fixed global-to-regional ingestion redirects across trusted same-cloud Azure Monitor host suffixes and updated internal Statsbeat routing so EU SDK statistics use the EU Statsbeat destination. [#39622](https://github.com/Azure/azure-sdk-for-js/pull/39622)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- Preserved operation, session, user, device, and synthetic-source context tags on OpenTelemetry log records, including availability telemetry, for correlation behavior. [#39734](https://github.com/Azure/azure-sdk-for-js/pull/39734)
 - Fixed global-to-regional ingestion redirects across trusted same-cloud Azure Monitor host suffixes and updated internal Statsbeat routing so EU SDK statistics use the EU Statsbeat destination. [#39622](https://github.com/Azure/azure-sdk-for-js/pull/39622)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -139,25 +139,6 @@ The following attributes are required:
 
 Availability records use the same correlation context as other OpenTelemetry logs. When a record is emitted with an active span (or an explicit OpenTelemetry context), the span trace ID and span ID populate the Application Insights operation ID and parent ID. These values are authoritative and cannot be overridden by log attributes. The availability test-run ID remains separate from the operation ID.
 
-The following log attributes map to Application Insights context tags, matching the .NET Azure Monitor OpenTelemetry exporter:
-
-| Log attribute | Application Insights context tag |
-| --- | --- |
-| `microsoft.operation_name` | `ai.operation.name` |
-| `microsoft.session.id` | `ai.session.id` |
-| `microsoft.client.ip` | `ai.location.ip` |
-| `enduser.pseudo.id` | `ai.user.id` |
-| `enduser.id` | `ai.user.authUserId` |
-| `user_agent.original` | `ai.user.userAgent` |
-| `ai.device.id` | `ai.device.id` |
-| `ai.device.model` | `ai.device.model` |
-| `ai.device.type` | `ai.device.type` |
-| `ai.device.osVersion` | `ai.device.osVersion` |
-| `microsoft.synthetic_source` | `ai.operation.syntheticSource` |
-| `microsoft.user.account_id` | `ai.user.accountId` |
-
-For backward compatibility, `ai.operation.name` remains a fallback when `microsoft.operation_name` is absent, and `user_agent.synthetic.type` continues to set `ai.operation.syntheticSource` to `True` when `microsoft.synthetic_source` is absent. Other `ai.*` log attributes remain custom dimensions rather than overriding context tags.
-
 If any required attribute is missing or empty, the exporter sends the record as regular message telemetry instead. Exception and custom event attributes take precedence over availability attributes.
 
 ### Sampling

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -121,7 +121,6 @@ logger.emit({
     "microsoft.availability.success": true,
     "microsoft.availability.runLocation": "westus2",
     "microsoft.availability.message": "HTTP 200",
-    "microsoft.availability.testTimestamp": new Date().toISOString(),
   },
 });
 ```
@@ -135,7 +134,7 @@ The following attributes are required:
 | `microsoft.availability.duration` | Test duration, for example `00:00:00.250`. |
 | `microsoft.availability.success` | Whether the test succeeded. |
 
-`microsoft.availability.runLocation`, `microsoft.availability.message`, and `microsoft.availability.testTimestamp` are optional. The timestamp must be an ISO 8601 string and overrides the log record time when valid. If the message attribute is omitted, the log body is used as the availability message.
+`microsoft.availability.runLocation` and `microsoft.availability.message` are optional. If the message attribute is omitted, the log body is used as the availability message. The availability result timestamp comes from the OpenTelemetry log record.
 
 Availability records use the same correlation context as other OpenTelemetry logs. When a record is emitted with an active span (or an explicit OpenTelemetry context), the span trace ID and span ID populate the Application Insights operation ID and parent ID. These values are authoritative and cannot be overridden by log attributes. The availability test-run ID remains separate from the operation ID.
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -137,6 +137,8 @@ The following attributes are required:
 
 `microsoft.availability.runLocation`, `microsoft.availability.message`, and `microsoft.availability.testTimestamp` are optional. The timestamp must be an ISO 8601 string and overrides the log record time when valid. If the message attribute is omitted, the log body is used as the availability message.
 
+Availability records use the same correlation context as other OpenTelemetry logs. When a record is emitted with an active span (or an explicit OpenTelemetry context), the span trace ID and span ID populate the Application Insights operation ID and parent ID. For migration from the Application Insights Node.js 2.x SDK, legacy `ai.*` context-tag attributes are also honored as explicit overrides. The exporter maps `microsoft.operation_name`, `microsoft.session.id`, `microsoft.synthetic_source`, `microsoft.user.account_id`, `enduser.id`, `enduser.pseudo.id`, and `user_agent.original` to their corresponding Application Insights context tags.
+
 If any required attribute is missing or empty, the exporter sends the record as regular message telemetry instead. Exception and custom event attributes take precedence over availability attributes.
 
 ### Sampling

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -137,7 +137,26 @@ The following attributes are required:
 
 `microsoft.availability.runLocation`, `microsoft.availability.message`, and `microsoft.availability.testTimestamp` are optional. The timestamp must be an ISO 8601 string and overrides the log record time when valid. If the message attribute is omitted, the log body is used as the availability message.
 
-Availability records use the same correlation context as other OpenTelemetry logs. When a record is emitted with an active span (or an explicit OpenTelemetry context), the span trace ID and span ID populate the Application Insights operation ID and parent ID. For migration from the Application Insights Node.js 2.x SDK, legacy `ai.*` context-tag attributes are also honored as explicit overrides. The exporter maps `microsoft.operation_name`, `microsoft.session.id`, `microsoft.synthetic_source`, `microsoft.user.account_id`, `enduser.id`, `enduser.pseudo.id`, and `user_agent.original` to their corresponding Application Insights context tags.
+Availability records use the same correlation context as other OpenTelemetry logs. When a record is emitted with an active span (or an explicit OpenTelemetry context), the span trace ID and span ID populate the Application Insights operation ID and parent ID. These values are authoritative and cannot be overridden by log attributes. The availability test-run ID remains separate from the operation ID.
+
+The following log attributes map to Application Insights context tags, matching the .NET Azure Monitor OpenTelemetry exporter:
+
+| Log attribute | Application Insights context tag |
+| --- | --- |
+| `microsoft.operation_name` | `ai.operation.name` |
+| `microsoft.session.id` | `ai.session.id` |
+| `microsoft.client.ip` | `ai.location.ip` |
+| `enduser.pseudo.id` | `ai.user.id` |
+| `enduser.id` | `ai.user.authUserId` |
+| `user_agent.original` | `ai.user.userAgent` |
+| `ai.device.id` | `ai.device.id` |
+| `ai.device.model` | `ai.device.model` |
+| `ai.device.type` | `ai.device.type` |
+| `ai.device.osVersion` | `ai.device.osVersion` |
+| `microsoft.synthetic_source` | `ai.operation.syntheticSource` |
+| `microsoft.user.account_id` | `ai.user.accountId` |
+
+For backward compatibility, `ai.operation.name` remains a fallback when `microsoft.operation_name` is absent, and `user_agent.synthetic.type` continues to set `ai.operation.syntheticSource` to `True` when `microsoft.synthetic_source` is absent. Other `ai.*` log attributes remain custom dimensions rather than overriding context tags.
 
 If any required attribute is missing or empty, the exporter sends the record as regular message telemetry instead. Exception and custom event attributes take precedence over availability attributes.
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/logSample.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples-dev/logSample.ts
@@ -56,7 +56,6 @@ export async function main(): Promise<void> {
       "microsoft.availability.success": true,
       "microsoft.availability.runLocation": "westus2",
       "microsoft.availability.message": "HTTP 200",
-      "microsoft.availability.testTimestamp": new Date().toISOString(),
     },
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/javascript/logSample.js
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/javascript/logSample.js
@@ -56,7 +56,6 @@ async function main() {
       "microsoft.availability.success": true,
       "microsoft.availability.runLocation": "westus2",
       "microsoft.availability.message": "HTTP 200",
-      "microsoft.availability.testTimestamp": new Date().toISOString(),
     },
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/typescript/src/logSample.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1-beta/typescript/src/logSample.ts
@@ -56,7 +56,6 @@ export async function main(): Promise<void> {
       "microsoft.availability.success": true,
       "microsoft.availability.runLocation": "westus2",
       "microsoft.availability.message": "HTTP 200",
-      "microsoft.availability.testTimestamp": new Date().toISOString(),
     },
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -46,7 +46,6 @@ export const ApplicationInsightsAvailabilityDuration = "microsoft.availability.d
 export const ApplicationInsightsAvailabilitySuccess = "microsoft.availability.success";
 export const ApplicationInsightsAvailabilityRunLocation = "microsoft.availability.runLocation";
 export const ApplicationInsightsAvailabilityMessage = "microsoft.availability.message";
-export const ApplicationInsightsAvailabilityTestTimestamp = "microsoft.availability.testTimestamp";
 export const MicrosoftClientIp = "microsoft.client.ip";
 
 export const ApplicationInsightsMessageName = "Microsoft.ApplicationInsights.Message";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -47,6 +47,10 @@ export const ApplicationInsightsAvailabilitySuccess = "microsoft.availability.su
 export const ApplicationInsightsAvailabilityRunLocation = "microsoft.availability.runLocation";
 export const ApplicationInsightsAvailabilityMessage = "microsoft.availability.message";
 export const ApplicationInsightsAvailabilityTestTimestamp = "microsoft.availability.testTimestamp";
+export const ApplicationInsightsOperationName = "microsoft.operation_name";
+export const ApplicationInsightsSessionId = "microsoft.session.id";
+export const ApplicationInsightsSyntheticSource = "microsoft.synthetic_source";
+export const ApplicationInsightsUserAccountId = "microsoft.user.account_id";
 export const MicrosoftClientIp = "microsoft.client.ip";
 
 export const ApplicationInsightsMessageName = "Microsoft.ApplicationInsights.Message";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -47,10 +47,6 @@ export const ApplicationInsightsAvailabilitySuccess = "microsoft.availability.su
 export const ApplicationInsightsAvailabilityRunLocation = "microsoft.availability.runLocation";
 export const ApplicationInsightsAvailabilityMessage = "microsoft.availability.message";
 export const ApplicationInsightsAvailabilityTestTimestamp = "microsoft.availability.testTimestamp";
-export const ApplicationInsightsOperationName = "microsoft.operation_name";
-export const ApplicationInsightsSessionId = "microsoft.session.id";
-export const ApplicationInsightsSyntheticSource = "microsoft.synthetic_source";
-export const ApplicationInsightsUserAccountId = "microsoft.user.account_id";
 export const MicrosoftClientIp = "microsoft.client.ip";
 
 export const ApplicationInsightsMessageName = "Microsoft.ApplicationInsights.Message";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -23,7 +23,6 @@ import {
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
   ATTR_EXCEPTION_TYPE,
-  ATTR_USER_AGENT_ORIGINAL,
 } from "@opentelemetry/semantic-conventions";
 import { experimentalOpenTelemetryValues } from "../types.js";
 import type { Measurements, Properties, Tags } from "../types.js";
@@ -48,72 +47,11 @@ import {
   ApplicationInsightsExceptionName,
   ApplicationInsightsMessageBaseType,
   ApplicationInsightsMessageName,
-  ApplicationInsightsOperationName,
   ApplicationInsightsPageViewBaseType,
   ApplicationInsightsPageViewName,
-  ApplicationInsightsSessionId,
-  ApplicationInsightsSyntheticSource,
-  ApplicationInsightsUserAccountId,
   DEFAULT_BREEZE_DATA_VERSION,
   MicrosoftClientIp,
 } from "./constants/applicationinsights.js";
-
-const ApplicationInsightsUserAgent = "ai.user.userAgent";
-
-const logContextTagMappings: readonly {
-  contextTagKey: KnownContextTagKeys;
-  attributeNames: readonly string[];
-}[] = [
-  {
-    contextTagKey: KnownContextTagKeys.AiOperationName,
-    attributeNames: [ApplicationInsightsOperationName, KnownContextTagKeys.AiOperationName],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiSessionId,
-    attributeNames: [ApplicationInsightsSessionId],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiDeviceId,
-    attributeNames: [KnownContextTagKeys.AiDeviceId],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiDeviceModel,
-    attributeNames: [KnownContextTagKeys.AiDeviceModel],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiDeviceType,
-    attributeNames: [KnownContextTagKeys.AiDeviceType],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiDeviceOSVersion,
-    attributeNames: [KnownContextTagKeys.AiDeviceOSVersion],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiOperationSyntheticSource,
-    attributeNames: [ApplicationInsightsSyntheticSource],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiUserAccountId,
-    attributeNames: [ApplicationInsightsUserAccountId],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiUserAuthUserId,
-    attributeNames: [experimentalOpenTelemetryValues.ATTR_ENDUSER_ID],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiUserId,
-    attributeNames: [experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID],
-  },
-  {
-    contextTagKey: KnownContextTagKeys.AiLocationIp,
-    attributeNames: [MicrosoftClientIp],
-  },
-];
-
-const logContextAttributeNames = new Set<string>([
-  ...logContextTagMappings.flatMap(({ attributeNames }) => attributeNames),
-  ATTR_USER_AGENT_ORIGINAL,
-]);
 
 /**
  * Log to Azure envelope parsing.
@@ -261,54 +199,45 @@ function getAttributeString(log: ReadableLogRecord, attributeName: string): stri
 
 function createTagsFromLog(log: ReadableLogRecord): Tags {
   const tags: Tags = createTagsFromResource(log.resource);
-  const attributes = log.attributes as Attributes;
-
   if (log.spanContext?.traceId) {
     tags[KnownContextTagKeys.AiOperationId] = log.spanContext.traceId;
   }
   if (log.spanContext?.spanId) {
     tags[KnownContextTagKeys.AiOperationParentId] = log.spanContext.spanId;
   }
-
-  for (const { contextTagKey, attributeNames } of logContextTagMappings) {
-    setContextTagFromAttributes(tags, attributes, contextTagKey, attributeNames);
+  if (log.attributes[KnownContextTagKeys.AiOperationName]) {
+    tags[KnownContextTagKeys.AiOperationName] = log.attributes[
+      KnownContextTagKeys.AiOperationName
+    ] as string;
   }
-
-  if (!tags[KnownContextTagKeys.AiOperationSyntheticSource] && isSyntheticSource(attributes)) {
+  if (isSyntheticSource(log.attributes as Attributes)) {
     tags[KnownContextTagKeys.AiOperationSyntheticSource] = "True";
   }
 
-  const userAgent = getContextAttribute(attributes, ATTR_USER_AGENT_ORIGINAL);
-  if (userAgent !== undefined) {
-    tags[ApplicationInsightsUserAgent] = userAgent;
+  // Set ai.location.ip from microsoft.client.ip if it exists
+  const microsoftClientIp = log.attributes?.[MicrosoftClientIp];
+  if (microsoftClientIp) {
+    tags[KnownContextTagKeys.AiLocationIp] = String(microsoftClientIp);
+  }
+
+  // Map user ID attributes
+  const attributes = log.attributes as Attributes;
+  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]) {
+    const endUserId = String(attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]);
+    if (endUserId && endUserId.length > 0) {
+      tags[KnownContextTagKeys.AiUserAuthUserId] = endUserId;
+    }
+  }
+  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]) {
+    const endUserPseudoId = String(
+      attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID],
+    );
+    if (endUserPseudoId && endUserPseudoId.length > 0) {
+      tags[KnownContextTagKeys.AiUserId] = endUserPseudoId;
+    }
   }
 
   return tags;
-}
-
-function setContextTagFromAttributes(
-  tags: Tags,
-  attributes: Attributes,
-  contextTagKey: KnownContextTagKeys,
-  attributeNames: readonly string[],
-): void {
-  for (const attributeName of attributeNames) {
-    const value = getContextAttribute(attributes, attributeName);
-    if (value !== undefined) {
-      tags[contextTagKey] = value;
-      return;
-    }
-  }
-}
-
-function getContextAttribute(attributes: Attributes, attributeName: string): string | undefined {
-  const value = attributes[attributeName];
-  if (value === undefined) {
-    return;
-  }
-
-  const stringValue = String(value);
-  return stringValue.length > 0 ? stringValue : undefined;
 }
 
 function createPropertiesFromLog(log: ReadableLogRecord): [Properties, Measurements] {
@@ -322,7 +251,7 @@ function createPropertiesFromLog(log: ReadableLogRecord): [Properties, Measureme
         key.startsWith("microsoft") ||
         legacySemanticValues.includes(key) ||
         httpSemanticValues.includes(key as any) ||
-        logContextAttributeNames.has(key)
+        key === (KnownContextTagKeys.AiOperationName as string)
       )) {
         properties[key] = serializeAttribute(log.attributes[key]);
       }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -60,37 +60,58 @@ import {
 
 const ApplicationInsightsUserAgent = "ai.user.userAgent";
 
-const legacyContextTagKeys: readonly KnownContextTagKeys[] = [
-  KnownContextTagKeys.AiApplicationVer,
-  KnownContextTagKeys.AiDeviceId,
-  KnownContextTagKeys.AiDeviceLocale,
-  KnownContextTagKeys.AiDeviceModel,
-  KnownContextTagKeys.AiDeviceOemName,
-  KnownContextTagKeys.AiDeviceOSVersion,
-  KnownContextTagKeys.AiDeviceType,
-  KnownContextTagKeys.AiLocationCountry,
-  KnownContextTagKeys.AiLocationIp,
-  KnownContextTagKeys.AiOperationCorrelationVector,
-  KnownContextTagKeys.AiOperationId,
-  KnownContextTagKeys.AiOperationName,
-  KnownContextTagKeys.AiOperationParentId,
-  KnownContextTagKeys.AiOperationSyntheticSource,
-  KnownContextTagKeys.AiSessionId,
-  KnownContextTagKeys.AiSessionIsFirst,
-  KnownContextTagKeys.AiUserAccountId,
-  KnownContextTagKeys.AiUserAuthUserId,
-  KnownContextTagKeys.AiUserId,
-  KnownContextTagKeys.AiCloudRole,
-  KnownContextTagKeys.AiCloudRoleInstance,
+const logContextTagMappings: readonly {
+  contextTagKey: KnownContextTagKeys;
+  attributeNames: readonly string[];
+}[] = [
+  {
+    contextTagKey: KnownContextTagKeys.AiOperationName,
+    attributeNames: [ApplicationInsightsOperationName, KnownContextTagKeys.AiOperationName],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiSessionId,
+    attributeNames: [ApplicationInsightsSessionId],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiDeviceId,
+    attributeNames: [KnownContextTagKeys.AiDeviceId],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiDeviceModel,
+    attributeNames: [KnownContextTagKeys.AiDeviceModel],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiDeviceType,
+    attributeNames: [KnownContextTagKeys.AiDeviceType],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiDeviceOSVersion,
+    attributeNames: [KnownContextTagKeys.AiDeviceOSVersion],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiOperationSyntheticSource,
+    attributeNames: [ApplicationInsightsSyntheticSource],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiUserAccountId,
+    attributeNames: [ApplicationInsightsUserAccountId],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiUserAuthUserId,
+    attributeNames: [experimentalOpenTelemetryValues.ATTR_ENDUSER_ID],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiUserId,
+    attributeNames: [experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID],
+  },
+  {
+    contextTagKey: KnownContextTagKeys.AiLocationIp,
+    attributeNames: [MicrosoftClientIp],
+  },
 ];
 
 const logContextAttributeNames = new Set<string>([
-  ...legacyContextTagKeys,
-  ApplicationInsightsOperationName,
-  ApplicationInsightsSessionId,
-  ApplicationInsightsSyntheticSource,
-  ApplicationInsightsUserAccountId,
-  ApplicationInsightsUserAgent,
+  ...logContextTagMappings.flatMap(({ attributeNames }) => attributeNames),
   ATTR_USER_AGENT_ORIGINAL,
 ]);
 
@@ -242,71 +263,22 @@ function createTagsFromLog(log: ReadableLogRecord): Tags {
   const tags: Tags = createTagsFromResource(log.resource);
   const attributes = log.attributes as Attributes;
 
-  for (const contextTagKey of legacyContextTagKeys) {
-    const value = getContextAttribute(attributes, contextTagKey);
-    if (value !== undefined) {
-      tags[contextTagKey] = value;
-    }
-  }
-
-  if (!tags[KnownContextTagKeys.AiOperationId] && log.spanContext?.traceId) {
+  if (log.spanContext?.traceId) {
     tags[KnownContextTagKeys.AiOperationId] = log.spanContext.traceId;
   }
-  if (!tags[KnownContextTagKeys.AiOperationParentId] && log.spanContext?.spanId) {
+  if (log.spanContext?.spanId) {
     tags[KnownContextTagKeys.AiOperationParentId] = log.spanContext.spanId;
   }
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiOperationName,
-    ApplicationInsightsOperationName,
-  );
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiSessionId,
-    ApplicationInsightsSessionId,
-  );
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiOperationSyntheticSource,
-    ApplicationInsightsSyntheticSource,
-  );
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiUserAccountId,
-    ApplicationInsightsUserAccountId,
-  );
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiUserAuthUserId,
-    experimentalOpenTelemetryValues.ATTR_ENDUSER_ID,
-  );
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiUserId,
-    experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID,
-  );
+
+  for (const { contextTagKey, attributeNames } of logContextTagMappings) {
+    setContextTagFromAttributes(tags, attributes, contextTagKey, attributeNames);
+  }
 
   if (!tags[KnownContextTagKeys.AiOperationSyntheticSource] && isSyntheticSource(attributes)) {
     tags[KnownContextTagKeys.AiOperationSyntheticSource] = "True";
   }
 
-  // Set ai.location.ip from microsoft.client.ip if it exists
-  setContextTagFromAttributes(
-    tags,
-    attributes,
-    KnownContextTagKeys.AiLocationIp,
-    MicrosoftClientIp,
-  );
-
-  const userAgent =
-    getContextAttribute(attributes, ApplicationInsightsUserAgent) ??
-    getContextAttribute(attributes, ATTR_USER_AGENT_ORIGINAL);
+  const userAgent = getContextAttribute(attributes, ATTR_USER_AGENT_ORIGINAL);
   if (userAgent !== undefined) {
     tags[ApplicationInsightsUserAgent] = userAgent;
   }
@@ -318,15 +290,14 @@ function setContextTagFromAttributes(
   tags: Tags,
   attributes: Attributes,
   contextTagKey: KnownContextTagKeys,
-  attributeName: string,
+  attributeNames: readonly string[],
 ): void {
-  if (getContextAttribute(attributes, contextTagKey) !== undefined) {
-    return;
-  }
-
-  const value = getContextAttribute(attributes, attributeName);
-  if (value !== undefined) {
-    tags[contextTagKey] = value;
+  for (const attributeName of attributeNames) {
+    const value = getContextAttribute(attributes, attributeName);
+    if (value !== undefined) {
+      tags[contextTagKey] = value;
+      return;
+    }
   }
 }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -23,6 +23,7 @@ import {
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
   ATTR_EXCEPTION_TYPE,
+  ATTR_USER_AGENT_ORIGINAL,
 } from "@opentelemetry/semantic-conventions";
 import { experimentalOpenTelemetryValues } from "../types.js";
 import type { Measurements, Properties, Tags } from "../types.js";
@@ -47,11 +48,51 @@ import {
   ApplicationInsightsExceptionName,
   ApplicationInsightsMessageBaseType,
   ApplicationInsightsMessageName,
+  ApplicationInsightsOperationName,
   ApplicationInsightsPageViewBaseType,
   ApplicationInsightsPageViewName,
+  ApplicationInsightsSessionId,
+  ApplicationInsightsSyntheticSource,
+  ApplicationInsightsUserAccountId,
   DEFAULT_BREEZE_DATA_VERSION,
   MicrosoftClientIp,
 } from "./constants/applicationinsights.js";
+
+const ApplicationInsightsUserAgent = "ai.user.userAgent";
+
+const legacyContextTagKeys: readonly KnownContextTagKeys[] = [
+  KnownContextTagKeys.AiApplicationVer,
+  KnownContextTagKeys.AiDeviceId,
+  KnownContextTagKeys.AiDeviceLocale,
+  KnownContextTagKeys.AiDeviceModel,
+  KnownContextTagKeys.AiDeviceOemName,
+  KnownContextTagKeys.AiDeviceOSVersion,
+  KnownContextTagKeys.AiDeviceType,
+  KnownContextTagKeys.AiLocationCountry,
+  KnownContextTagKeys.AiLocationIp,
+  KnownContextTagKeys.AiOperationCorrelationVector,
+  KnownContextTagKeys.AiOperationId,
+  KnownContextTagKeys.AiOperationName,
+  KnownContextTagKeys.AiOperationParentId,
+  KnownContextTagKeys.AiOperationSyntheticSource,
+  KnownContextTagKeys.AiSessionId,
+  KnownContextTagKeys.AiSessionIsFirst,
+  KnownContextTagKeys.AiUserAccountId,
+  KnownContextTagKeys.AiUserAuthUserId,
+  KnownContextTagKeys.AiUserId,
+  KnownContextTagKeys.AiCloudRole,
+  KnownContextTagKeys.AiCloudRoleInstance,
+];
+
+const logContextAttributeNames = new Set<string>([
+  ...legacyContextTagKeys,
+  ApplicationInsightsOperationName,
+  ApplicationInsightsSessionId,
+  ApplicationInsightsSyntheticSource,
+  ApplicationInsightsUserAccountId,
+  ApplicationInsightsUserAgent,
+  ATTR_USER_AGENT_ORIGINAL,
+]);
 
 /**
  * Log to Azure envelope parsing.
@@ -199,45 +240,104 @@ function getAttributeString(log: ReadableLogRecord, attributeName: string): stri
 
 function createTagsFromLog(log: ReadableLogRecord): Tags {
   const tags: Tags = createTagsFromResource(log.resource);
-  if (log.spanContext?.traceId) {
+  const attributes = log.attributes as Attributes;
+
+  for (const contextTagKey of legacyContextTagKeys) {
+    const value = getContextAttribute(attributes, contextTagKey);
+    if (value !== undefined) {
+      tags[contextTagKey] = value;
+    }
+  }
+
+  if (!tags[KnownContextTagKeys.AiOperationId] && log.spanContext?.traceId) {
     tags[KnownContextTagKeys.AiOperationId] = log.spanContext.traceId;
   }
-  if (log.spanContext?.spanId) {
+  if (!tags[KnownContextTagKeys.AiOperationParentId] && log.spanContext?.spanId) {
     tags[KnownContextTagKeys.AiOperationParentId] = log.spanContext.spanId;
   }
-  if (log.attributes[KnownContextTagKeys.AiOperationName]) {
-    tags[KnownContextTagKeys.AiOperationName] = log.attributes[
-      KnownContextTagKeys.AiOperationName
-    ] as string;
-  }
-  if (isSyntheticSource(log.attributes as Attributes)) {
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiOperationName,
+    ApplicationInsightsOperationName,
+  );
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiSessionId,
+    ApplicationInsightsSessionId,
+  );
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiOperationSyntheticSource,
+    ApplicationInsightsSyntheticSource,
+  );
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiUserAccountId,
+    ApplicationInsightsUserAccountId,
+  );
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiUserAuthUserId,
+    experimentalOpenTelemetryValues.ATTR_ENDUSER_ID,
+  );
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiUserId,
+    experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID,
+  );
+
+  if (!tags[KnownContextTagKeys.AiOperationSyntheticSource] && isSyntheticSource(attributes)) {
     tags[KnownContextTagKeys.AiOperationSyntheticSource] = "True";
   }
 
   // Set ai.location.ip from microsoft.client.ip if it exists
-  const microsoftClientIp = log.attributes?.[MicrosoftClientIp];
-  if (microsoftClientIp) {
-    tags[KnownContextTagKeys.AiLocationIp] = String(microsoftClientIp);
-  }
+  setContextTagFromAttributes(
+    tags,
+    attributes,
+    KnownContextTagKeys.AiLocationIp,
+    MicrosoftClientIp,
+  );
 
-  // Map user ID attributes
-  const attributes = log.attributes as Attributes;
-  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]) {
-    const endUserId = String(attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]);
-    if (endUserId && endUserId.length > 0) {
-      tags[KnownContextTagKeys.AiUserAuthUserId] = endUserId;
-    }
-  }
-  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]) {
-    const endUserPseudoId = String(
-      attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID],
-    );
-    if (endUserPseudoId && endUserPseudoId.length > 0) {
-      tags[KnownContextTagKeys.AiUserId] = endUserPseudoId;
-    }
+  const userAgent =
+    getContextAttribute(attributes, ApplicationInsightsUserAgent) ??
+    getContextAttribute(attributes, ATTR_USER_AGENT_ORIGINAL);
+  if (userAgent !== undefined) {
+    tags[ApplicationInsightsUserAgent] = userAgent;
   }
 
   return tags;
+}
+
+function setContextTagFromAttributes(
+  tags: Tags,
+  attributes: Attributes,
+  contextTagKey: KnownContextTagKeys,
+  attributeName: string,
+): void {
+  if (getContextAttribute(attributes, contextTagKey) !== undefined) {
+    return;
+  }
+
+  const value = getContextAttribute(attributes, attributeName);
+  if (value !== undefined) {
+    tags[contextTagKey] = value;
+  }
+}
+
+function getContextAttribute(attributes: Attributes, attributeName: string): string | undefined {
+  const value = attributes[attributeName];
+  if (value === undefined) {
+    return;
+  }
+
+  const stringValue = String(value);
+  return stringValue.length > 0 ? stringValue : undefined;
 }
 
 function createPropertiesFromLog(log: ReadableLogRecord): [Properties, Measurements] {
@@ -251,7 +351,7 @@ function createPropertiesFromLog(log: ReadableLogRecord): [Properties, Measureme
         key.startsWith("microsoft") ||
         legacySemanticValues.includes(key) ||
         httpSemanticValues.includes(key as any) ||
-        key === (KnownContextTagKeys.AiOperationName as string)
+        logContextAttributeNames.has(key)
       )) {
         properties[key] = serializeAttribute(log.attributes[key]);
       }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -38,7 +38,6 @@ import {
   ApplicationInsightsAvailabilityNameAttribute,
   ApplicationInsightsAvailabilityRunLocation,
   ApplicationInsightsAvailabilitySuccess,
-  ApplicationInsightsAvailabilityTestTimestamp,
   ApplicationInsightsBaseType,
   ApplicationInsightsCustomEventName,
   ApplicationInsightsEventBaseType,
@@ -58,7 +57,7 @@ import {
  * @internal
  */
 export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | undefined {
-  let time = hrTimeToDate(log.hrTime);
+  const time = hrTimeToDate(log.hrTime);
   const sampleRate = 100;
   const instrumentationKey = ikey;
   const tags = createTagsFromLog(log);
@@ -108,7 +107,6 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
     name = ApplicationInsightsAvailabilityName;
     baseType = ApplicationInsightsAvailabilityBaseType;
     baseData = availabilityData;
-    time = getAvailabilityTime(log) ?? time;
   } else if (isMessageType) {
     name = ApplicationInsightsMessageName;
     baseType = ApplicationInsightsMessageBaseType;
@@ -180,16 +178,6 @@ function getAvailabilityData(log: ReadableLogRecord): AvailabilityData | undefin
       getAttributeString(log, ApplicationInsightsAvailabilityMessage) ??
       (log.body === undefined ? undefined : serializeAttribute(log.body)),
   };
-}
-
-function getAvailabilityTime(log: ReadableLogRecord): Date | undefined {
-  const testTimestamp = log.attributes[ApplicationInsightsAvailabilityTestTimestamp];
-  if (typeof testTimestamp !== "string") {
-    return;
-  }
-
-  const time = new Date(testTimestamp);
-  return Number.isNaN(time.getTime()) ? undefined : time;
 }
 
 function getAttributeString(log: ReadableLogRecord, attributeName: string): string | undefined {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -57,7 +57,6 @@ function assertEnvelope(
   expectedBaseData?: Partial<MonitorDomain>,
   expectedTime?: Date,
   expectedServiceTags: Tags = expectedServiceTagsBase,
-  expectedSyntheticSource = "True",
 ): void {
   assert.isDefined(envelope);
   assert.strictEqual(envelope?.name, name);
@@ -76,9 +75,7 @@ function assertEnvelope(
   assert.deepStrictEqual(envelope?.tags, {
     ...context.tags,
     ...expectedServiceTags,
-    ...(expectedSyntheticSource
-      ? { [KnownContextTagKeys.AiOperationSyntheticSource]: expectedSyntheticSource }
-      : {}),
+    [KnownContextTagKeys.AiOperationSyntheticSource]: "True",
   });
   assert.deepStrictEqual((envelope?.data?.baseData as any).properties, expectedProperties);
   assert.deepStrictEqual((envelope?.data?.baseData as any).measurements, expectedMeasurements);
@@ -844,42 +841,21 @@ describe("logUtils.ts", () => {
       );
     });
 
-    it("should map the supported correlation context on availability telemetry", () => {
+    it("should preserve span correlation on availability telemetry", () => {
       testLogRecord.attributes = {
         "microsoft.availability.id": "test-id",
         "microsoft.availability.name": "test-name",
         "microsoft.availability.duration": "00:00:02",
         "microsoft.availability.success": true,
-        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
-        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
-        [KnownContextTagKeys.AiOperationName]: "legacy-operation-name",
-        "microsoft.operation_name": "GET /availability",
-        "microsoft.session.id": "session-id",
-        "microsoft.synthetic_source": "availability-test",
-        "microsoft.user.account_id": "account-id",
-        [experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]: "authenticated-user-id",
-        [experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]: "anonymous-user-id",
-        "user_agent.original": "availability-agent/1.0",
-        [KnownContextTagKeys.AiDeviceId]: "device-id",
-        [KnownContextTagKeys.AiDeviceModel]: "device-model",
-        [KnownContextTagKeys.AiDeviceType]: "PC",
-        [KnownContextTagKeys.AiDeviceOSVersion]: "test-os",
-        [KnownContextTagKeys.AiOperationCorrelationVector]: "correlation-vector",
-        [KnownContextTagKeys.AiSessionIsFirst]: "true",
-        [KnownContextTagKeys.AiDeviceLocale]: "en-US",
-        "ai.user.userAgent": "legacy-agent/1.0",
-        InvocationId: "invocation-id",
+        [KnownContextTagKeys.AiOperationId]: "attribute-operation-id",
+        [KnownContextTagKeys.AiOperationParentId]: "attribute-parent-id",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = "availability log";
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
       const expectedProperties = {
-        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
-        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
-        [KnownContextTagKeys.AiOperationCorrelationVector]: "correlation-vector",
-        [KnownContextTagKeys.AiSessionIsFirst]: "true",
-        [KnownContextTagKeys.AiDeviceLocale]: "en-US",
-        "ai.user.userAgent": "legacy-agent/1.0",
-        InvocationId: "invocation-id",
+        [KnownContextTagKeys.AiOperationId]: "attribute-operation-id",
+        [KnownContextTagKeys.AiOperationParentId]: "attribute-parent-id",
       };
       const expectedBaseData: Partial<AvailabilityData> = {
         id: "test-id",
@@ -891,22 +867,6 @@ describe("logUtils.ts", () => {
         version: 2,
         properties: expectedProperties,
         measurements: {},
-      };
-      const expectedTags: Tags = {
-        [KnownContextTagKeys.AiCloudRole]: "testServiceNamespace.testServiceName",
-        [KnownContextTagKeys.AiCloudRoleInstance]: "testServiceInstanceID",
-        [KnownContextTagKeys.AiOperationId]: "1f1008dc8e270e85c40a0d7c3939b278",
-        [KnownContextTagKeys.AiOperationParentId]: "5e107261f64fa53e",
-        [KnownContextTagKeys.AiOperationName]: "GET /availability",
-        [KnownContextTagKeys.AiSessionId]: "session-id",
-        [KnownContextTagKeys.AiUserAccountId]: "account-id",
-        [KnownContextTagKeys.AiUserAuthUserId]: "authenticated-user-id",
-        [KnownContextTagKeys.AiUserId]: "anonymous-user-id",
-        [KnownContextTagKeys.AiDeviceId]: "device-id",
-        [KnownContextTagKeys.AiDeviceModel]: "device-model",
-        [KnownContextTagKeys.AiDeviceType]: "PC",
-        [KnownContextTagKeys.AiDeviceOSVersion]: "test-os",
-        "ai.user.userAgent": "availability-agent/1.0",
       };
 
       const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
@@ -920,8 +880,7 @@ describe("logUtils.ts", () => {
         emptyMeasurements,
         expectedBaseData,
         expectedTime,
-        expectedTags,
-        "availability-test",
+        expectedServiceTagsBase,
       );
     });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -762,7 +762,6 @@ describe("logUtils.ts", () => {
 
   describe("#availability logs", () => {
     it("should create an availability envelope from availability attributes", () => {
-      const testTimestamp = "2025-04-19T12:10:59.9930000+00:00";
       testLogRecord.attributes = {
         "microsoft.availability.id": "test-id",
         "microsoft.availability.name": "test-name",
@@ -770,7 +769,6 @@ describe("logUtils.ts", () => {
         "microsoft.availability.success": true,
         "microsoft.availability.runLocation": "test-location",
         "microsoft.availability.message": "test-message",
-        "microsoft.availability.testTimestamp": testTimestamp,
         "extra.attribute": "foo",
         [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
         [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
@@ -800,7 +798,7 @@ describe("logUtils.ts", () => {
         expectedProperties,
         emptyMeasurements,
         expectedBaseData,
-        new Date(testTimestamp),
+        hrTimeToDate(testLogRecord.hrTime),
         expectedServiceTagsBase,
       );
     });
@@ -920,13 +918,13 @@ describe("logUtils.ts", () => {
       );
     });
 
-    it("should use the log time when the availability test timestamp is invalid", () => {
+    it("should ignore a customer-supplied availability test timestamp", () => {
       testLogRecord.attributes = {
         "microsoft.availability.id": "test-id",
         "microsoft.availability.name": "test-name",
         "microsoft.availability.duration": "00:00:02",
         "microsoft.availability.success": true,
-        "microsoft.availability.testTimestamp": "invalid",
+        "microsoft.availability.testTimestamp": "2025-04-19T12:10:59.9930000+00:00",
         [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = "availability log";

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -844,7 +844,7 @@ describe("logUtils.ts", () => {
       );
     });
 
-    it("should preserve legacy correlation context on availability telemetry", () => {
+    it("should map the supported correlation context on availability telemetry", () => {
       testLogRecord.attributes = {
         "microsoft.availability.id": "test-id",
         "microsoft.availability.name": "test-name",
@@ -852,6 +852,7 @@ describe("logUtils.ts", () => {
         "microsoft.availability.success": true,
         [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
         [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
+        [KnownContextTagKeys.AiOperationName]: "legacy-operation-name",
         "microsoft.operation_name": "GET /availability",
         "microsoft.session.id": "session-id",
         "microsoft.synthetic_source": "availability-test",
@@ -863,22 +864,22 @@ describe("logUtils.ts", () => {
         [KnownContextTagKeys.AiDeviceModel]: "device-model",
         [KnownContextTagKeys.AiDeviceType]: "PC",
         [KnownContextTagKeys.AiDeviceOSVersion]: "test-os",
+        [KnownContextTagKeys.AiOperationCorrelationVector]: "correlation-vector",
+        [KnownContextTagKeys.AiSessionIsFirst]: "true",
+        [KnownContextTagKeys.AiDeviceLocale]: "en-US",
+        "ai.user.userAgent": "legacy-agent/1.0",
         InvocationId: "invocation-id",
-        ProcessId: "process-id",
-        LogLevel: "Information",
-        Category: "availability",
-        HostInstanceId: "host-instance-id",
-        AzFuncLiveLogsSessionId: "live-logs-session-id",
       };
       testLogRecord.body = "availability log";
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
       const expectedProperties = {
+        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
+        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
+        [KnownContextTagKeys.AiOperationCorrelationVector]: "correlation-vector",
+        [KnownContextTagKeys.AiSessionIsFirst]: "true",
+        [KnownContextTagKeys.AiDeviceLocale]: "en-US",
+        "ai.user.userAgent": "legacy-agent/1.0",
         InvocationId: "invocation-id",
-        ProcessId: "process-id",
-        LogLevel: "Information",
-        Category: "availability",
-        HostInstanceId: "host-instance-id",
-        AzFuncLiveLogsSessionId: "live-logs-session-id",
       };
       const expectedBaseData: Partial<AvailabilityData> = {
         id: "test-id",
@@ -894,8 +895,8 @@ describe("logUtils.ts", () => {
       const expectedTags: Tags = {
         [KnownContextTagKeys.AiCloudRole]: "testServiceNamespace.testServiceName",
         [KnownContextTagKeys.AiCloudRoleInstance]: "testServiceInstanceID",
-        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
-        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
+        [KnownContextTagKeys.AiOperationId]: "1f1008dc8e270e85c40a0d7c3939b278",
+        [KnownContextTagKeys.AiOperationParentId]: "5e107261f64fa53e",
         [KnownContextTagKeys.AiOperationName]: "GET /availability",
         [KnownContextTagKeys.AiSessionId]: "session-id",
         [KnownContextTagKeys.AiUserAccountId]: "account-id",

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -57,6 +57,7 @@ function assertEnvelope(
   expectedBaseData?: Partial<MonitorDomain>,
   expectedTime?: Date,
   expectedServiceTags: Tags = expectedServiceTagsBase,
+  expectedSyntheticSource = "True",
 ): void {
   assert.isDefined(envelope);
   assert.strictEqual(envelope?.name, name);
@@ -75,7 +76,9 @@ function assertEnvelope(
   assert.deepStrictEqual(envelope?.tags, {
     ...context.tags,
     ...expectedServiceTags,
-    [KnownContextTagKeys.AiOperationSyntheticSource]: "True",
+    ...(expectedSyntheticSource
+      ? { [KnownContextTagKeys.AiOperationSyntheticSource]: expectedSyntheticSource }
+      : {}),
   });
   assert.deepStrictEqual((envelope?.data?.baseData as any).properties, expectedProperties);
   assert.deepStrictEqual((envelope?.data?.baseData as any).measurements, expectedMeasurements);
@@ -838,6 +841,86 @@ describe("logUtils.ts", () => {
         expectedBaseData,
         expectedTime,
         expectedServiceTagsBase,
+      );
+    });
+
+    it("should preserve legacy correlation context on availability telemetry", () => {
+      testLogRecord.attributes = {
+        "microsoft.availability.id": "test-id",
+        "microsoft.availability.name": "test-name",
+        "microsoft.availability.duration": "00:00:02",
+        "microsoft.availability.success": true,
+        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
+        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
+        "microsoft.operation_name": "GET /availability",
+        "microsoft.session.id": "session-id",
+        "microsoft.synthetic_source": "availability-test",
+        "microsoft.user.account_id": "account-id",
+        [experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]: "authenticated-user-id",
+        [experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]: "anonymous-user-id",
+        "user_agent.original": "availability-agent/1.0",
+        [KnownContextTagKeys.AiDeviceId]: "device-id",
+        [KnownContextTagKeys.AiDeviceModel]: "device-model",
+        [KnownContextTagKeys.AiDeviceType]: "PC",
+        [KnownContextTagKeys.AiDeviceOSVersion]: "test-os",
+        InvocationId: "invocation-id",
+        ProcessId: "process-id",
+        LogLevel: "Information",
+        Category: "availability",
+        HostInstanceId: "host-instance-id",
+        AzFuncLiveLogsSessionId: "live-logs-session-id",
+      };
+      testLogRecord.body = "availability log";
+      const expectedTime = hrTimeToDate(testLogRecord.hrTime);
+      const expectedProperties = {
+        InvocationId: "invocation-id",
+        ProcessId: "process-id",
+        LogLevel: "Information",
+        Category: "availability",
+        HostInstanceId: "host-instance-id",
+        AzFuncLiveLogsSessionId: "live-logs-session-id",
+      };
+      const expectedBaseData: Partial<AvailabilityData> = {
+        id: "test-id",
+        name: "test-name",
+        duration: "00:00:02",
+        success: true,
+        runLocation: undefined,
+        message: "availability log",
+        version: 2,
+        properties: expectedProperties,
+        measurements: {},
+      };
+      const expectedTags: Tags = {
+        [KnownContextTagKeys.AiCloudRole]: "testServiceNamespace.testServiceName",
+        [KnownContextTagKeys.AiCloudRoleInstance]: "testServiceInstanceID",
+        [KnownContextTagKeys.AiOperationId]: "legacy-operation-id",
+        [KnownContextTagKeys.AiOperationParentId]: "legacy-parent-id",
+        [KnownContextTagKeys.AiOperationName]: "GET /availability",
+        [KnownContextTagKeys.AiSessionId]: "session-id",
+        [KnownContextTagKeys.AiUserAccountId]: "account-id",
+        [KnownContextTagKeys.AiUserAuthUserId]: "authenticated-user-id",
+        [KnownContextTagKeys.AiUserId]: "anonymous-user-id",
+        [KnownContextTagKeys.AiDeviceId]: "device-id",
+        [KnownContextTagKeys.AiDeviceModel]: "device-model",
+        [KnownContextTagKeys.AiDeviceType]: "PC",
+        [KnownContextTagKeys.AiDeviceOSVersion]: "test-os",
+        "ai.user.userAgent": "availability-agent/1.0",
+      };
+
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+      assertEnvelope(
+        envelope,
+        "Microsoft.ApplicationInsights.Availability",
+        100,
+        "AvailabilityData",
+        expectedProperties,
+        emptyMeasurements,
+        expectedBaseData,
+        expectedTime,
+        expectedTags,
+        "availability-test",
       );
     });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/snippets.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/snippets.spec.ts
@@ -86,7 +86,6 @@ describe("snippets", () => {
         "microsoft.availability.success": true,
         "microsoft.availability.runLocation": "westus2",
         "microsoft.availability.message": "HTTP 200",
-        "microsoft.availability.testTimestamp": new Date().toISOString(),
       },
     });
   });


### PR DESCRIPTION
## Description

Aligns availability telemetry with OpenTelemetry log-record semantics and W3C distributed tracing.

- preserves the active log record trace ID and span ID as the Application Insights operation ID and parent ID
- verifies attribute-provided operation IDs cannot override span-derived correlation
- removes `microsoft.availability.testTimestamp` support so availability envelope time always comes from the OpenTelemetry `LogRecord`
- removes the obsolete timestamp attribute from documentation, snippets, and generated samples

This follows up on #39734 and aligns timestamp handling with Azure/azure-sdk-for-python#48841.

## Testing

- `pnpm update-snippets`
- `pnpm check-format`
- `pnpm lint`
- `pnpm turbo build --filter=@azure/monitor-opentelemetry-exporter... --token 1`
- `pnpm test:node -- --run test/internal/logUtils.spec.ts`