### PR TITLE
fix(event-hubs): bound receiver credit

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -5,7 +5,7 @@
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/eventhub/event-hubs/README.md",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/eventhub/event-hubs/README.md",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Azure/azure-sdk-for-js",
@@ -17,7 +17,7 @@
     "cloud",
     "event hubs",
     "events",
-    "Azure"
+    "azure"
   ],
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -241,7 +241,12 @@ export function createReceiver(
                   timeoutInMs: getRetryAttemptTimeoutInMs(options.retryOptions),
                 })
                 .then(() => {
-                  addCredits(state.link, Math.max(prefetchCount, maxMessageCount) - queue.length);
+                  addCredits(
+                    state.link,
+                    Math.max(prefetchCount, maxMessageCount) -
+                      queue.length -
+                      (state.link?.credit ?? 0),
+                  );
                   logger.verbose(`setting the max wait time to ${maxWaitTimeInSeconds} seconds`);
                   return waitForEvents(
                     maxMessageCount,

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -9,8 +9,13 @@ import type {
   MessagingError,
 } from "../../src/index.js";
 import { translate } from "@azure/core-amqp";
+import type { ConnectionContext } from "../../src/connectionContext.js";
+import { createReceiver as createPartitionReceiver } from "../../src/partitionReceiver.js";
+import type { PartitionReceiver } from "../../src/partitionReceiver.js";
+import type { PartitionReceiverOptions } from "../../src/models/private.js";
 import "../utils/chai.js";
-import { describe, it, beforeEach, afterEach } from "vitest";
+import type { CreateReceiverOptions, EventContext, Receiver } from "rhea-promise";
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
 import { createConsumer, createProducer, createReceiver } from "../utils/clients.js";
 
 describe("EventHubConsumerClient", () => {
@@ -128,5 +133,151 @@ describe("EventHubConsumerClient", () => {
       events.length.should.equal(1, "Unexpected number of events received.");
       events[0].body.should.equal(message.body, "Unexpected message received.");
     });
+  });
+});
+
+function createFakeReceiver(options: PartitionReceiverOptions = {}): {
+  context: ConnectionContext;
+  receiver: PartitionReceiver;
+  additions: number[];
+  getCredit: () => number;
+  getQueueLength: () => number;
+  removeFromQueue: (count: number) => void;
+  dispatch: (body: string) => void;
+} {
+  let credit = 0;
+  let queueLength = 0;
+  let linkIsOpen = true;
+  let onMessage: ((context: EventContext) => void) | undefined;
+  const additions: number[] = [];
+
+  const link = {
+    get credit() {
+      return credit;
+    },
+    addCredit: vi.fn((credits: number) => {
+      additions.push(credits);
+      credit += credits;
+    }),
+    close: vi.fn(async () => {
+      linkIsOpen = false;
+    }),
+    isOpen: () => linkIsOpen,
+  } as unknown as Receiver;
+
+  const createAmqpReceiver = vi.fn(async (receiverOptions: CreateReceiverOptions) => {
+    onMessage = receiverOptions.onMessage;
+    return link;
+  });
+
+  const context = {
+    connectionId: "fake-connection",
+    config: {
+      host: "fake.servicebus.windows.net",
+      endpoint: "sb://fake.servicebus.windows.net/",
+      entityPath: "fake-event-hub",
+      getReceiverAddress: () => "fake-event-hub/ConsumerGroups/$default/Partitions/0",
+      getReceiverAudience: () =>
+        "sb://fake.servicebus.windows.net/fake-event-hub/ConsumerGroups/$default/Partitions/0",
+    },
+    tokenCredential: {
+      isSasTokenProvider: true as const,
+      getToken: vi.fn(async () => ({ token: "fake-token" })),
+    },
+    cbsSession: {
+      cbsLock: "fake-cbs-lock",
+      init: vi.fn(async () => undefined),
+      negotiateClaim: vi.fn(async () => ({ statusCode: 200 })),
+    },
+    connection: {
+      createReceiver: createAmqpReceiver,
+    },
+    readyToOpenLink: vi.fn(async () => undefined),
+    wasConnectionCloseCalled: false,
+    receivers: {},
+    senders: {},
+    close: vi.fn(async () => undefined),
+  } as unknown as ConnectionContext;
+
+  const receiver = createPartitionReceiver(
+    context,
+    "$default",
+    "fake-consumer",
+    "0",
+    { enqueuedOn: Date.now() },
+    options,
+  );
+
+  return {
+    context,
+    receiver,
+    additions,
+    getCredit: () => credit,
+    getQueueLength: () => queueLength,
+    removeFromQueue: (count: number) => {
+      queueLength -= count;
+    },
+    dispatch: (body: string) => {
+      if (!onMessage) {
+        throw new Error("The receiver has not been connected.");
+      }
+      credit -= 1;
+      queueLength += 1;
+      onMessage({ message: { body } } as EventContext);
+    },
+  };
+}
+
+describe("PartitionReceiver credit replenishment", () => {
+  let fake: ReturnType<typeof createFakeReceiver>;
+
+  afterEach(async () => {
+    await fake.receiver.close();
+    await fake.context.close();
+    vi.restoreAllMocks();
+  });
+
+  it("does not increase receiver credit across repeated empty receive cycles", async () => {
+    fake = createFakeReceiver();
+    const results = [];
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      results.push(await fake.receiver.receiveBatch(2, 0));
+    }
+
+    results.forEach((events) => events.length.should.equal(0));
+    ({ additions: fake.additions, credit: fake.getCredit() }).should.deep.equal({
+      additions: [6],
+      credit: 6,
+    });
+    (fake.getQueueLength() + fake.getCredit()).should.be.at.most(6);
+  });
+
+  it("accounts for queued events and existing credit when replenishing", async () => {
+    fake = createFakeReceiver({ prefetchCount: 5 });
+
+    const initialEvents = await fake.receiver.receiveBatch(2, 0);
+    initialEvents.length.should.equal(0);
+    fake.getQueueLength().should.equal(0);
+    fake.getCredit().should.equal(5);
+
+    fake.dispatch("event-1");
+    fake.dispatch("event-2");
+    fake.dispatch("event-3");
+    (fake.getQueueLength() + fake.getCredit()).should.equal(5);
+
+    const firstEvents = await fake.receiver.receiveBatch(2, 0);
+    firstEvents.length.should.equal(2);
+    fake.removeFromQueue(firstEvents.length);
+    fake.getQueueLength().should.equal(1);
+    (fake.getQueueLength() + fake.getCredit()).should.be.at.most(5);
+
+    const secondEvents = await fake.receiver.receiveBatch(2, 0);
+    secondEvents.length.should.equal(1);
+    fake.removeFromQueue(secondEvents.length);
+    fake.getQueueLength().should.equal(0);
+
+    fake.additions.should.deep.equal([5, 2]);
+    (fake.getQueueLength() + fake.getCredit()).should.be.at.most(5);
   });
 });


### PR DESCRIPTION
## Summary

Bounds Event Hubs receiver queue length plus outstanding link credit.

## Motivation

Receiver credit was replenished from queued events alone. Existing link credit could therefore accumulate across idle receive cycles and exceed the configured bound, weakening backpressure for slow handlers.

## Changes

Subtracts existing receiver link credit from the positive credit deficit. Adds deterministic regression coverage for empty cycles, partial queue consumption, and existing credit. Preserves prefetch defaults, max batch behavior, retry behavior, queue splicing, and public APIs.

## Test plan

- Focused credit regression tests passed: 2 passed.
- `npx --yes pnpm@11.24.0 check-format` passed.
- `npx --yes pnpm@11.24.0 lint` passed with 46 existing warnings and no errors.
- `npx --yes pnpm@11.24.0 turbo build --filter=@azure/event-hubs... --token 1` passed: 24 of 24 tasks.
- `npx --yes pnpm@11.24.0 exec dev-tool check --tag=local` passed build, browser unit tests, and node unit tests.
- Package version gate passed because 6.0.5 is unpublished.
- Required dev-tool metadata normalization changed the README homepage URL from tree to blob and normalized the Azure keyword to lowercase.

Fixes #39452
