### PR TITLE
Update Communication Identity API version to 2026-09-23

### DIFF
--- a/sdk/communication/communication-identity/CHANGELOG.md
+++ b/sdk/communication/communication-identity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.4.0-beta.2 (Unreleased)
 
+### Features Added
+
+- Updated the default service API version to `2026-09-23`.
+
 ### Other Changes
 
 - Optimized type imports for improved tree-shaking and build performance.

--- a/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
+++ b/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
@@ -71,7 +71,7 @@ export class IdentityRestClient extends coreClient.ServiceClient {
     this.endpoint = endpoint;
 
     // Assigning values to Constant parameters
-    this.apiVersion = options.apiVersion || "2025-03-02-preview";
+    this.apiVersion = options.apiVersion || "2026-09-23";
     this.communicationIdentityOperations =
       new CommunicationIdentityOperationsImpl(this);
     this.teamsExtensionToken = new TeamsExtensionTokenImpl(this);

--- a/sdk/communication/communication-identity/src/generated/src/models/parameters.ts
+++ b/sdk/communication/communication-identity/src/generated/src/models/parameters.ts
@@ -73,7 +73,7 @@ export const endpoint: OperationURLParameter = {
 export const apiVersion: OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
-    defaultValue: "2025-03-02-preview",
+    defaultValue: "2026-09-23",
     isConstant: true,
     serializedName: "api-version",
     type: {

--- a/sdk/communication/communication-identity/src/generated/src/operations/communicationIdentityOperations.ts
+++ b/sdk/communication/communication-identity/src/generated/src/operations/communicationIdentityOperations.ts
@@ -27,9 +27,7 @@ import {
 } from "../models/index.js";
 
 /** Class containing CommunicationIdentityOperations operations. */
-export class CommunicationIdentityOperationsImpl
-  implements CommunicationIdentityOperations
-{
+export class CommunicationIdentityOperationsImpl implements CommunicationIdentityOperations {
   private readonly client: IdentityRestClient;
 
   /**

--- a/sdk/communication/communication-identity/swagger/README.md
+++ b/sdk/communication/communication-identity/swagger/README.md
@@ -27,4 +27,8 @@ typescript:
   generate-metadata: false
   azure-arm: false
 module-kind: esm
+directive:
+  from: swagger-document
+  where: $.info
+  transform: $.version = "2026-09-23";
 ```

--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
@@ -33,6 +33,7 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     const request = spy.mock.calls[0][0];
 
     assert.equal(request.headers.get("host"), "contoso.spool.azure.local");
+    assert.equal(new URL(request.url).searchParams.get("api-version"), "2026-09-23");
 
     assert.typeOf(request.headers.get(dateHeader), "string");
     assert.isDefined(request.headers.get("authorization"));

--- a/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-identity/test/public/utils/recordedClient.ts
@@ -29,6 +29,12 @@ const envSetupForPlayback: { [k: string]: string } = {
   SKIP_INT_IDENTITY_EXCHANGE_TOKEN_TEST: "false",
 };
 
+const apiVersionSanitizer = {
+  regex: true,
+  target: "api-version=[^&]+",
+  value: "api-version=Sanitized",
+};
+
 const sanitizerOptions: SanitizerOptions = {
   connectionStringSanitizers: [
     {
@@ -37,6 +43,7 @@ const sanitizerOptions: SanitizerOptions = {
     },
   ],
   uriSanitizers: [
+    apiVersionSanitizer,
     {
       regex: true,
       target: `(.*)/identities/(?<secret_content>.*?)[/|?](.*)`,
@@ -65,6 +72,7 @@ const recorderOptions: RecorderStartOptions = {
 export async function createRecorder(context: TestInfo | undefined): Promise<Recorder> {
   const recorder = new Recorder(context);
   await recorder.start(recorderOptions);
+  await recorder.addSanitizers({ uriSanitizers: [apiVersionSanitizer] }, ["playback"]);
   await recorder.setMatcher("CustomDefaultMatcher", {
     excludedHeaders: [
       "Accept-Language", // This is env-dependent


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/communication-identity`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Communication Identity clients need to send the stable `2026-09-23` service API version while preserving the existing SDK surface. This change uses the prior Swagger contract as the generation base and overrides only its API version.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The stable specification reorganizes generated operation groups and would introduce unrelated client changes. The AutoRest transform keeps this update limited to the requested API version and remains reproducible during regeneration.

### Are there test cases added in this PR? _(If not, why?)_

Yes. A mocked-client assertion verifies the outgoing `api-version`, and playback sanitization allows existing recordings to validate the new version.

Validation completed:

- `npm run check-format --prefix sdk/communication/communication-identity`
- `npm run lint --prefix sdk/communication/communication-identity`
- `pnpm turbo build --filter=@azure/communication-identity... --token 1`
- Node tests: 95 passed
- Browser tests: 59 passed

### Provide a list of related PRs _(if any)_

N/A

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator? No.
- [x] Added a changelog (if necessary).