### PR TITLE
[Storage Blob] Fix test bug: loop variable `i` reset every iteration in listBlobsByHierarchy startFrom test

### DIFF
--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -910,8 +910,9 @@ describe("ContainerClient", () => {
     assert.deepStrictEqual(result.delimiter, delimiter);
     assert.deepStrictEqual(result.segment.blobPrefixes!.length, blobClients.length - 1);
 
-    for (const blob of blobClients) {
-      assert.ok(blob.url.indexOf(result.segment.blobPrefixes![0].name));
+    let i = 0;
+    for (const blob of blobClients.slice(1)) {
+      assert.ok(blob.url.indexOf(result.segment.blobPrefixes![i++].name));
     }
 
     for (const blob of blobClients) {


### PR DESCRIPTION
Copilot agent 🤖 (on behalf of @jeremymeng): Follow-up to a review comment on #39784 (https://github.com/Azure/azure-sdk-for-js/pull/39784#pullrequestreview-5072581352).

## Background

PR #39784 (restoring the `no-useless-assignment` ESLint rule) changed `listBlobsByHierarchy with startFrom` in `sdk/storage/storage-blob/test/containerclient.spec.ts` from:

```ts
for (const blob of blobClients) {
  let i = 0;
  assert.ok(blob.url.indexOf(result.segment.blobPrefixes![i++].name));
}
```

to:

```ts
for (const blob of blobClients) {
  assert.ok(blob.url.indexOf(result.segment.blobPrefixes![0].name));
}
```

This was a faithful lint fix, but it exposed a pre-existing test bug: `let i = 0;` was declared *inside* the loop body, so it was reset to `0` on every iteration and the `i++` increment was always discarded. The test therefore always compared against `blobPrefixes![0]`, never advancing through the array as clearly intended.

## Fix

- Declared `i` once, before the loop, so it increments across iterations as originally intended.
- Since `startFrom` excludes the first blob's prefix from the results (`blobPrefixes!.length === blobClients.length - 1`), iterating over all of `blobClients` while incrementing `i` from `0` would index past the end of `blobPrefixes` on the last iteration and throw. Changed the loop to iterate over `blobClients.slice(1)` so the indices stay in bounds and line up with the blobs actually present in the paged result.

## Validation

- `npx eslint test/containerclient.spec.ts` — clean, no diagnostics.
- `pnpm turbo build --filter=@azure/storage-blob... --token 1` — succeeded.
- Package tests in Playback mode (Node + browser): all passed, including `listBlobsByHierarchy with startFrom` (Node: 606 passed / 131 skipped; browser: 333 passed / 68 skipped, matching pre-existing skip counts).