### PR TITLE
[EngSys] Fix shared Vitest dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "@types/node": "catalog:",
     "cspell": "^9.6.4",
     "prettier-plugin-packagejson": "^2.5.22",
     "rimraf": "^6.1.3",
-    "turbo": "^2.8.9"
+    "turbo": "^2.8.9",
+    "vitest": "catalog:testing"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
       cspell:
         specifier: ^9.6.4
         version: 9.8.0
@@ -124,6 +127,9 @@ importers:
       turbo:
         specifier: ^2.8.9
         version: 2.10.7
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   common/tools/dev-tool:
     dependencies:


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): Fix shared Vitest configuration imports under pnpm's strict dependency resolution.

### Packages impacted by this PR

All packages that consume the repository's shared Vitest configuration. The change is owned by the root `@azure/monorepo` workspace package.

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The root `vitest.shared.config.ts` imports `vitest/config` and `vitest/node`, but the root package did not declare Vitest. When a leaf SDK package loaded this shared configuration, the config bundler could not resolve those imports from the root and emitted `UNRESOLVED_IMPORT` warnings even though tests passed.

This PR declares Vitest at the root and also declares the existing `@types/node` catalog dependency so pnpm reuses the repository's Node 22 Vite peer variant instead of creating a Node 25 variant.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The alternatives were to duplicate or redirect Vitest imports in each leaf package, or change config loading to tolerate unresolved imports. Declaring the dependencies where the shared configuration lives preserves strict resolution and fixes all consumers without per-package changes.

### Are there test cases added in this PR? _(If not, why?)_

No new test case is needed because this is a dependency-resolution correction. The original `@azure/storage-queue` command was run and completed with 21 passing tests without either `UNRESOLVED_IMPORT` warning:

`npm run test:node -- -- .\test\queueclient.spec.ts`

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary)