### PR TITLE
[engSys] Fall back to clean generated output when pipeline customization fails

### DIFF
--- a/eng/tools/js-sdk-release-tools/src/common/devToolUtils.ts
+++ b/eng/tools/js-sdk-release-tools/src/common/devToolUtils.ts
@@ -3,6 +3,9 @@ import { runCommand, runCommandOptions } from "./utils.js";
 import fs from "fs";
 import path from "path";
 
+const CUSTOMIZATION_HELP_URL =
+  "https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/modular-customization.md";
+
 export async function formatSdk(packageDirectory: string) {
   logger.info(`Start to format code in '${packageDirectory}'.`);
   const cwd = packageDirectory;
@@ -101,4 +104,51 @@ export async function customizeCodes(packageDirectory: string): Promise<void> {
   } catch (error) {
     logger.warn(`Failed to customize codes due to: ${(error as Error)?.stack ?? error}`);
   }
+}
+
+/**
+ * Emits the shared warning telling the package owner that automatic customization
+ * failed and must be re-applied manually on the generated SDK pull request.
+ */
+export function warnCustomizationFallback(packageName?: string): void {
+  const pkg = packageName ? ` for '${packageName}'` : "";
+  logger.warn(
+    `Automatic customization could not be applied${pkg}, so the SDK was generated WITHOUT ` +
+      `customization to keep validation and API view generation unblocked. The package owner ` +
+      `must apply customization manually on the generated SDK pull request. See ${CUSTOMIZATION_HELP_URL}.`,
+  );
+}
+
+/**
+ * Wholesale fallback used by the automated pipelines when a package fails to build
+ * after customization: replace the customized `src` tree with a clean copy of the
+ * freshly generated output, dropping *all* customizations.
+ *
+ * This mirrors the Java generator's `disable_customization` clean regeneration
+ * (eng/automation/generate_data.py). Resetting only the conflicting files is not
+ * safe because customizations are cross-file coupled (a kept file may import a
+ * symbol from a reset file), so the result would not be guaranteed to compile.
+ * The emitter output in `generated/` is self-contained and builds on its own.
+ *
+ * Only packages that use the merge-based customization layout (a root `generated/`
+ * directory) are reset; other packages are left untouched.
+ *
+ * @returns true if a clean generated tree was materialized, false otherwise.
+ */
+export async function resetToGeneratedOutput(packageDirectory: string): Promise<boolean> {
+  const generatedDirectory = path.join(packageDirectory, "generated");
+  const sourceDirectory = path.join(packageDirectory, "src");
+
+  if (!fs.existsSync(generatedDirectory)) {
+    // Not a merge-based customization package; nothing to reset to.
+    return false;
+  }
+
+  logger.info(
+    `Resetting '${sourceDirectory}' to the clean generated output from '${generatedDirectory}'.`,
+  );
+  await fs.promises.rm(sourceDirectory, { force: true, recursive: true });
+  await fs.promises.mkdir(path.dirname(sourceDirectory), { recursive: true });
+  await fs.promises.cp(generatedDirectory, sourceDirectory, { recursive: true });
+  return true;
 }

--- a/eng/tools/js-sdk-release-tools/src/common/rushUtils.ts
+++ b/eng/tools/js-sdk-release-tools/src/common/rushUtils.ts
@@ -8,7 +8,14 @@ import { runCommand, runCommandOptions, cleanupSamplesFolder } from "./utils.js"
 
 import { glob } from "glob";
 import { logger } from "../utils/logger.js";
-import { customizeCodes, formatSdk, lintFix, updateSnippets } from "./devToolUtils.js";
+import {
+  customizeCodes,
+  formatSdk,
+  lintFix,
+  resetToGeneratedOutput,
+  updateSnippets,
+  warnCustomizationFallback,
+} from "./devToolUtils.js";
 import { getModularSDKType } from "../utils/generateInputUtils.js";
 
 async function packPackage(packageDirectory: string, packageName: string) {
@@ -118,18 +125,39 @@ export async function buildPackage(
   if (modularSDKType === ModularSDKType.DataPlane) {
     errorAsWarning = true;
   }
-  try {
-    await runCommand(
-      "pnpm",
-      ["turbo", "build", "--filter", `${name}...`, "--token 1"],
-      runCommandOptions,
-      true,
-      undefined,
-      errorAsWarning,
-    );
-  } catch (error) {
-    logger.warn(`Failed to build data plane package due to ${(error as Error)?.stack ?? error}`);
-    buildStatus = `failed`;
+  const buildOnce = async (): Promise<"succeeded" | "failed"> => {
+    try {
+      await runCommand(
+        "pnpm",
+        ["turbo", "build", "--filter", `${name}...`, "--token 1"],
+        runCommandOptions,
+        true,
+        undefined,
+        errorAsWarning,
+      );
+      return "succeeded";
+    } catch (error) {
+      logger.warn(`Failed to build data plane package due to ${(error as Error)?.stack ?? error}`);
+      return "failed";
+    }
+  };
+
+  buildStatus = await buildOnce();
+
+  // Mirror the Java generator: in the automated spec-PR / batch pipelines a
+  // customization that is incompatible with the newly generated code cannot be
+  // resolved by a human, so fall back to the clean (uncustomized) generated
+  // output and rebuild. Gating on the build result also catches customizations
+  // that merged without conflict markers but no longer compile.
+  if (
+    buildStatus === "failed" &&
+    (options.runMode === RunMode.SpecPullRequest || options.runMode === RunMode.Batch)
+  ) {
+    const didReset = await resetToGeneratedOutput(packageDirectory);
+    if (didReset) {
+      warnCustomizationFallback(name);
+      buildStatus = await buildOnce();
+    }
   }
   if (buildStatus === `succeeded`) {
     const apiViewContext = await addApiViewInfo(

--- a/eng/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/eng/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -24,7 +24,14 @@ import {
 } from "../../common/utils.js";
 import { generateChangelogAndBumpVersion } from "../../common/changelog/automaticGenerateChangeLogAndBumpVersion.js";
 import { updateChangelogResult } from "../../common/packageResultUtils.js";
-import { formatSdk, updateSnippets, lintFix, customizeCodes } from "../../common/devToolUtils.js";
+import {
+  formatSdk,
+  updateSnippets,
+  lintFix,
+  customizeCodes,
+  resetToGeneratedOutput,
+  warnCustomizationFallback,
+} from "../../common/devToolUtils.js";
 import { ensurePnpmInstalled } from "../../common/rushUtils.js";
 import { RunMode } from "../../common/types.js";
 import fsExtra from "fs-extra";
@@ -314,7 +321,30 @@ export async function generateRLCInPipeline(options: {
         buildStatus = `failed`;
       }
     } else {
-      execSync(`pnpm run --filter ${packageName}... build`, { stdio: "inherit" });
+      // spec-PR / batch: a customization that no longer applies must not block the
+      // pipeline. Fall back to the clean generated output and rebuild, mirroring the
+      // Java generator; the owner re-applies customization on the generated SDK PR.
+      try {
+        execSync(`pnpm run --filter ${packageName}... build`, { stdio: "inherit" });
+      } catch (error) {
+        const didReset = await resetToGeneratedOutput(packagePath);
+        if (didReset) {
+          warnCustomizationFallback(packageName);
+          try {
+            execSync(`pnpm run --filter ${packageName}... build`, { stdio: "inherit" });
+          } catch (retryError) {
+            logger.warn(
+              `Failed to build package after customization fallback due to: ${
+                (retryError as Error)?.stack ?? retryError
+              }`,
+            );
+            buildStatus = `failed`;
+          }
+        } else {
+          logger.warn(`Failed to build package due to: ${(error as Error)?.stack ?? error}`);
+          buildStatus = `failed`;
+        }
+      }
     }
 
     logger.info(`Start to run command 'pnpm run --filter ${packageJson.name}... pack'.`);

--- a/eng/tools/js-sdk-release-tools/src/test/common/devToolUtils.test.ts
+++ b/eng/tools/js-sdk-release-tools/src/test/common/devToolUtils.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const mocks = vi.hoisted(() => ({
   runCommand: vi.fn(),
@@ -52,5 +56,52 @@ describe("customizeCodes", () => {
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
       `Failed to customize codes due to: ${error.stack}`,
     );
+  });
+});
+
+describe("resetToGeneratedOutput", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    mocks.loggerInfo.mockReset();
+    dir = await mkdtemp(join(tmpdir(), "reset-generated-"));
+  });
+
+  test("replaces src with a clean copy of generated, dropping customizations", async () => {
+    await mkdir(join(dir, "generated", "api"), { recursive: true });
+    await writeFile(join(dir, "generated", "index.ts"), "export const generated = true;");
+    await writeFile(join(dir, "generated", "api", "operations.ts"), "export const op = 1;");
+    await mkdir(join(dir, "src"), { recursive: true });
+    await writeFile(join(dir, "src", "index.ts"), "export const customized = true;");
+    // customization-only file that is not present in generated
+    await writeFile(join(dir, "src", "handwritten.ts"), "export const custom = 1;");
+
+    const { resetToGeneratedOutput } = await import("../../common/devToolUtils.js");
+    await expect(resetToGeneratedOutput(dir)).resolves.toBe(true);
+
+    // src now mirrors generated exactly
+    expect(await readFile(join(dir, "src", "index.ts"), "utf-8")).toBe(
+      "export const generated = true;",
+    );
+    expect(existsSync(join(dir, "src", "api", "operations.ts"))).toBe(true);
+    // the customization-only file is gone (wholesale reset)
+    expect(existsSync(join(dir, "src", "handwritten.ts"))).toBe(false);
+
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  test("is a no-op for packages without a generated directory", async () => {
+    await mkdir(join(dir, "src"), { recursive: true });
+    await writeFile(join(dir, "src", "index.ts"), "export const customized = true;");
+
+    const { resetToGeneratedOutput } = await import("../../common/devToolUtils.js");
+    await expect(resetToGeneratedOutput(dir)).resolves.toBe(false);
+
+    // src is untouched
+    expect(await readFile(join(dir, "src", "index.ts"), "utf-8")).toBe(
+      "export const customized = true;",
+    );
+
+    await rm(dir, { force: true, recursive: true });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/js-sdk-release-tools` (engineering system / generation pipeline; no shipped SDK package changes)

### Issues associated with this PR

None.

### Describe the problem that is addressed by this PR

#39748 made the generation pipeline run each package's `customize` script automatically but that means that when the customization script encounters a merge conflict the spec PR fails and there's no way for the engineer to fix it. This PR matches Java's strategy of "trying to apply customization but on error fallback to purely generated code". That at least allows an engineer to:

1. Validate their typespec produces valid JS (by using the newly generated code)
2. Apply customization manually after the fact and fix any merge conflicts

Note: For HLC packages I think we should move them to the pattern storage is using (where codegen dumps generated files in src/generated and there's no 3-way-merge)

### Provide a list of related PRs _(if any)_

- #39748 (introduced automatic customization)
- #39924 (temporarily disabled Key Vault customization; a follow-up PR will revert that once this lands)

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? _(If so, create an Issue in the [typespec-azure](https://github.com/Azure/typespec-azure) repository and link it here)_
- [x] Added a changelog (if necessary) - N/A, internal tooling with no changelog
