### PR TITLE
[engSys] Revert #39748

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,7 +856,7 @@ importers:
         version: link:../../monitor/monitor-opentelemetry
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.45
-        version: link:../../monitor/monitor-opentelemetry-exporter
+        version: 1.0.0-beta.45(supports-color@8.1.1)
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0(supports-color@8.1.1)
@@ -962,7 +962,7 @@ importers:
         version: 4.13.0(supports-color@8.1.1)
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.45
-        version: link:../../monitor/monitor-opentelemetry-exporter
+        version: 1.0.0-beta.45(supports-color@8.1.1)
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0(supports-color@8.1.1)
@@ -22463,7 +22463,7 @@ importers:
         specifier: ^1.3.0
         version: link:../../core/logger
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.45
+        specifier: 1.0.0-beta.46
         version: link:../monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.1.0-beta.1
@@ -22798,7 +22798,7 @@ importers:
         version: 4.13.0(supports-color@8.1.1)
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.45
-        version: link:../monitor-opentelemetry-exporter
+        version: 1.0.0-beta.45(supports-color@8.1.1)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -22889,7 +22889,7 @@ importers:
         version: 4.13.0(supports-color@8.1.1)
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.45
-        version: link:../monitor-opentelemetry-exporter
+        version: 1.0.0-beta.45(supports-color@8.1.1)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -36019,6 +36019,10 @@ packages:
     resolution: {integrity: sha1-WVl6L1Q4ujxsh4n8hw9p4OeFMag=}
     engines: {node: '>=22.0.0'}
 
+  '@azure/core-process@1.0.0':
+    resolution: {integrity: sha1-w68cFyI9ZTjhs2ln3clM2uUyy4M=}
+    engines: {node: '>=22.0.0'}
+
   '@azure/core-tracing@1.4.0':
     resolution: {integrity: sha1-1lenAOJNJW0ZXmKKeV22qMxHXqs=}
     engines: {node: '>=22.0.0'}
@@ -36081,6 +36085,10 @@ packages:
   '@azure/maps-common@1.0.0-beta.2':
     resolution: {integrity: sha1-Cey+hAiSgQAjgn7y2DjyGaUcHDU=}
     engines: {node: '>=14.0.0'}
+
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.45':
+    resolution: {integrity: sha1-G9v/g//cBjwX3AxPLXK+Gdd0IDI=}
+    engines: {node: '>=22.0.0'}
 
   '@azure/msal-browser@4.30.0':
     resolution: {integrity: sha1-MPuveuJtmrdnGqvKPUH5xS0qOTc=}
@@ -42305,6 +42313,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@azure/core-process@1.0.0': {}
+
   '@azure/core-tracing@1.4.0':
     dependencies:
       tslib: 2.8.1
@@ -42465,6 +42475,26 @@ snapshots:
       '@azure/core-client': 1.11.0(supports-color@8.1.1)
       '@azure/core-lro': 2.7.2(supports-color@8.1.1)
       '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.45(supports-color@8.1.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.8.0(supports-color@8.1.1)
+      '@azure/core-auth': 1.11.0(supports-color@8.1.1)
+      '@azure/core-client': 1.11.0(supports-color@8.1.1)
+      '@azure/core-process': 1.0.0
+      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
+      '@azure/core-util': 1.14.0(supports-color@8.1.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -96,7 +96,7 @@
     "extract-api": "rimraf review && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"samples-dev/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "generate": "rimraf ./src/generated && mkdirp ./src/generated && npm run copy:yaml && npm run tsp:update && rimraf ./src/generated/test && rimraf ./src/generated/tsp-location.yaml",
-    "generate:client": "tsp-client update -d && npm run customize",
+    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply",
     "generate-samples": "dev-tool samples publish -f",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
@@ -106,8 +106,7 @@
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "post-emitter": "node scripts/post-emitter.mjs",
     "tsp:update": "tsp-client update -o ./src/generated",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && dev-tool customization apply"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/batch/batch-rest/package.json
+++ b/sdk/batch/batch-rest/package.json
@@ -100,8 +100,7 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -96,8 +96,7 @@
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/communication/communication-job-router-rest/package.json
+++ b/sdk/communication/communication-job-router-rest/package.json
@@ -49,8 +49,7 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -114,7 +114,6 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   }
 }

--- a/sdk/contentunderstanding/ai-content-understanding/package.json
+++ b/sdk/contentunderstanding/ai-content-understanding/package.json
@@ -101,8 +101,7 @@
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/discovery/ai-discovery/package.json
+++ b/sdk/discovery/ai-discovery/package.json
@@ -231,8 +231,7 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "//sampleConfiguration": {
     "productName": "Microsoft Discovery",

--- a/sdk/eventgrid/eventgrid-systemevents/package.json
+++ b/sdk/eventgrid/eventgrid-systemevents/package.json
@@ -44,12 +44,11 @@
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
-    "regenerate": "tsp-client update -d --emitter-options=\"generate-metadata=false;generate-test=false\" && npm run customize",
+    "regenerate": "tsp-client update -d --emitter-options=\"generate-metadata=false;generate-test=false\" && dev-tool customization apply && node scripts/generateMapping.mjs && npm run format",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser --no-test-proxy",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest --no-test-proxy",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply && node scripts/generateMapping.mjs && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -54,8 +54,7 @@
     "test:browser": "echo Skipped",
     "test:node": "dev-tool run test:vitest",
     "test:node:live": "cross-env TEST_MODE=live dev-tool run test:vitest --no-test-proxy",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "echo skipped: customization must be run manually"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -122,8 +122,7 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "echo skipped: customization must be run manually"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "imports": {
     "#platform/*": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -50,8 +50,7 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "echo skipped: customization must be run manually"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,
   "//metadata": {

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -133,8 +133,7 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "echo skipped: customization must be run manually"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "imports": {
     "#platform/*": {

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -66,8 +66,7 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -88,7 +88,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/identity": "^4.13.1",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.45",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.46",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.1.0-beta.1",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.1",

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -30,8 +30,7 @@
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "test:node:live": "dev-tool run test:vitest -- -c vitest.int.config.ts",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
     "dist/",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -22,8 +22,7 @@
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "test:node:live": "dev-tool run test:vitest -- -c vitest.int.config.ts",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
     "dist/",

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
@@ -93,8 +93,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "npm run build:test && dev-tool run test:vitest --browser",
     "unit-test:node": "dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "//sampleConfiguration": {
     "productName": "Azure Online Experimentation REST",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -20,8 +20,7 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
     "dist/",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -14,7 +14,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,mts}\" \"generated/**/*.{ts,mts}\" \"test/**/*.{ts,mts}\" \"samples-dev/**/*.{ts,mts}\" \"*.{js,mjs,json}\"",
-    "generate:client": "tsp-client update -d --emitter-options=\"api-version=2026-08-01-preview;ignore-nullable-on-optional=true;wrap-non-model-return=false\" && npm run customize",
+    "generate:client": "tsp-client update -d --emitter-options=\"api-version=2026-08-01-preview;ignore-nullable-on-optional=true;wrap-non-model-return=false\" && npm run format && npx dev-tool customization apply --skip index.ts",
     "generate:embeddings": "ts-node scripts/generateSampleEmbeddings.ts",
     "lint": "eslint package.json src test samples-dev",
     "lint:fix": "eslint package.json src test samples-dev --fix --fix-type [problem,suggestion]",
@@ -22,8 +22,7 @@
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
     "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest --test-proxy-debug",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && npx dev-tool customization apply --skip index.ts"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
     "dist/",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -91,7 +91,7 @@
     "execute:samples": "echo skipped",
     "extract-api": "rimraf review && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"generated/**/*.{ts,cts,mts}\" \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update && npm run customize",
+    "generate:client": "tsp-client update && npm run format && dev-tool customization apply",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
@@ -99,8 +99,7 @@
     "test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && dev-tool customization apply"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/transcription/ai-speech-transcription/package.json
+++ b/sdk/transcription/ai-speech-transcription/package.json
@@ -82,14 +82,13 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "execute:samples": "echo skipped",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update && npm run customize",
+    "generate:client": "tsp-client update && npm run format && dev-tool customization apply-v2",
     "test:browser": "echo skipped",
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test:node:esm": "dev-tool run test:vitest --esm",
     "test": "npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && dev-tool customization apply"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/translation/ai-translation-document/package.json
+++ b/sdk/translation/ai-translation-document/package.json
@@ -228,7 +228,6 @@
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   }
 }

--- a/sdk/translation/ai-translation-text-rest/package.json
+++ b/sdk/translation/ai-translation-text-rest/package.json
@@ -66,8 +66,7 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "dev-tool customization apply -s ./generated -t ./src && npm run format"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/voicelive/ai-voicelive/package.json
+++ b/sdk/voicelive/ai-voicelive/package.json
@@ -90,7 +90,7 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
     "execute:samples": "echo skipped",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" ",
-    "generate:client": "tsp-client update -d && npm run customize",
+    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply",
     "test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser",
     "test:browser:debug": "dev-tool run build-test && vitest --config vitest.browser.debug.config.ts --browser",
     "test:browser:grep": "dev-tool run build-test && vitest --config vitest.browser.debug.config.ts --browser --run -t",
@@ -110,8 +110,7 @@
     "test:integration:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/integration-test.ps1",
     "update-snippets": "dev-tool run update-snippets",
     "dev": "./fast-dev.sh",
-    "watch": "dev-tool run build-package --watch",
-    "customize": "npm run format && dev-tool customization apply"
+    "watch": "dev-tool run build-package --watch"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/web-pubsub/web-pubsub-chat/package.json
+++ b/sdk/web-pubsub/web-pubsub-chat/package.json
@@ -120,13 +120,12 @@
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" \"samples-dev/*.ts\"",
     "execute:samples": "dev-tool samples run samples-dev",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" \"samples-dev/*.ts\"",
-    "generate:client": "tsp-client update -d && npm run customize",
+    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply --skip index.ts",
     "test:browser": "echo skipped",
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "test:node": "dev-tool run test:vitest",
     "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && dev-tool customization apply --skip index.ts"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "//sampleConfiguration": {
     "productName": "@azure/web-pubsub-chat",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -14,15 +14,14 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "tsp-client update -d && npm run customize",
+    "generate:client": "tsp-client update -d && npm run format && dev-tool customization apply --skip index.ts --skip README.md",
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
-    "update-snippets": "dev-tool run update-snippets",
-    "customize": "npm run format && dev-tool customization apply --skip index.ts --skip README.md"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
### Packages impacted by this PR

Scripts only (no shipped behaviour change) for the 25 packages #39748 touched, including `@azure/keyvault-*`, `@azure/search-documents`, `@azure/batch*`, `@azure/eventgrid-systemevents`, `@azure/ai-projects`, `@azure/monitor-*`, `@azure/web-pubsub*`, and others.

### Issues associated with this PR

None.

### Describe the problem that is addressed by this PR

#39748 added a `customize` script to every merge-based package and wired the generation pipeline to run it automatically (`npm run --if-present customize` -> `dev-tool customization apply`). When a regeneration touches the same lines a customization touches, that three-way merge produces conflict markers, and in the `spec-pull-request` / `batch` pipelines nobody can resolve them, so they fail the build. That's what broke the Key Vault data-plane spec PR and led to #39924.

Until the pipeline handles those conflicts gracefully (see the companion PR #39941), this returns the affected packages to their prior, manual customization behaviour.

### Provide a list of related PRs _(if any)_

- #39748 (introduced automatic customization - reverted here)
- #39941 (companion: makes the pipeline fall back to clean generated output on customization failure)
- #39924 (temporary Key Vault-only disable; superseded by this)

In passing and to get CI green again, I fixed the missed dependency update introduced in  #39923 
