### PR TITLE
[web-pubsub-client] Add reliable recovery lifecycle events

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-client/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added group state APIs to set or clear the current connection's group state, subscribe to group state changes, and read cached group state records.
+- Added `recovering` and `recovered` lifecycle events with `OnRecoveringArgs` and `OnRecoveredArgs` to observe reliable recovery of the same logical connection.
 
 ### Breaking Changes
 

--- a/sdk/web-pubsub/web-pubsub-client/README.md
+++ b/sdk/web-pubsub/web-pubsub-client/README.md
@@ -212,6 +212,37 @@ client.on("stopped", () => {
 
 ---
 
+### Observe reliable recovery
+
+With a reliable subprotocol, `recovering` is emitted once when the SDK enters recovery for an interrupted logical connection, before its first attempt. `recovered` is emitted when the active recovery socket opens for that same connection ID. Neither event is emitted for initial startup or a fresh reconnect, and retries within one recovery episode do not emit additional `recovering` events.
+
+```ts snippet:ReadmeSampleRecoveryEvents
+import { WebPubSubClient } from "@azure/web-pubsub-client";
+
+// Disabling fresh reconnect does not disable reliable recovery.
+const client = new WebPubSubClient("<client-access-url>", { autoReconnect: false });
+
+// Register listeners before starting the client.
+client.on("recovering", (e) => {
+  console.log(`Recovering connection ${e.connectionId}.`);
+});
+client.on("recovered", (e) => {
+  console.log(`Connection ${e.connectionId} recovered; message replay may still be in progress.`);
+});
+
+await client.start();
+```
+
+A successful recovery has the sequence `connected(A) → recovering(A) → recovered(A)`, without another `connected` event. If recovery fails, the existing `disconnected` event and reconnect/stopped behavior still apply. When recovery is unavailable, neither recovery event is emitted. Setting `autoReconnect: false` disables fresh reconnection, not reliable recovery.
+
+Both events provide only `connectionId`, through the exported `OnRecoveringArgs` and `OnRecoveredArgs` types. Use `client.off("recovering", listener)` or `client.off("recovered", listener)` with the registered listener to unsubscribe.
+
+`recovered` describes socket recovery, not completed retained-message replay or application synchronization. Continue handling errors from normal client operations. Calling `stop()` during an episode suppresses its later `recovered` notification; these events do not change existing shutdown or recovery behavior.
+
+Synchronous exceptions from these two event notifications are logged without interrupting recovery. A throwing listener can prevent later listeners for that notification from running; rejected promises from async listeners are not handled by this mechanism.
+
+---
+
 ### Use a negotiation server to generate Client Access URL programatically
 
 In production, clients usually fetch the Client Access URL from an application server. The server holds the connection string to your Web PubSub resource and generates the Client Access URL with the help from the server library `@azure/web-pubsub`.
@@ -377,6 +408,8 @@ A connection, also known as a client or a client connection, represents an indiv
 ### Recovery
 
 If a client using reliable protocols disconnects, a new WebSocket tries to establish using the connection ID of the lost connection. If the new WebSocket connection is successfully connected, the connection is recovered. Throughout the time a client is disconnected, the service retains the client's context as well as all messages that the client was subscribed to, and when the client recovers, the service will send these messages to the client. If the service returns WebSocket error code `1008` or the recovery attempt lasts more than 30 seconds, the recovery fails.
+
+The `recovering` and `recovered` events let applications observe this same-connection recovery without treating it as a new connection. See [Observe reliable recovery](#observe-reliable-recovery) for their timing and limitations.
 
 ### Reconnect
 

--- a/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
+++ b/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
@@ -305,6 +305,16 @@ export interface OnGroupStreamOptions {
 }
 
 // @public
+export interface OnRecoveredArgs {
+    connectionId: string;
+}
+
+// @public
+export interface OnRecoveringArgs {
+    connectionId: string;
+}
+
+// @public
 export interface OnRejoinGroupFailedArgs {
     error: Error;
     group: string;
@@ -582,6 +592,8 @@ export class WebPubSubClient {
     leaveGroup(groupName: string, options?: LeaveGroupOptions): Promise<WebPubSubResult>;
     listGroupStates(groupName: string): readonly GroupStateRecord[];
     off(event: "connected", listener: (e: OnConnectedArgs) => void): void;
+    off(event: "recovering", listener: (e: OnRecoveringArgs) => void): void;
+    off(event: "recovered", listener: (e: OnRecoveredArgs) => void): void;
     off(event: "disconnected", listener: (e: OnDisconnectedArgs) => void): void;
     off(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     off(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
@@ -589,6 +601,8 @@ export class WebPubSubClient {
     off(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
     off(event: "group-states-changed", listener: (e: OnGroupStatesChangedArgs) => void): void;
     on(event: "connected", listener: (e: OnConnectedArgs) => void): void;
+    on(event: "recovering", listener: (e: OnRecoveringArgs) => void): void;
+    on(event: "recovered", listener: (e: OnRecoveredArgs) => void): void;
     on(event: "disconnected", listener: (e: OnDisconnectedArgs) => void): void;
     on(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     on(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;

--- a/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
@@ -357,6 +357,29 @@ export interface OnConnectedArgs {
 }
 
 /**
+ * Arguments for the recovering event, emitted once before the first attempt to
+ * recover an interrupted logical connection using a reliable subprotocol.
+ */
+export interface OnRecoveringArgs {
+  /**
+   * The ID of the logical connection being recovered.
+   */
+  connectionId: string;
+}
+
+/**
+ * Arguments for the recovered event, emitted when the active recovery socket
+ * opens for the same logical connection. This does not indicate that retained
+ * message replay or application synchronization is complete.
+ */
+export interface OnRecoveredArgs {
+  /**
+   * The ID of the logical connection that was recovered.
+   */
+  connectionId: string;
+}
+
+/**
  * Parameter of OnDisconnected callback
  */
 export interface OnDisconnectedArgs {

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -12,6 +12,8 @@ import type {
   JoinGroupOptions,
   LeaveGroupOptions,
   OnConnectedArgs,
+  OnRecoveringArgs,
+  OnRecoveredArgs,
   OnDisconnectedArgs,
   OnGroupDataMessageArgs,
   OnServerDataMessageArgs,
@@ -120,6 +122,8 @@ export class WebPubSubClient {
   private readonly _emitter: EventEmitter = new EventEmitter();
   private _state: WebPubSubClientState;
   private _isStopping: boolean = false;
+  // Notification bookkeeping only; does not control recovery or shutdown.
+  private _recoveryEventGeneration = 0;
   private _pingKeepaliveTask: AbortableTask | undefined;
   private _timeoutMonitorTask: AbortableTask | undefined;
 
@@ -263,6 +267,7 @@ export class WebPubSubClient {
       return;
     }
 
+    this._recoveryEventGeneration++;
     // TODO: Maybe we need a better logic for stopping control
     this._isStopping = true;
     if (this._wsClient && this._wsClient.isOpen()) {
@@ -291,6 +296,19 @@ export class WebPubSubClient {
    * @param listener - The handler
    */
   public on(event: "connected", listener: (e: OnConnectedArgs) => void): void;
+  /**
+   * Add a handler invoked once before reliable recovery attempts begin.
+   * @param event - The event name
+   * @param listener - The handler
+   */
+  public on(event: "recovering", listener: (e: OnRecoveringArgs) => void): void;
+  /**
+   * Add a handler invoked when the active recovery socket opens for the same
+   * logical connection, not when retained message replay is complete.
+   * @param event - The event name
+   * @param listener - The handler
+   */
+  public on(event: "recovered", listener: (e: OnRecoveredArgs) => void): void;
   /**
    * Add handler for disconnected event
    * @param event - The event name
@@ -330,6 +348,8 @@ export class WebPubSubClient {
   public on(
     event:
       | "connected"
+      | "recovering"
+      | "recovered"
       | "disconnected"
       | "stopped"
       | "server-message"
@@ -359,6 +379,18 @@ export class WebPubSubClient {
    * @param listener - The handler
    */
   public off(event: "connected", listener: (e: OnConnectedArgs) => void): void;
+  /**
+   * Remove a handler for the recovering event.
+   * @param event - The event name
+   * @param listener - The handler
+   */
+  public off(event: "recovering", listener: (e: OnRecoveringArgs) => void): void;
+  /**
+   * Remove a handler for the recovered event.
+   * @param event - The event name
+   * @param listener - The handler
+   */
+  public off(event: "recovered", listener: (e: OnRecoveredArgs) => void): void;
   /**
    * Remove handler for disconnected event
    * @param event - The event name
@@ -398,6 +430,8 @@ export class WebPubSubClient {
   public off(
     event:
       | "connected"
+      | "recovering"
+      | "recovered"
       | "disconnected"
       | "stopped"
       | "server-message"
@@ -410,6 +444,8 @@ export class WebPubSubClient {
   }
 
   private _emitEvent(event: "connected", args: OnConnectedArgs): void;
+  private _emitEvent(event: "recovering", args: OnRecoveringArgs): void;
+  private _emitEvent(event: "recovered", args: OnRecoveredArgs): void;
   private _emitEvent(event: "disconnected", args: OnDisconnectedArgs): void;
   private _emitEvent(event: "stopped", args: OnStoppedArgs): void;
   private _emitEvent(event: "server-message", args: OnServerDataMessageArgs): void;
@@ -419,6 +455,8 @@ export class WebPubSubClient {
   private _emitEvent(
     event:
       | "connected"
+      | "recovering"
+      | "recovered"
       | "disconnected"
       | "stopped"
       | "server-message"
@@ -1436,12 +1474,24 @@ export class WebPubSubClient {
     // Try recover connection
     let recovered = false;
     this._state = WebPubSubClientState.Recovering;
+    const connectionId = this._connectionId!;
+    const recoveryEventGeneration = ++this._recoveryEventGeneration;
+    this._safeEmitRecovering(connectionId);
     const abortSignal = AbortSignal.timeout(30 * 1000);
     try {
       while (!abortSignal.aborted && !this._isStopping) {
         try {
-          await this._connectCore.call(this, recoveryUri);
+          const connecting = this._connectCore.call(this, recoveryUri);
+          const recoverySocket = this._wsClient;
+          await connecting;
           recovered = true;
+          if (
+            recoveryEventGeneration === this._recoveryEventGeneration &&
+            recoverySocket === this._wsClient &&
+            recoverySocket?.isOpen()
+          ) {
+            this._safeEmitRecovered(connectionId);
+          }
           return;
         } catch {
           await delay(1000);
@@ -1473,6 +1523,22 @@ export class WebPubSubClient {
     sessions.forEach((session) => {
       session.close(reason);
     });
+  }
+
+  private _safeEmitRecovering(connectionId: string): void {
+    try {
+      this._emitEvent("recovering", { connectionId });
+    } catch (err) {
+      logger.warning("An error occurred in a recovering event listener.", err);
+    }
+  }
+
+  private _safeEmitRecovered(connectionId: string): void {
+    try {
+      this._emitEvent("recovered", { connectionId });
+    } catch (err) {
+      logger.warning("An error occurred in a recovered event listener.", err);
+    }
   }
 
   private _safeEmitConnected(connectionId: string, userId: string): void {

--- a/sdk/web-pubsub/web-pubsub-client/test/client.recovery.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.recovery.spec.ts
@@ -1,0 +1,403 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import type {
+  OnRecoveredArgs,
+  OnRecoveringArgs,
+  WebPubSubClientOptions,
+  WebPubSubClientCredential,
+} from "../src/index.js";
+import { WebPubSubClient, WebPubSubJsonProtocol } from "../src/index.js";
+import { ControlledWebSocketFactory } from "./controlledWebSocketClient.js";
+import { getConnectedPayload, getGroupDataPayload } from "./utils.js";
+
+describe("WebPubSubClient reliable recovery", () => {
+  let client: WebPubSubClient;
+  let transport: ControlledWebSocketFactory;
+  let recoveryTimeout: AbortController;
+  let events: string[];
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    recoveryTimeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(recoveryTimeout.signal);
+    await startClient();
+  });
+
+  async function startClient(
+    options: WebPubSubClientOptions = {},
+    connectedPayload: object = getConnectedPayload("A", "test-token"),
+    credential: WebPubSubClientCredential = {
+      getClientAccessUrl: "wss://example.com/client/hubs/test",
+    },
+  ): Promise<void> {
+    client = new WebPubSubClient(credential, {
+      autoReconnect: false,
+      keepAliveIntervalInMs: 0,
+      keepAliveTimeoutInMs: 0,
+      messageRetryOptions: { maxRetries: 0 },
+      ...options,
+    });
+    transport = new ControlledWebSocketFactory(client);
+    events = [];
+    client.on("connected", ({ connectionId }) => events.push(`connected(${connectionId})`));
+    client.on("disconnected", ({ connectionId }) => events.push(`disconnected(${connectionId})`));
+    client.on("stopped", () => events.push("stopped"));
+    client.on("recovering", ({ connectionId }) => events.push(`recovering(${connectionId})`));
+    client.on("recovered", ({ connectionId }) => events.push(`recovered(${connectionId})`));
+
+    const starting = client.start();
+    await vi.advanceTimersByTimeAsync(0);
+    transport.socket(0).receiveOpen();
+    await starting;
+    transport.socket(0).receiveMessage(JSON.stringify(connectedPayload));
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  afterEach(async () => {
+    try {
+      recoveryTimeout.abort();
+      client.stop();
+      const socket = transport.sockets.at(-1);
+      if (socket && !socket.isOpen()) {
+        // Release a pending open so the real recovery loop can finish teardown.
+        socket.receiveClose(1008);
+      }
+      await vi.advanceTimersByTimeAsync(1000);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("does not emit recovery events for an intentional stop", async () => {
+    client.stop();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(events).toEqual(["connected(A)", "disconnected(A)", "stopped"]);
+    expect(transport.sockets).toHaveLength(1);
+  });
+
+  it("retains subscriptions across stop/start and allows a listener to remove itself", async () => {
+    const selfRemoving = vi.fn((_: OnRecoveredArgs) => client.off("recovered", selfRemoving));
+    client.on("recovered", selfRemoving);
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+    client.stop();
+    const starting = client.start();
+    transport.socket(2).receiveOpen();
+    await starting;
+    transport.socket(2).receiveMessage(JSON.stringify(getConnectedPayload("B", "new-token")));
+    await vi.advanceTimersByTimeAsync(0);
+    transport.socket(2).receiveClose(1006);
+    transport.socket(3).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(selfRemoving).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      "connected(A)",
+      "recovering(A)",
+      "recovered(A)",
+      "disconnected(A)",
+      "stopped",
+      "connected(B)",
+      "recovering(B)",
+      "recovered(B)",
+    ]);
+  });
+
+  it("supports typed listeners, ordered dispatch, minimal payloads, and removal", async () => {
+    expectTypeOf<keyof OnRecoveringArgs>().toEqualTypeOf<"connectionId">();
+    expectTypeOf<keyof OnRecoveredArgs>().toEqualTypeOf<"connectionId">();
+    const calls: string[] = [];
+    const payloads: unknown[] = [];
+    const startSocketCounts: number[] = [];
+    const recoveredSocketOpen: boolean[] = [];
+    const recovering = (args: OnRecoveringArgs): void => {
+      calls.push("start:first");
+      payloads.push(args);
+    };
+    const recovered = (args: OnRecoveredArgs): void => {
+      calls.push("success:first");
+      payloads.push(args);
+    };
+    client.on("recovering", recovering);
+    client.on("recovering", (args) => {
+      expectTypeOf(args).toEqualTypeOf<OnRecoveringArgs>();
+      calls.push("start:second");
+      startSocketCounts.push(transport.sockets.length);
+    });
+    client.on("recovered", recovered);
+    client.on("recovered", (args) => {
+      expectTypeOf(args).toEqualTypeOf<OnRecoveredArgs>();
+      calls.push("success:second");
+      recoveredSocketOpen.push(transport.sockets.at(-1)!.isOpen());
+    });
+
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+    client.off("recovering", recovering);
+    client.off("recovered", recovered);
+    transport.socket(1).receiveClose(1006);
+    transport.socket(2).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls).toEqual([
+      "start:first",
+      "start:second",
+      "success:first",
+      "success:second",
+      "start:second",
+      "success:second",
+    ]);
+    expect(payloads).toEqual([{ connectionId: "A" }, { connectionId: "A" }]);
+    expect(startSocketCounts).toEqual([1, 2]);
+    expect(recoveredSocketOpen).toEqual([true, true]);
+  });
+
+  it.each([
+    {
+      name: "close code 1008",
+      options: {},
+      payload: getConnectedPayload("A", "test-token"),
+      code: 1008,
+    },
+    {
+      name: "non-reliable protocol",
+      options: { protocol: WebPubSubJsonProtocol() },
+      payload: getConnectedPayload("A", "test-token"),
+      code: 1006,
+    },
+    { name: "missing token", options: {}, payload: getConnectedPayload("A"), code: 1006 },
+    {
+      name: "missing connection ID",
+      options: {},
+      payload: {
+        type: "system",
+        event: "connected",
+        userId: "user",
+        reconnectionToken: "test-token",
+      },
+      code: 1006,
+    },
+  ])("does not emit recovery events for $name", async ({ options, payload, code }) => {
+    client.stop();
+    await startClient(options, payload);
+    transport.socket(0).receiveClose(code);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events.filter((event) => event.startsWith("recover"))).toEqual([]);
+    expect(events.at(-1)).toBe("stopped");
+    expect(transport.sockets).toHaveLength(1);
+  });
+
+  it.each([false, true])(
+    "preserves exhaustion fallback with autoReconnect=%s",
+    async (autoReconnect) => {
+      client.stop();
+      await startClient({ autoReconnect });
+      transport.socket(0).receiveClose(1006);
+      transport.socket(1).receiveClose(1006);
+      recoveryTimeout.abort();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      if (autoReconnect) {
+        transport.socket(2).receiveOpen();
+        transport.socket(2).receiveMessage(JSON.stringify(getConnectedPayload("B", "new-token")));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(events).toEqual([
+          "connected(A)",
+          "recovering(A)",
+          "disconnected(A)",
+          "connected(B)",
+        ]);
+      } else {
+        expect(events).toEqual(["connected(A)", "recovering(A)", "disconnected(A)", "stopped"]);
+        expect(transport.sockets).toHaveLength(2);
+      }
+    },
+  );
+
+  it("emits one pair per episode rather than per retry", async () => {
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveClose(1006);
+    await vi.advanceTimersByTimeAsync(1000);
+    transport.socket(2).receiveClose(1006);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(events).toEqual(["connected(A)", "recovering(A)"]);
+
+    transport.socket(3).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+    transport.socket(3).receiveClose(1006);
+    transport.socket(4).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events).toEqual([
+      "connected(A)",
+      "recovering(A)",
+      "recovered(A)",
+      "recovering(A)",
+      "recovered(A)",
+    ]);
+    expect(transport.sockets).toHaveLength(5);
+  });
+
+  it("does not attribute an old recovery success to a newly started connection", async () => {
+    let restarting: Promise<void> | undefined;
+    const restart = (): void => {
+      client.off("stopped", restart);
+      restarting = client.start();
+      transport.socket(2).receiveOpen();
+      transport.socket(2).receiveMessage(JSON.stringify(getConnectedPayload("B", "new-token")));
+    };
+    client.on("stopped", restart);
+
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveOpen();
+    transport.socket(1).receiveClose(1008);
+    await restarting;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events).toEqual([
+      "connected(A)",
+      "recovering(A)",
+      "disconnected(A)",
+      "stopped",
+      "connected(B)",
+    ]);
+  });
+
+  it("does not announce success if the recovery socket closes before notification", async () => {
+    transport.socket(0).receiveClose(1006);
+    const recovery = transport.socket(1);
+    recovery.receiveOpen();
+    recovery.receiveClose(1008);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events).toEqual(["connected(A)", "recovering(A)", "disconnected(A)", "stopped"]);
+  });
+
+  it.each(["pending", "backoff", "open", "listener"] as const)(
+    "does not announce recovery after stop during %s",
+    async (timing) => {
+      if (timing === "listener") {
+        client.on("recovering", () => client.stop());
+      }
+      transport.socket(0).receiveClose(1006);
+      let recovery = transport.socket(1);
+      if (timing === "backoff") {
+        recovery.receiveClose(1006);
+        await vi.advanceTimersByTimeAsync(0);
+        client.stop();
+        await vi.advanceTimersByTimeAsync(1000);
+        // Existing recovery may continue after stop; this PR changes only notifications.
+        recovery = transport.sockets.at(-1)!;
+        recovery.receiveOpen();
+      } else if (timing === "open") {
+        recovery.receiveOpen();
+        client.stop();
+      } else {
+        client.stop();
+        recovery.receiveOpen();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events.filter((event) => event.startsWith("recover"))).toEqual(["recovering(A)"]);
+    },
+  );
+
+  it("does not emit success from an episode superseded by another recovery", async () => {
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveOpen();
+    transport.socket(1).receiveClose(1006);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(events).toEqual(["connected(A)", "recovering(A)", "recovering(A)"]);
+
+    transport.socket(2).receiveOpen();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(events).toEqual(["connected(A)", "recovering(A)", "recovering(A)", "recovered(A)"]);
+  });
+
+  it("does not retry when a recovered listener stops the client", async () => {
+    client.on("recovered", () => client.stop());
+    transport.socket(0).receiveClose(1006);
+    transport.socket(1).receiveOpen();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(events).toEqual([
+      "connected(A)",
+      "recovering(A)",
+      "recovered(A)",
+      "disconnected(A)",
+      "stopped",
+    ]);
+    expect(transport.sockets).toHaveLength(2);
+  });
+
+  it.each(["recovering", "recovered"] as const)(
+    "does not let a throwing %s listener interrupt recovery or cause a retry",
+    async (event) => {
+      const listener = (): void => {
+        throw new Error("Listener failure");
+      };
+      if (event === "recovering") {
+        client.on("recovering", listener);
+      } else {
+        client.on("recovered", listener);
+      }
+
+      transport.socket(0).receiveClose(1006);
+      expect(transport.sockets).toHaveLength(2);
+      transport.socket(1).receiveOpen();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(events).toEqual(["connected(A)", "recovering(A)", "recovered(A)"]);
+      expect(transport.sockets).toHaveLength(2);
+    },
+  );
+
+  it.each([false, true])(
+    "recovers without a second connected event with autoReconnect=%s",
+    async (autoReconnect) => {
+      client.stop();
+      const getClientAccessUrl = vi.fn(async () => "wss://example.com/client/hubs/test");
+      await startClient({ autoReconnect }, getConnectedPayload("A", "test-token"), {
+        getClientAccessUrl,
+      });
+      expect(events).toEqual(["connected(A)"]);
+      const messages: unknown[] = [];
+      client.on("group-message", (args) => messages.push(args.message.data));
+      transport.socket(0).receiveMessage(JSON.stringify(getGroupDataPayload("test", "before", 1)));
+      transport.socket(0).receiveClose(1006);
+      const recovery = transport.socket(1);
+      expect(recovery.isOpen()).toBe(false);
+      expect(transport.socket(0).isOpen()).toBe(false);
+      expect(events).toEqual(["connected(A)", "recovering(A)"]);
+      const recoveryUrl = new URL(transport.requests[1].uri);
+      expect(recoveryUrl.searchParams.get("awps_connection_id")).toBe("A");
+      expect(recoveryUrl.searchParams.get("awps_reconnection_token")).toBe("test-token");
+
+      recovery.receiveOpen();
+      await vi.advanceTimersByTimeAsync(0);
+      await client.sendEvent("test", "after recovery", "text", { fireAndForget: true });
+
+      expect(recovery.sent.map((data) => JSON.parse(String(data)))).toContainEqual({
+        type: "event",
+        event: "test",
+        dataType: "text",
+        data: "after recovery",
+      });
+      expect(events).toEqual(["connected(A)", "recovering(A)", "recovered(A)"]);
+      recovery.receiveMessage(JSON.stringify(getConnectedPayload("A", "test-token")));
+      recovery.receiveMessage(JSON.stringify(getGroupDataPayload("test", "before", 1)));
+      recovery.receiveMessage(JSON.stringify(getGroupDataPayload("test", "after", 2)));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(messages).toEqual(["before", "after"]);
+      expect(events).toEqual(["connected(A)", "recovering(A)", "recovered(A)"]);
+      expect(getClientAccessUrl).toHaveBeenCalledTimes(1);
+      expect(transport.sockets).toHaveLength(2);
+    },
+  );
+});

--- a/sdk/web-pubsub/web-pubsub-client/test/controlledWebSocketClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/controlledWebSocketClient.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { WebPubSubClient } from "../src/index.js";
+import type {
+  WebSocketClientFactoryLike,
+  WebSocketClientLike,
+} from "../src/websocket/websocketClientLike.js";
+
+/** A transport boundary with distinct sockets and manually delivered events. */
+export class ControlledWebSocketClient implements WebSocketClientLike {
+  private _open = false;
+  private _onOpen?: () => void;
+  private _onClose?: (code: number, reason: string) => void;
+  private _onError?: (error: unknown) => void;
+  private _onMessage?: (data: string | Buffer | ArrayBuffer | Buffer[]) => void;
+
+  public readonly sent: unknown[] = [];
+
+  onopen(fn: () => void): void {
+    this._onOpen = fn;
+  }
+
+  onclose(fn: (code: number, reason: string) => void): void {
+    this._onClose = fn;
+  }
+
+  onerror(fn: (error: unknown) => void): void {
+    this._onError = fn;
+  }
+
+  onmessage(fn: (data: string | Buffer | ArrayBuffer | Buffer[]) => void): void {
+    this._onMessage = fn;
+  }
+
+  isOpen(): boolean {
+    return this._open;
+  }
+
+  async send(data: unknown): Promise<void> {
+    if (!this._open) {
+      throw new Error("Test socket is not open");
+    }
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = ""): void {
+    this.receiveClose(code, reason);
+  }
+
+  receiveOpen(): void {
+    this._open = true;
+    this._onOpen?.();
+  }
+
+  receiveClose(code: number, reason = ""): void {
+    this._open = false;
+    this._onClose?.(code, reason);
+  }
+
+  receiveError(error: Error): void {
+    this._onError?.(error);
+  }
+
+  receiveMessage(data: string): void {
+    this._onMessage?.(data);
+  }
+}
+
+export class ControlledWebSocketFactory implements WebSocketClientFactoryLike {
+  public readonly sockets: ControlledWebSocketClient[] = [];
+  public readonly requests: { uri: string; protocolName: string }[] = [];
+
+  constructor(client: WebPubSubClient) {
+    // Replace only the transport factory, as in TestWebSocketClient. All client
+    // lifecycle decisions and message serialization remain real SDK behavior.
+    client["_getWebSocketClientFactory"] = () => this;
+  }
+
+  create(uri: string, protocolName: string): ControlledWebSocketClient {
+    const socket = new ControlledWebSocketClient();
+    this.requests.push({ uri, protocolName });
+    this.sockets.push(socket);
+    return socket;
+  }
+
+  socket(index: number): ControlledWebSocketClient {
+    const socket = this.sockets[index];
+    if (!socket) {
+      throw new Error(`Socket ${index} has not been created`);
+    }
+    return socket;
+  }
+}

--- a/sdk/web-pubsub/web-pubsub-client/test/snippets.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/snippets.spec.ts
@@ -22,6 +22,23 @@ describe("snippets", () => {
     await client.start();
   });
 
+  it("ReadmeSampleRecoveryEvents", async () => {
+    // Disabling fresh reconnect does not disable reliable recovery.
+    const client = new WebPubSubClient("<client-access-url>", { autoReconnect: false });
+    // @ts-preserve-whitespace
+    // Register listeners before starting the client.
+    client.on("recovering", (e) => {
+      console.log(`Recovering connection ${e.connectionId}.`);
+    });
+    client.on("recovered", (e) => {
+      console.log(
+        `Connection ${e.connectionId} recovered; message replay may still be in progress.`,
+      );
+    });
+    // @ts-preserve-whitespace
+    await client.start();
+  });
+
   it("ReadmeSampleJoinGroups", async () => {
     const client = new WebPubSubClient("<client-access-url>");
     // @ts-preserve-whitespace


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/web-pubsub-client`

### Issues associated with this PR

Related discussions:

- https://github.com/Azure/azure-sdk-for-js/issues/32735 — recovery observability is relevant, but this PR does not claim to fix the reported iOS transport behavior.
- https://github.com/Azure/azure-sdk-for-js/issues/39821 — adjacent lifecycle observability request; close-code fields are outside this PR's scope.

### Describe the problem that is addressed by this PR

With a reliable subprotocol, the client can recover an interrupted connection while retaining its logical connection ID. The existing `disconnected` event is emitted only when recovery is unavailable or fails, and successful same-connection recovery does not emit a new `connected` event.

Consequently, an application cannot observe the beginning and successful completion of reliable recovery through the public event interface. It cannot reliably show recovery status or measure recovery duration without parsing SDK logs or relying on private implementation details.

This proposal adds two typed events:

- `recovering`, with `OnRecoveringArgs { connectionId: string }`, when the SDK enters its reliable-recovery episode.
- `recovered`, with `OnRecoveredArgs { connectionId: string }`, when the active recovery socket opens successfully for the retained logical connection.

Both events support `on` and `off`. They do not expose recovery credentials. The success event describes the SDK's socket-recovery outcome; it does not promise that retained-message replay or application synchronization is complete.

Expected successful sequence:

```text
connected(A) → recovering(A) → recovered(A)
```

If recovery fails, existing `disconnected` and auto-reconnect/stopped behavior remains authoritative. There is no additional failure event and no change to the meaning of `connected`. Reliable recovery remains available when `autoReconnect` is false.

Synchronous listener exceptions for the new events are logged without interrupting recovery or turning an opened recovery socket into a retry. This does not change existing EventEmitter dispatch semantics or handle rejected async listener promises.

Notification-generation and socket-identity/open checks suppress success notifications from stopped or superseded episodes. These checks affect only the new notifications: this PR does not fix existing shutdown bugs or alter recovery attempts, retry timing, or existing lifecycle events.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

1. **Two additive typed events (proposed).** Matches existing registration patterns, preserves same-connection versus fresh-connection semantics, and gives per-client observations without changing recovery ownership.
2. **Reuse `disconnected` and `connected`.** Would change existing contracts and could cause consumers to repeat fresh-connection initialization or abandon successful reliable recovery.
3. **Expose internal state or socket objects.** Requires polling or coupling to implementation details and exposes substantially more surface than this use case needs.
4. **Parse SDK logs.** Not a stable typed interface and requires handling process-global diagnostics and per-client attribution.

No new retry policy, keep-alive configuration, delivery replay, group management behavior, or recovery-failure event is proposed.

### Are there test cases added in this PR? _(If not, why?)_

22 recovery-event tests were added and passed in Node and Chromium. Coverage includes:

- Typed registration, removal, root exports, and argument shape.
- Successful same-connection event ordering without a second `connected` event.
- Multiple retry attempts and repeated independent recovery episodes.
- Recovery unavailable or exhausted, with auto-reconnect enabled and disabled.
- Synchronous throwing listeners and suppression of new success notifications after stop or stale completion.
- Compatibility with existing lifecycle and message behavior.

Local verification results (not upstream CI):

| Check | Actual command / environment | Result |
| --- | --- | --- |
| Package/dependency build | `pnpm turbo build --filter=@azure/web-pubsub-client... --token 1` | Passed |
| API report and public types | `pnpm run extract-api`; local public-root consumer checks for ESM/CommonJS/browser/React Native declarations | Passed; API report adds only two types and four overloads |
| Node tests | `pnpm run test` (Node phase) | 200 passed |
| Browser tests | `pnpm run test` (Chromium phase) | 180 passed, 15 live integration tests skipped |
| Lint and formatting | `pnpm run lint`, `pnpm run check-format` | Passed |
| Snippet generation | `pnpm run update-snippets` | Passed |
| Live recovery smoke check | Requires an authorized Azure test resource | Not run |

Environment: Windows x64, Node 24.20.0, pnpm 11.24.0, Vitest 4.1.10, Chromium 151.0.7922.34. Artifact import/registration smoke checks used a Node host; no React Native device run is claimed.

### Provide a list of related PRs _(if any)_

None. Existing bug fixes are explicitly outside this PR's scope.

### Command used to generate this PR: _(Applicable only to SDK release request PRs)_

Not applicable; this is a hand-authored client-library feature, not a generated SDK release request.

### Checklists

- [x] No SDK Generator/TypeSpec change is required for this hand-authored client feature.
- [x] Added an Unreleased changelog feature entry.
- [x] Updated lifecycle documentation and generated snippets.
- [x] Regenerated and reviewed the public API report.
- [x] Recorded actual verification results and any limitations.