### PR TITLE
[prepare-pipelines.yml] Don't cancel comment-triggered runs

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pr:
+  autoCancel: false
+
 variables:
 - template: /eng/pipelines/templates/variables/image.yml
 


### PR DESCRIPTION
Ports Azure/azure-sdk-for-python#48911 to this repo.

Sets `pr.autoCancel: false` on `prepare-pipelines.yml` so comment-triggered (`/azp run`) runs are not cancelled by subsequent runs on the same PR.