### PR TITLE
[keyvault] Skip automatic customization in pipelines

### DIFF
--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -55,7 +55,7 @@
     "test:node": "dev-tool run test:vitest",
     "test:node:live": "cross-env TEST_MODE=live dev-tool run test:vitest --no-test-proxy",
     "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "customize": "echo skipped: customization must be run manually"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -123,7 +123,7 @@
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "customize": "echo skipped: customization must be run manually"
   },
   "imports": {
     "#platform/*": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -51,7 +51,7 @@
     "test:browser": "echo skipped",
     "test:node": "dev-tool run test:vitest",
     "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "customize": "echo skipped: customization must be run manually"
   },
   "sideEffects": false,
   "//metadata": {

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -134,7 +134,7 @@
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "customize": "echo skipped: customization must be run manually"
   },
   "imports": {
     "#platform/*": {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-admin`
- `@azure/keyvault-certificates`
- `@azure/keyvault-keys`
- `@azure/keyvault-secrets`

### Issues associated with this PR

None.

### Describe the problem that is addressed by this PR

The pipeline validation for #39748 runs the package `customize` commands automatically, which applies the Key Vault customizations again and causes the pipeline to fail.

This changes the four Key Vault `customize` commands to an explicit no-op so customization must be run manually (restoring the previous behavior). 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could change the pipeline behavior, but I would rather keep the scope small and make these package scripts explicit about the current manual customization workflow.

### Are there test cases added in this PR? _(If not, why?)_

No tests added since this only changes package scripts. I ran all four `customize` commands and their `check-format` scripts locally.

### Provide a list of related PRs _(if any)_

- #39748

### Checklists
- [x] Added impacted package names to the PR description.
- [x] No SDK Generator fix is needed for this change.
- [x] No changelog is necessary because this does not change package behavior.