### PR TITLE
warp: fix self-reference resolution for generated pkgJson imports

### DIFF
--- a/common/tools/warp/src/exports.ts
+++ b/common/tools/warp/src/exports.ts
@@ -123,6 +123,15 @@ export async function writeExportsToPackageJson(
 
   pkg.exports = merged;
 
+  // Root package identity, threaded into the outDir shims so Node's package
+  // self-reference resolution (e.g. generated code doing
+  // `import pkgJson from "<pkg>/package.json"`) can succeed from the shim
+  // itself — see writeModuleTypeShims for details.
+  const pkgIdentity: PackageIdentity = {
+    name: typeof pkg.name === "string" ? pkg.name : undefined,
+    version: typeof pkg.version === "string" ? pkg.version : undefined,
+  };
+
   // Skip write if exports are unchanged — avoids unnecessary I/O and
   // prevents tools watching package.json from triggering false rebuilds.
   const newContent = `${JSON.stringify(pkg, null, 2)}\n`;
@@ -131,7 +140,7 @@ export async function writeExportsToPackageJson(
     if (existing === newContent) {
       // Exports and package.json are identical — skip write entirely.
       // Still write module-type shims below since outDirs were cleaned.
-      await writeModuleTypeShims(results);
+      await writeModuleTypeShims(results, pkgIdentity);
       return;
     }
   } catch {
@@ -153,13 +162,37 @@ export async function writeExportsToPackageJson(
 
   // Write module-type shim into each target's outDir — in parallel since
   // they write to independent directories.
-  await writeModuleTypeShims(results);
+  await writeModuleTypeShims(results, pkgIdentity);
+}
+
+/** Identity fields from the root package.json, threaded into outDir shims. */
+interface PackageIdentity {
+  name?: string;
+  version?: string;
 }
 
 /**
- * Write a `{"type": "module"|"commonjs"}` shim into each target's outDir.
+ * Write a package.json shim into each target's outDir marking the module
+ * type (`"type": "module"|"commonjs"`).
+ *
+ * The shim also carries the root package's `name`/`version` and a
+ * self-pointing `"exports": { "./package.json": "./package.json" }` entry.
+ * This is required for Node's package **self-reference** resolution: when
+ * generated code does `import pkgJson from "<pkg>/package.json"`, Node walks
+ * up from the importing file to the nearest ancestor package.json and uses
+ * *that file's* `name`/`exports` to resolve the specifier — it stops at the
+ * first ancestor found, even if it lacks a matching `name`/`exports`. Since
+ * generated files live under e.g. `dist/esm/generated/...`, this shim (not
+ * the real root package.json) is the nearest ancestor. Without `name`/
+ * `exports` here, self-reference resolution aborts and Node falls back to a
+ * `node_modules` lookup, which fails for packages that don't list
+ * themselves as a dependency.
+ * See https://github.com/Azure/azure-sdk-for-js/issues/39832.
  */
-async function writeModuleTypeShims(results: CompileResult[]): Promise<void> {
+async function writeModuleTypeShims(
+  results: CompileResult[],
+  pkgIdentity: PackageIdentity,
+): Promise<void> {
   await Promise.all(
     results.map(async (result) => {
       const shimPath = path.join(result.outDir, "package.json");
@@ -167,7 +200,14 @@ async function writeModuleTypeShims(results: CompileResult[]): Promise<void> {
 
       const moduleType: ModuleType = result.target.moduleType ?? "module";
 
-      await fsp.writeFile(shimPath, `${JSON.stringify({ type: moduleType }, null, 2)}\n`, "utf-8");
+      const shim = {
+        name: pkgIdentity.name,
+        version: pkgIdentity.version,
+        type: moduleType,
+        exports: { "./package.json": "./package.json" },
+      };
+
+      await fsp.writeFile(shimPath, `${JSON.stringify(shim, null, 2)}\n`, "utf-8");
     }),
   );
 }

--- a/common/tools/warp/test/internal/quality.spec.ts
+++ b/common/tools/warp/test/internal/quality.spec.ts
@@ -574,7 +574,7 @@ describe("module type shim from compiler options", () => {
   it("writes commonjs shim when moduleType is explicit", async () => {
     await fs.writeFile(
       path.join(tmpDir, "package.json"),
-      `${JSON.stringify({ name: "test" }, null, 2)}\n`,
+      `${JSON.stringify({ name: "test", version: "1.2.3" }, null, 2)}\n`,
     );
     await fs.mkdir(path.join(tmpDir, "dist/cjs"), { recursive: true });
 
@@ -599,6 +599,13 @@ describe("module type shim from compiler options", () => {
 
     const shim = await readJsonObject(path.join(tmpDir, "dist/cjs/package.json"));
     expect(shim["type"]).toBe("commonjs");
+    // Shim must carry the root package's name/version and a self-pointing
+    // exports entry so Node's package self-reference resolution (used by
+    // generated code importing "<pkg>/package.json") succeeds from here,
+    // the nearest ancestor package.json to files under dist/cjs.
+    expect(shim["name"]).toBe("test");
+    expect(shim["version"]).toBe("1.2.3");
+    expect(shim["exports"]).toEqual({ "./package.json": "./package.json" });
   });
 
   it("defaults to module when no explicit moduleType", async () => {
@@ -624,6 +631,11 @@ describe("module type shim from compiler options", () => {
 
     const shim = await readJsonObject(path.join(tmpDir, "dist/esm/package.json"));
     expect(shim["type"]).toBe("module");
+    expect(shim["name"]).toBe("test");
+    // No version in the root package.json here — key should be omitted
+    // entirely rather than written as null/undefined.
+    expect("version" in shim).toBe(false);
+    expect(shim["exports"]).toEqual({ "./package.json": "./package.json" });
   });
 });
 

--- a/sdk/contentunderstanding/ai-content-understanding/vitest.config.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/vitest.config.ts
@@ -3,12 +3,6 @@
 
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
-import { fileURLToPath } from "url";
-
-viteConfig.test.alias?.unshift({
-  find: "@azure/storage-blob/package.json",
-  replacement: fileURLToPath(import.meta.resolve("@azure/storage-blob/package.json")),
-});
 
 export default mergeConfig(
   viteConfig,

--- a/sdk/storage/storage-file-datalake/vitest.browser.config.ts
+++ b/sdk/storage/storage-file-datalake/vitest.browser.config.ts
@@ -2,11 +2,5 @@
 // Licensed under the MIT License.
 
 import viteConfig from "../../../vitest.browser.shared.config.ts";
-import { fileURLToPath } from "node:url";
-
-viteConfig.test.alias?.unshift({
-  find: "@azure/storage-blob/package.json",
-  replacement: fileURLToPath(import.meta.resolve("@azure/storage-blob/package.json")),
-});
 
 export default viteConfig;

--- a/sdk/storage/storage-file-datalake/vitest.config.ts
+++ b/sdk/storage/storage-file-datalake/vitest.config.ts
@@ -2,11 +2,5 @@
 // Licensed under the MIT License.
 
 import viteConfig from "../../../vitest.shared.config.ts";
-import { fileURLToPath } from "node:url";
-
-viteConfig.test.alias?.unshift({
-  find: "@azure/storage-blob/package.json",
-  replacement: fileURLToPath(import.meta.resolve("@azure/storage-blob/package.json")),
-});
 
 export default viteConfig;


### PR DESCRIPTION
Copilot agent 🤖 (on behalf of @jeremymeng): 

## Summary

TypeSpec-ts generated code reads its own package version for the user-agent string via a package **self-reference** import, e.g. (`sdk/storage/storage-blob/src/generated/api/blobContext.ts`):

```ts
import pkgJson from "@azure/storage-blob/package.json" with { type: "json" };
```

This relies on Node.js's package self-reference resolution (`PACKAGE_SELF_RESOLVE`), which walks up from the importing file to the **nearest ancestor** `package.json` and uses *that file's* `"name"`/`"exports"` fields to resolve the specifier — it stops at the first ancestor found, even if it lacks those fields, and falls back to a normal `node_modules` lookup in that case.

## Root cause

`common/tools/warp`'s `writeModuleTypeShims` (in `src/exports.ts`) writes a bare module-type shim `package.json` into each compiled target's `outDir`, e.g. `dist/esm/package.json` → `{"type": "module"}`.

Because generated files like `blobContext.js` live several directories deep under `dist/esm/generated/api/`, Node's ancestor walk finds this bare shim **before** the real root `package.json` (which correctly has `"name": "@azure/storage-blob"` and a self-pointing `"exports"` entry). Since the shim lacks `name`/`exports`, self-reference resolution aborts and Node falls back to a `node_modules` lookup for `@azure/storage-blob` — which fails, since storage-blob isn't listed as its own dependency — hence `ERR_MODULE_NOT_FOUND`.

This affects ~30 typespec-ts generated packages that self-import their own `package.json` (storage-blob, storage-file-datalake, search-documents, ai-projects, several arm-* packages, etc.), surfacing whenever the built `dist/esm`/`dist/commonjs` output is executed directly rather than consumed as an installed dependency — e.g. the Blob live-tests pipeline's "Execute Samples" step (`dev-tool samples run`):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@azure/storage-blob' imported from .../dist/esm/generated/api/blobContext.js
```

Fixes #39832

## Fix

Enrich the shim written by `writeModuleTypeShims` to include the root package's `name`, `version`, and a self-pointing `exports` map, alongside the existing `type` marker:

```json
{ "name": "@azure/storage-blob", "version": "12.35.0-beta.1", "type": "module", "exports": { "./package.json": "./package.json" } }
```

This preserves the CJS/ESM type marker while keeping self-reference resolution intact for both `dist/esm` and `dist/commonjs`. Generic — derives `name`/`version` from the already-parsed root `package.json`, no hardcoded package name, and omits `version` entirely (rather than writing `null`) when absent.

## Alias cleanup (consequence of the fix)

Removes the now-redundant `@azure/storage-blob/package.json` vitest `alias` workaround from:
- `sdk/storage/storage-file-datalake/vitest.config.ts`
- `sdk/storage/storage-file-datalake/vitest.browser.config.ts`
- `sdk/contentunderstanding/ai-content-understanding/vitest.config.ts`

This workaround was added in the same commit that introduced the `pkgJson` self-import pattern, aliasing `@azure/storage-blob/package.json` to the real installed file so Vitest could resolve it for storage-blob as a transitive dependency. With the warp shim fix in place, it's no longer needed — Vitest/Vite's own resolver was found (via direct testing, see below) to resolve the self-import correctly regardless of alias presence.

Verified by temporarily removing the alias and comparing test results before/after, in every scenario:

| Suite | Scenario | With alias (baseline) | Without alias (after fix) |
|---|---|---|---|
| storage-file-datalake `test:node` | local | 8 failed / 302 passed / 86 skipped | 8 failed / 302 passed / 86 skipped |
| storage-file-datalake `test:node` | CI-like (`SYSTEM_TEAMPROJECTID` set) | 8 failed / 302 passed / 86 skipped | 8 failed / 302 passed / 86 skipped |
| storage-file-datalake `test:browser` | chromium | 11/11 files, 199 passed / 29 skipped | 11/11 files, 199 passed / 29 skipped |
| ai-content-understanding `test:node` | — | 36/36 files, 165 passed / 13 skipped | 36/36 files, 165 passed / 13 skipped |

(The 8 datalake `test:node` failures in `sas.spec.ts` are pre-existing, unrelated recorded-fixture DST/timestamp mismatches — present identically with and without the alias.)

## Validation performed

- `common/tools/warp`: `npm run build`, `npm run test:node` (vitest) — **281 passed, 4 skipped**, 14 files, all green. `check-format` and `lint` also clean.
- Built `@azure/storage-blob` locally (`pnpm turbo build --filter=@azure/storage-blob... --token 1`) and confirmed `dist/esm/package.json`/`dist/commonjs/package.json` now contain `name`/`version`/`exports`.
- **Positive control**: a script importing `BlobServiceClient` from the built `@azure/storage-blob` package (plain `node`, no `node_modules` install of storage-blob itself) succeeded.
- **Negative control**: reverting `dist/esm/package.json` to the old bare `{"type":"module"}` shim reproduced the *exact* CI error verbatim (`ERR_MODULE_NOT_FOUND ... imported from .../dist/esm/generated/api/blobContext.js`), confirming root cause and fix.
- Rebuilt and re-ran the affected downstream packages' test suites as described above.

**Not tested**: the full live-tests CI pipeline (Blob live-tests, "Execute Samples" step) — all validation above is local. This PR's CI run should exercise the real pipeline for final confirmation.