### PR TITLE
[monitor-opentelemetry-exporter] Detect distros for OneSettings

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.0.0-beta.46 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Added Azure Monitor OpenTelemetry distro detection to the OneSettings configuration profile so distro processes are targeted with the distro component and version.
+
 ## 1.0.0-beta.45 (2026-09-04)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed OneSettings configuration profiles incorrectly identifying Azure Monitor and Microsoft OpenTelemetry distro processes as standalone exporters. [#39923](https://github.com/Azure/azure-sdk-for-js/pull/39923)
 
-- Added Azure Monitor and Microsoft OpenTelemetry distro detection to the OneSettings configuration profile so distro processes are targeted with the appropriate component and version.
+### Other Changes
 
 ## 1.0.0-beta.45 (2026-09-04)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Added Azure Monitor OpenTelemetry distro detection to the OneSettings configuration profile so distro processes are targeted with the distro component and version.
+- Added Azure Monitor and Microsoft OpenTelemetry distro detection to the OneSettings configuration profile so distro processes are targeted with the appropriate component and version.
 
 ## 1.0.0-beta.45 (2026-09-04)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/monitor-opentelemetry-exporter",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.45",
+  "version": "1.0.0-beta.46",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -4,6 +4,7 @@
 import { diag } from "@opentelemetry/api";
 import {
   ENV_AZURE_MONITOR_DISTRO_VERSION,
+  ENV_MICROSOFT_OPENTELEMETRY_VERSION,
   ONE_SETTINGS_BACKOFF_BASE_MS,
   ONE_SETTINGS_CHANGE_URL,
   ONE_SETTINGS_CONFIG_URL,
@@ -77,19 +78,22 @@ export class ConfigurationManager {
    * constructor, since only the first call has any effect.
    *
    * @param profile - Running SDK attributes contributed by the caller. Existing profile fields
-   * remain unchanged. When the Azure Monitor distro version environment variable is present, the
-   * distro component and version take precedence over the caller's values.
+   * remain unchanged. When a supported distro version environment variable is present, its
+   * component and version take precedence over the caller's values.
    */
   public initialize(profile: Partial<ConfigurationProfileValues> = {}): void {
-    const distroVersion = process.env[ENV_AZURE_MONITOR_DISTRO_VERSION];
+    const microsoftDistroVersion = process.env[ENV_MICROSOFT_OPENTELEMETRY_VERSION];
+    const azureMonitorDistroVersion = process.env[ENV_AZURE_MONITOR_DISTRO_VERSION];
+    const distroProfile: Partial<ConfigurationProfileValues> = microsoftDistroVersion
+      ? { component: "mot", version: microsoftDistroVersion }
+      : azureMonitorDistroVersion
+        ? { component: "dst", version: azureMonitorDistroVersion }
+        : {};
     ConfigurationProfile.getInstance().fill(
-      distroVersion
-        ? {
-            ...profile,
-            component: "dst",
-            version: distroVersion,
-          }
-        : profile,
+      {
+        ...profile,
+        ...distroProfile,
+      },
     );
     if (this.worker) {
       return;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -3,6 +3,7 @@
 
 import { diag } from "@opentelemetry/api";
 import {
+  ENV_AZURE_MONITOR_DISTRO_VERSION,
   ONE_SETTINGS_BACKOFF_BASE_MS,
   ONE_SETTINGS_CHANGE_URL,
   ONE_SETTINGS_CONFIG_URL,
@@ -76,10 +77,20 @@ export class ConfigurationManager {
    * constructor, since only the first call has any effect.
    *
    * @param profile - Running SDK attributes contributed by the caller. Existing profile fields
-   * remain unchanged.
+   * remain unchanged. When the Azure Monitor distro version environment variable is present, the
+   * distro component and version take precedence over the caller's values.
    */
   public initialize(profile: Partial<ConfigurationProfileValues> = {}): void {
-    ConfigurationProfile.getInstance().fill(profile);
+    const distroVersion = process.env[ENV_AZURE_MONITOR_DISTRO_VERSION];
+    ConfigurationProfile.getInstance().fill(
+      distroVersion
+        ? {
+            ...profile,
+            component: "dst",
+            version: distroVersion,
+          }
+        : profile,
+    );
     if (this.worker) {
       return;
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/_configuration/configurationManager.ts
@@ -89,12 +89,10 @@ export class ConfigurationManager {
       : azureMonitorDistroVersion
         ? { component: "dst", version: azureMonitorDistroVersion }
         : {};
-    ConfigurationProfile.getInstance().fill(
-      {
-        ...profile,
-        ...distroProfile,
-      },
-    );
+    ConfigurationProfile.getInstance().fill({
+      ...profile,
+      ...distroProfile,
+    });
     if (this.worker) {
       return;
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -20,7 +20,7 @@ export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
  * AzureMonitorTraceExporter version.
  * @internal
  */
-export const packageVersion = "1.0.0-beta.45";
+export const packageVersion = "1.0.0-beta.46";
 
 /**
  * Telemetry base data version.

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
@@ -8,6 +8,7 @@ import type { OneSettingsResponse } from "../../src/_configuration/utils.js";
 import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
 import {
   ENV_AZURE_MONITOR_DISTRO_VERSION,
+  ENV_MICROSOFT_OPENTELEMETRY_VERSION,
   ONE_SETTINGS_CHANGE_URL,
   ONE_SETTINGS_CONFIG_URL,
   ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
@@ -38,6 +39,7 @@ describe("ConfigurationManager", () => {
     ConfigurationProfile.getInstance().reset();
     request.mockReset();
     vi.stubEnv(ENV_AZURE_MONITOR_DISTRO_VERSION, "");
+    vi.stubEnv(ENV_MICROSOFT_OPENTELEMETRY_VERSION, "");
   });
 
   afterEach(() => {
@@ -79,6 +81,44 @@ describe("ConfigurationManager", () => {
       component: "dst",
       region: "westus",
       ikey: "test-ikey",
+    });
+  });
+
+  it("detects the Microsoft OpenTelemetry distro from its version environment variable", () => {
+    vi.stubEnv(ENV_MICROSOFT_OPENTELEMETRY_VERSION, "2.0.0");
+
+    manager.initialize({
+      component: "ext",
+      version: "1.0.0-beta.46",
+      region: "westus",
+      ikey: "test-ikey",
+    });
+
+    assert.deepStrictEqual(ConfigurationProfile.getInstance().snapshot(), {
+      os: "",
+      rp: "",
+      attach: "",
+      version: "2.0.0",
+      component: "mot",
+      region: "westus",
+      ikey: "test-ikey",
+    });
+  });
+
+  it("prefers the Microsoft distro when both distro version variables are present", () => {
+    vi.stubEnv(ENV_AZURE_MONITOR_DISTRO_VERSION, "1.20.0");
+    vi.stubEnv(ENV_MICROSOFT_OPENTELEMETRY_VERSION, "2.0.0");
+
+    manager.initialize({ component: "ext", version: "1.0.0-beta.46" });
+
+    assert.deepStrictEqual(ConfigurationProfile.getInstance().snapshot(), {
+      os: "",
+      rp: "",
+      attach: "",
+      version: "2.0.0",
+      component: "mot",
+      region: "",
+      ikey: "",
     });
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/configurationManager.spec.ts
@@ -7,6 +7,7 @@ import { ConfigurationProfile } from "../../src/_configuration/configurationProf
 import type { OneSettingsResponse } from "../../src/_configuration/utils.js";
 import { makeOneSettingsRequest } from "../../src/_configuration/utils.js";
 import {
+  ENV_AZURE_MONITOR_DISTRO_VERSION,
   ONE_SETTINGS_CHANGE_URL,
   ONE_SETTINGS_CONFIG_URL,
   ONE_SETTINGS_DEFAULT_REFRESH_INTERVAL_MS,
@@ -36,11 +37,13 @@ describe("ConfigurationManager", () => {
     manager.reset();
     ConfigurationProfile.getInstance().reset();
     request.mockReset();
+    vi.stubEnv(ENV_AZURE_MONITOR_DISTRO_VERSION, "");
   });
 
   afterEach(() => {
     manager.reset();
     ConfigurationProfile.getInstance().reset();
+    vi.unstubAllEnvs();
   });
 
   it("fills the write-once evaluation profile across repeated initialization", () => {
@@ -53,6 +56,27 @@ describe("ConfigurationManager", () => {
       attach: "",
       version: "1.0.0",
       component: "ext",
+      region: "westus",
+      ikey: "test-ikey",
+    });
+  });
+
+  it("detects the Azure Monitor distro from its version environment variable", () => {
+    vi.stubEnv(ENV_AZURE_MONITOR_DISTRO_VERSION, "1.20.0");
+
+    manager.initialize({
+      component: "ext",
+      version: "1.0.0-beta.45",
+      region: "westus",
+      ikey: "test-ikey",
+    });
+
+    assert.deepStrictEqual(ConfigurationProfile.getInstance().snapshot(), {
+      os: "",
+      rp: "",
+      attach: "",
+      version: "1.20.0",
+      component: "dst",
       region: "westus",
       ikey: "test-ikey",
     });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry-exporter`

### Describe the problem that is addressed by this PR

The OneSettings configuration profile currently identifies every exporter initialization as the standalone exporter (`ext`), even when the exporter is running through the released Azure Monitor OpenTelemetry distro or the Microsoft OpenTelemetry distro.

Detect `MICROSOFT_OPENTELEMETRY_VERSION` and `AZURE_MONITOR_DISTRO_VERSION` during configuration manager initialization and identify the process as the Microsoft distro (`mot`) or Azure Monitor distro (`dst`) with the corresponding package version. Microsoft distro detection takes precedence when both markers are present, matching the exporter’s existing `ai.internal.sdkVersion` behavior. Exporter-contributed fields such as region and instrumentation key continue to populate the write-once profile.

The Azure Monitor distro path follows the Python Azure Monitor OpenTelemetry implementation while preserving standalone exporter behavior.

### Are there test cases added in this PR?

Yes. Unit coverage verifies standalone exporter behavior, both distro detection paths, and Microsoft distro precedence. The exporter Node test suite, lint, formatting checks, and package build pass.